### PR TITLE
Fix bug on Array Builder

### DIFF
--- a/Core/Array/Unboxed/Builder.hs
+++ b/Core/Array/Unboxed/Builder.hs
@@ -36,8 +36,9 @@ appendTy v = ArrayBuilder $ State $ \st ->
         then do
             newChunk <- new (chunkSize st)
             cur <- unsafeFreeze (currentBuffer st)
+            write newChunk 0 v
             return ((), st { prevBuffers   = cur : prevBuffers st
-                           , currentOffset = Offset 0
+                           , currentOffset = Offset 1
                            , currentBuffer = newChunk
                            })
         else do

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -477,6 +477,9 @@ tests =
         [ testCase "The foundation Serie" $ testCaseModifiedUTF8 "基地系列" "基地系列"
         , testCase "has null bytes" $ testCaseModifiedUTF8 "let's\0 do \0 it" "let's\0 do \0 it"
         , testCase "Vincent's special" $ testCaseModifiedUTF8 "abc\0안, 蠀\0, ☃" "abc\0안, 蠀\0, ☃"
+        , testCase "Long string" $ testCaseModifiedUTF8
+              "this is only a simple string but quite longer than the 64 bytes used in the modified UTF8 parser"
+              "this is only a simple string but quite longer than the 64 bytes used in the modified UTF8 parser"
         ]
     , testGroup "BoxedZippable"
         [ testGroup "Array"


### PR DESCRIPTION
We simply forgot to write the (size of chunk)th value in the `appendTy` function