### PR TITLE
Set `-fobject-code` option for GHCi project-wide

### DIFF
--- a/.ghci
+++ b/.ghci
@@ -1,0 +1,1 @@
+:set -fobject-code


### PR DESCRIPTION
Workaround for #51 