### PR TITLE
update documentation of `arch`

### DIFF
--- a/Core/System/Info.hs
+++ b/Core/System/Info.hs
@@ -65,10 +65,14 @@ instance IsString OS where
 os :: OS
 os = fromString System.Info.os
 
--- | get the architecture info
+-- | get the machine architecture on which the program is running
 --
--- get the `arch` from base package but convert
--- it into a strict String
+-- This function uses base implementation:
+--
+-- > fromList System.Info.arch
+--
+-- Potential results are: i386, x86_64, powerpc, sparc, arm, ...
+--
 arch :: String
 arch = fromList System.Info.arch
 


### PR DESCRIPTION
address issue #59 

This is based on the information gathered from `ghc` and `base`.

In `GHC`, we can find the supported Arch:

* [in the config: TargetArch_CPP](https://github.com/ghc/ghc/blob/ffe4660510a7ba4adce846f316db455ccd91142a/mk/config.mk.in#L202-L203) for the build system;
* Then `HOST_ARCH` is defined with the value of `TargetArch_CPP` in [ghcplatform.h](https://github.com/ghc/ghc/blob/865602e0beb8e30ea1e1edf7db90f24088badb9e/includes/ghc.mk#L125-L139);
* which is then use for [System.Info.arch](https://github.com/ghc/ghc/blob/5d98b8bf249fab9bb0be6c5d4e8ddd4578994abb/libraries/base/System/Info.hs#L43)