### PR TITLE
Fix missing base case in cons/snoc for UTF8 strings

### DIFF
--- a/Core/Array/Boxed.hs
+++ b/Core/Array/Boxed.hs
@@ -469,20 +469,24 @@ mapIndex f a = create (length a) (\i -> f i $ unsafeIndex a i)
 -}
 
 cons ::  ty -> Array ty -> Array ty
-cons e vec = runST $ do
-    mv <- new (len + 1)
-    unsafeWrite mv 0 e
-    unsafeCopyAtRO mv 1 vec 0 len
-    unsafeFreeze mv
+cons e vec
+    | len == 0  = C.singleton e
+    | otherwise = runST $ do
+        mv <- new (len + 1)
+        unsafeWrite mv 0 e
+        unsafeCopyAtRO mv 1 vec 0 len
+        unsafeFreeze mv
   where
     !len = length vec
 
 snoc ::  Array ty -> ty -> Array ty
-snoc vec e = runST $ do
-    mv <- new (len + 1)
-    unsafeCopyAtRO mv 0 vec 0 len
-    unsafeWrite mv len e
-    unsafeFreeze mv
+snoc vec e
+    | len == 0  = C.singleton e
+    | otherwise = runST $ do
+        mv <- new (len + 1)
+        unsafeCopyAtRO mv 0 vec 0 len
+        unsafeWrite mv len e
+        unsafeFreeze mv
   where
     !len = length vec
 

--- a/Core/Array/Boxed.hs
+++ b/Core/Array/Boxed.hs
@@ -191,7 +191,7 @@ unsafeThaw (Array a) = primitive $ \st -> (# st, MArray (unsafeCoerce# a) #)
 thaw :: PrimMonad prim => Array ty -> prim (MArray ty (PrimState prim))
 thaw array = do
     m <- new (length array)
-    copyAtRO m 0 array 0 (length array)
+    unsafeCopyAtRO m 0 array 0 (length array)
     return m
 {-# INLINE thaw #-}
 
@@ -212,14 +212,19 @@ copyAt dst od src os n = loop od os
             | i == endIndex = return ()
             | otherwise     = unsafeRead src i >>= unsafeWrite dst d >> loop (d+1) (i+1)
 
-copyAtRO :: PrimMonad prim
-         => MArray ty (PrimState prim) -- ^ destination array
-         -> Int                -- ^ offset at destination
-         -> Array ty         -- ^ source array
-         -> Int                -- ^ offset at source
-         -> Int                -- ^ number of elements to copy
-         -> prim ()
-copyAtRO dst od src os n = loop od os
+-- | Copy @n@ sequential elements from the specified offset in a source array
+--   to the specified position in a destination array.
+--
+--   This function does not check bounds. Accessing invalid memory can return
+--   unpredictable and invalid values.
+unsafeCopyAtRO :: PrimMonad prim
+               => MArray ty (PrimState prim) -- ^ destination array
+               -> Int                        -- ^ offset at destination
+               -> Array ty                   -- ^ source array
+               -> Int                        -- ^ offset at source
+               -> Int                        -- ^ number of elements to copy
+               -> prim ()
+unsafeCopyAtRO dst od src os n = loop od os
   where endIndex = os + n
         loop d i
             | i == endIndex = return ()
@@ -371,7 +376,7 @@ take nbElems v
     | nbElems <= 0 = empty
     | otherwise    = runST $ do
         muv <- new n
-        copyAtRO muv 0 v 0 n
+        unsafeCopyAtRO muv 0 v 0 n
         unsafeFreeze muv
   where
     n = min nbElems (length v)
@@ -381,7 +386,7 @@ drop nbElems v
     | nbElems <= 0 = v
     | otherwise    = runST $ do
         muv <- new n
-        copyAtRO muv 0 v offset n
+        unsafeCopyAtRO muv 0 v offset n
         unsafeFreeze muv
   where
     offset = min nbElems (length v)
@@ -467,7 +472,7 @@ cons ::  ty -> Array ty -> Array ty
 cons e vec = runST $ do
     mv <- new (len + 1)
     unsafeWrite mv 0 e
-    copyAtRO mv 1 vec 0 len
+    unsafeCopyAtRO mv 1 vec 0 len
     unsafeFreeze mv
   where
     !len = length vec
@@ -475,7 +480,7 @@ cons e vec = runST $ do
 snoc ::  Array ty -> ty -> Array ty
 snoc vec e = runST $ do
     mv <- new (len + 1)
-    copyAtRO mv 0 vec 0 len
+    unsafeCopyAtRO mv 0 vec 0 len
     unsafeWrite mv len e
     unsafeFreeze mv
   where

--- a/Core/String/UTF8.hs
+++ b/Core/String/UTF8.hs
@@ -569,21 +569,25 @@ charMap f src@(String srcBa) =
         copyLoop ms xs start
 
 snoc :: String -> Char -> String
-snoc s@(String ba) c = runST $ do
-    ms@(MutableString mba) <- new (len + nbBytes)
-    Vec.copyAtRO mba (Offset 0) ba (Offset 0) len
-    _ <- write ms (azero `offsetPlusE` len) c
-    freeze ms
+snoc s@(String ba) c
+    | len == Size 0 = C.singleton c
+    | otherwise     = runST $ do
+        ms@(MutableString mba) <- new (len + nbBytes)
+        Vec.copyAtRO mba (Offset 0) ba (Offset 0) len
+        _ <- write ms (azero `offsetPlusE` len) c
+        freeze ms
   where
     !len     = size s
     !nbBytes = charToBytes (fromEnum c)
 
 cons :: Char -> String -> String
-cons c s@(String ba) = runST $ do
-    ms@(MutableString mba) <- new (len + nbBytes)
-    idx <- write ms (Offset 0) c
-    Vec.copyAtRO mba idx ba (Offset 0) len
-    freeze ms
+cons c s@(String ba)
+  | len == Size 0 = C.singleton c
+  | otherwise     = runST $ do
+      ms@(MutableString mba) <- new (len + nbBytes)
+      idx <- write ms (Offset 0) c
+      Vec.copyAtRO mba idx ba (Offset 0) len
+      freeze ms
   where
     !len     = size s
     !nbBytes = charToBytes (fromEnum c)

--- a/Core/String/UTF8.hs
+++ b/Core/String/UTF8.hs
@@ -565,7 +565,7 @@ charMap f src@(String srcBa) =
     copyLoop _   []     n          = error ("charMap invalid: " <> show n)
     copyLoop ms@(MutableString mba) ((String ba, sz):xs) end = do
         let start = end `offsetMinusE` sz
-        Vec.copyAtRO mba start ba (Offset 0) sz
+        Vec.unsafeCopyAtRO mba start ba (Offset 0) sz
         copyLoop ms xs start
 
 snoc :: String -> Char -> String
@@ -573,7 +573,7 @@ snoc s@(String ba) c
     | len == Size 0 = C.singleton c
     | otherwise     = runST $ do
         ms@(MutableString mba) <- new (len + nbBytes)
-        Vec.copyAtRO mba (Offset 0) ba (Offset 0) len
+        Vec.unsafeCopyAtRO mba (Offset 0) ba (Offset 0) len
         _ <- write ms (azero `offsetPlusE` len) c
         freeze ms
   where
@@ -586,7 +586,7 @@ cons c s@(String ba)
   | otherwise     = runST $ do
       ms@(MutableString mba) <- new (len + nbBytes)
       idx <- write ms (Offset 0) c
-      Vec.copyAtRO mba idx ba (Offset 0) len
+      Vec.unsafeCopyAtRO mba idx ba (Offset 0) len
       freeze ms
   where
     !len     = size s


### PR DESCRIPTION
Evaluating `cons` and `snoc` in `Core.String.UTF8` resulted in an exception when called with `mempty` while using `(fromList "" :: String)` worked fine:

    Core Core.Collection.Sequential> cons 'a' (mempty :: String)
    "*** Exception: empty de-referenced

    Core Core.Collection.Sequential> snoc (mempty :: String) 'a'
    "*** Exception: empty de-referenced

    Core Core.Collection.Sequential> cons 'a' (fromList "" :: String)
    "a"

    Core Core.Collection.Sequential> snoc (fromList "" :: String) 'a'
    "a"

Both failing functions called `copyAtRO` in `Core.Array.Unboxed` with a byte array pointer that can not be dereferenced.

QuickCheck tests didn't catch this as they currently only generate data using `fromList`.

`cons` and `snoc` now have a base case handling this. I also propose to rename `copyAtRO` to `unsafeCopyAtR0` as it does no bounds checking.

