### PR TITLE
export Arch

### DIFF
--- a/Foundation/System/Info.hs
+++ b/Foundation/System/Info.hs
@@ -14,6 +14,7 @@ module Foundation.System.Info
       OS(..)
     , os
       -- * CPU info
+    , Arch(..)
     , arch
     , cpus
     , Endianness(..)


### PR DESCRIPTION
This will fix the issue that `Foundation.System.Info.arch` was not usable since the type `Arch` was not exported...