### PR TITLE
Implement parser for Sequential types

### DIFF
--- a/Foundation/Parser.hs
+++ b/Foundation/Parser.hs
@@ -37,9 +37,12 @@ module Foundation.Parser
     , skip
     , skipWhile
     , skipAll
+    -- utils
+    , optional
+    , many, some
     ) where
 
-import           Control.Applicative (Alternative, empty, (<|>))
+import           Control.Applicative (Alternative, empty, (<|>), many, some, optional)
 import           Control.Monad       (MonadPlus, mzero, mplus)
 import           Foundation.Internal.Base
 import           Foundation.Collection hiding (take)
@@ -194,7 +197,7 @@ element w = Parser $ \buf err ok ->
 -- if the following `Element input` don't match the expected
 -- `input` completely, the parser will raise a failure
 elements :: (Show input, Eq input, Sequential input) => input -> Parser input ()
-elements allExpected = consumeEq allExpected
+elements = consumeEq
   where
     -- partially consume as much as possible or raise an error.
     consumeEq expected = Parser $ \actual err ok ->

--- a/Foundation/Parser.hs
+++ b/Foundation/Parser.hs
@@ -1,0 +1,251 @@
+-- |
+-- Module      : Foundation.Parser
+-- License     : BSD-style
+-- Maintainer  : Haskell Foundation
+-- Stability   : experimental
+-- Portability : portable
+--
+-- The current implementation is mainly, if not copy/pasted, inspired from
+-- `memory`'s Parser.
+--
+-- A very simple bytearray parser related to Parsec and Attoparsec
+--
+-- Simple example:
+--
+-- > > parse ((,,) <$> take 2 <*> element 0x20 <*> (elements "abc" *> anyElement)) "xx abctest"
+-- > ParseOK "est" ("xx", 116)
+--
+
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE Rank2Types #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Foundation.Parser
+    ( Parser
+    , Result(..)
+    -- * run the Parser
+    , parse
+    , parseFeed
+    -- * Parser methods
+    , hasMore
+    , element
+    , anyElement
+    , elements
+    , take
+    , takeWhile
+    , takeAll
+    , skip
+    , skipWhile
+    , skipAll
+    ) where
+
+import           Control.Applicative (Alternative, empty, (<|>))
+import           Control.Monad       (MonadPlus, mzero, mplus)
+import           Foundation.Internal.Base
+import           Foundation.Collection hiding (take)
+import           Foundation.String
+import           Foundation.Number
+
+-- | use for convenience
+type Reader a = Sequential a
+
+newtype ParserError = Custom String
+  deriving (Show, Eq, IsString)
+
+-- | Simple parsing result, that represent respectively:
+--
+-- * failure: with the error message
+--
+-- * continuation: that need for more input data
+--
+-- * success: the remaining unparsed data and the parser value
+--
+data Result input a =
+      ParseFail ParserError
+    | ParseMore (Maybe input -> Result input a)
+    | ParseOK   input a
+
+instance (Show ba, Show a) => Show (Result ba a) where
+    show (ParseFail err) = "ParseFailure: " <> show err
+    show (ParseMore _)   = "ParseMore _"
+    show (ParseOK b a)   = "ParseOK " <> show a <> " " <> show b
+
+-- | The continuation of the current buffer, and the error string
+type Failure input r = input -> ParserError -> Result input r
+
+-- | The continuation of the next buffer value, and the parsed value
+type Success input a r = input -> a -> Result input r
+
+-- | Simple parser structure
+newtype Parser input a = Parser
+    { runParser :: forall r . input
+                           -> Failure input r
+                           -> Success input a r
+                           -> Result input r }
+
+instance Functor (Parser input) where
+    fmap f p = Parser $ \buf err ok ->
+       runParser p buf err (\b a -> ok b (f a))
+instance Applicative (Parser input) where
+    pure      = return
+    (<*>) d e = d >>= \b -> e >>= \a -> return (b a)
+instance Monad (Parser input) where
+    fail errorMsg = Parser $ \buf err _ -> err buf (Custom $ "Parser failed: " <> fromList errorMsg)
+    return v      = Parser $ \buf _ ok -> ok buf v
+    m >>= k       = Parser $ \buf err ok ->
+        runParser m buf err (\buf' a -> runParser (k a) buf' err ok)
+instance MonadPlus (Parser input) where
+    mzero = fail "MonadPlus.mzero"
+    mplus f g = Parser $ \buf err ok ->
+        -- rewrite the err callback of @f to call @g
+        runParser f buf (\_ _ -> runParser g buf err ok) ok
+instance Alternative (Parser input) where
+    empty = fail "Alternative.empty"
+    (<|>) = mplus
+
+-- | Run a parser on an @initial input.
+--
+-- If the Parser need more data than available, the @feeder function
+-- is automatically called and fed to the More continuation.
+parseFeed :: (Reader input, Monad m)
+          => m (Maybe input)
+          -> Parser input a
+          -> input
+          -> m (Result input a)
+parseFeed feeder p initial = loop $ parse p initial
+  where loop (ParseMore k) = feeder >>= (loop . k)
+        loop r             = return r
+
+-- | Run a Parser on a ByteString and return a 'Result'
+parse :: Reader input
+      => Parser input a -> input -> Result input a
+parse p s = runParser p s (\_ msg -> ParseFail msg) ParseOK
+
+-- When needing more data, getMore append the next data
+-- to the current buffer. if no further data, then
+-- the err callback is called.
+getMore :: Reader input => Parser input ()
+getMore = Parser $ \buf err ok -> ParseMore $ \nextChunk ->
+    case nextChunk of
+        Nothing -> err buf "EOL: need more data"
+        Just nc
+            | null nc   -> runParser getMore buf err ok
+            | otherwise -> ok (mappend buf nc) ()
+
+--
+-- Only used by takeAll, which accumulate all the remaining data
+-- until ParseMore is fed a Nothing value.
+--
+-- getAll cannot fail.
+getAll :: Reader input => Parser input ()
+getAll = Parser $ \buf err ok -> ParseMore $ \nextChunk ->
+    case nextChunk of
+        Nothing -> ok buf ()
+        Just nc -> runParser getAll (mappend buf nc) err ok
+
+-- Only used by skipAll, which flush all the remaining data
+-- until ParseMore is fed a Nothing value.
+--
+-- flushAll cannot fail.
+flushAll :: Reader input => Parser input ()
+flushAll = Parser $ \buf err ok -> ParseMore $ \nextChunk ->
+    case nextChunk of
+        Nothing -> ok buf ()
+        Just _  -> runParser flushAll mempty err ok
+
+hasMore :: Reader input => Parser input Bool
+hasMore = Parser $ \buf err ok ->
+    if null buf
+        then ParseMore $ \nextChunk ->
+            case nextChunk of
+                Nothing -> ok buf False
+                Just nc -> runParser hasMore nc err ok
+        else ok buf True
+
+-- | Get the next `Element input` from the parser
+anyElement :: Reader input => Parser input (Element input)
+anyElement = Parser $ \buf err ok ->
+    case uncons buf of
+        Nothing      -> runParser (getMore >> anyElement) buf err ok
+        Just (c1,b2) -> ok b2 c1
+
+-- | Parse a specific `Element input` at current position
+--
+-- if the `Element input` is different than the expected one,
+-- this parser will raise a failure.
+element :: (Reader input, Eq (Element input))
+        => Element input -> Parser input ()
+element w = Parser $ \buf err ok ->
+    case uncons buf of
+        Nothing      -> runParser (getMore >> element w) buf err ok
+        Just (c1,b2) | c1 == w   -> ok b2 ()
+                     | otherwise -> err buf (Custom "elemen failed")
+
+-- | Parse a sequence of elements from current position
+--
+-- if the following `Element input` don't match the expected
+-- `input` completely, the parser will raise a failure
+elements :: (Show input, Eq input, Reader input) => input -> Parser input ()
+elements allExpected = consumeEq allExpected
+  where
+    errMsg = Custom $ "bytes " <> fromList (show allExpected) <> " : failed"
+    -- partially consume as much as possible or raise an error.
+    consumeEq expected = Parser $ \actual err ok ->
+        let eLen = length expected in
+         if length actual >= eLen
+             then    -- enough data for doing a full match
+                let (aMatch,aRem) = splitAt eLen actual
+                 in if aMatch == expected
+                     then ok aRem ()
+                     else err actual errMsg
+             else    -- not enough data, match as much as we have, and then recurse.
+                let (eMatch, eRem) = splitAt (length actual) expected
+                 in if actual == eMatch
+                     then runParser (getMore >> consumeEq eRem) mempty err ok
+                     else err actual errMsg
+
+-- | Take @n elements from the current position in the stream
+take :: Reader input => Int -> Parser input input
+take n = Parser $ \buf err ok ->
+    if length buf >= n
+        then let (b1,b2) = splitAt n buf in ok b2 b1
+        else runParser (getMore >> take n) buf err ok
+
+-- | Take elements while the @predicate hold from the current position in the
+-- stream
+takeWhile :: Reader input => (Element input -> Bool) -> Parser input input
+takeWhile predicate = Parser $ \buf err ok ->
+    let (b1, b2) = span predicate buf
+     in if null b2
+            then runParser (getMore >> takeWhile predicate) buf err ok
+            else ok b2 b1
+
+-- | Take the remaining elements from the current position in the stream
+takeAll :: Reader input => Parser input input
+takeAll = Parser $ \buf err ok ->
+    runParser (getAll >> returnBuffer) buf err ok
+  where
+    returnBuffer = Parser $ \buf _ ok -> ok mempty buf
+
+-- | Skip @n elements from the current position in the stream
+skip :: Reader input => Int -> Parser input ()
+skip n = Parser $ \buf err ok ->
+    if length buf >= n
+        then ok (drop n buf) ()
+        else runParser (getMore >> skip (n - length buf)) mempty err ok
+
+-- | Skip `Element input` while the @predicate hold from the current position
+-- in the stream
+skipWhile :: Reader input => (Element input -> Bool) -> Parser input ()
+skipWhile p = Parser $ \buf err ok ->
+    let (_, b2) = span p buf
+     in if null b2
+            then runParser (getMore >> skipWhile p) mempty err ok
+            else ok b2 ()
+
+-- | Skip all the remaining `Element input` from the current position in the
+-- stream
+skipAll :: Reader input => Parser input ()
+skipAll = Parser $ \buf err ok -> runParser flushAll buf err ok

--- a/Foundation/Parser.hs
+++ b/Foundation/Parser.hs
@@ -17,7 +17,6 @@
 --
 
 {-# LANGUAGE Rank2Types #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE FlexibleContexts #-}
 
 module Foundation.Parser

--- a/benchs/compare-libs/Parser.hs
+++ b/benchs/compare-libs/Parser.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main where
+
+import Foundation as F
+import qualified Foundation.Parser as P
+import Criterion.Main
+
+dat :: F.String
+dat = "EHLO sub.smtp.domain.mail.com"
+
+newtype Domain = Domain [F.String]
+
+authorisedNodeElem :: [Char]
+authorisedNodeElem = ['a'..'z'] <> ['A'..'Z'] <> "-_" <> ['0' .. '9']
+
+parseNode :: P.Parser F.String F.String
+parseNode = P.takeWhile $ \x -> x `elem` authorisedNodeElem
+
+parseNodes :: P.Parser F.String [F.String]
+parseNodes = (parseNode >>= \x -> parseNodes_ >>= \xs -> return (x : xs)) <|> return []
+parseNodes_ :: P.Parser F.String [F.String]
+parseNodes_ = P.element '.' >> parseNodes
+
+parseDomain :: P.Parser F.String Domain
+parseDomain = Domain <$> parseNodes
+
+parseEHLO :: P.Parser F.String Domain
+parseEHLO = do
+    P.elements "EHLO" <|> P.elements "HELO"
+    P.element ' '
+    parseDomain
+
+main = defaultMain
+    [ bgroup "parse"
+        [ bench "EHLO" $ whnf (P.parse parseEHLO) dat
+        ]
+    ]

--- a/benchs/compare-libs/Parser.hs
+++ b/benchs/compare-libs/Parser.hs
@@ -3,36 +3,83 @@
 module Main where
 
 import Foundation as F
+import Foundation.String as F
+import Foundation.Primitive
 import qualified Foundation.Parser as P
 import Criterion.Main
 
-dat :: F.String
-dat = "EHLO sub.smtp.domain.mail.com"
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Internal as BC
+import qualified Data.Attoparsec.ByteString as Atto
 
-newtype Domain = Domain [F.String]
+dat :: F.UArray Word8
+dat = F.toBytes F.UTF8 "EHLO sub.smtp.domain.mail.com "
 
-authorisedNodeElem :: [Char]
-authorisedNodeElem = ['a'..'z'] <> ['A'..'Z'] <> "-_" <> ['0' .. '9']
+datbs :: B.ByteString
+datbs = B.pack $ fmap BC.c2w "EHLO sub.smtp.domain.mail.com "
 
-parseNode :: P.Parser F.String F.String
+newtype DomainBS = DomainBS [B.ByteString]
+    deriving Show
+
+newtype Domain = Domain [F.UArray Word8]
+    deriving Show
+
+authorisedNodeElem :: [Word8]
+authorisedNodeElem = [0x61..0x7a]
+
+dot :: Word8
+dot = 0x2E
+space :: Word8
+space = 0x20
+
+parseNode :: P.Parser (F.UArray Word8) (F.UArray Word8)
 parseNode = P.takeWhile $ \x -> x `elem` authorisedNodeElem
 
-parseNodes :: P.Parser F.String [F.String]
+parseNodes :: P.Parser (F.UArray Word8) [F.UArray Word8]
 parseNodes = (parseNode >>= \x -> parseNodes_ >>= \xs -> return (x : xs)) <|> return []
-parseNodes_ :: P.Parser F.String [F.String]
-parseNodes_ = P.element '.' >> parseNodes
 
-parseDomain :: P.Parser F.String Domain
+parseNodesBS :: Atto.Parser [B.ByteString]
+parseNodesBS = do
+    x <- parseNodeBS
+    xs <- Atto.many' $ Atto.word8 dot *> parseNodeBS
+    return $ x:xs
+parseNodeBS :: Atto.Parser B.ByteString
+parseNodeBS = Atto.takeWhile (\x -> x `elem` authorisedNodeElem)
+
+parseNodes_ :: P.Parser (F.UArray Word8) [F.UArray Word8]
+parseNodes_ = P.element dot >> parseNodes
+
+parseDomain :: P.Parser (F.UArray Word8) Domain
 parseDomain = Domain <$> parseNodes
+parseDomainBS :: Atto.Parser DomainBS
+parseDomainBS = DomainBS <$> parseNodesBS
 
-parseEHLO :: P.Parser F.String Domain
+heloF :: F.UArray Word8
+heloF = fromList [0x48, 0x45, 0x4C, 0x4F]
+ehloF :: F.UArray Word8
+ehloF = fromList [0x45, 0x48, 0x4C, 0x4F]
+heloBS :: B.ByteString
+heloBS = B.pack [0x48, 0x45, 0x4C, 0x4F]
+ehloBS :: B.ByteString
+ehloBS = B.pack [0x45, 0x48, 0x4C, 0x4F]
+
+parseEHLO :: P.Parser (F.UArray Word8) Domain
 parseEHLO = do
-    P.elements "EHLO" <|> P.elements "HELO"
-    P.element ' '
+    P.elements ehloF <|> P.elements heloF
+    P.element space
     parseDomain
+parseEHLOBS :: Atto.Parser DomainBS
+parseEHLOBS = do
+    Atto.string ehloBS <|> Atto.string heloBS
+    Atto.word8 space
+    parseDomainBS
 
-main = defaultMain
+main = do
+  print $ P.parse parseEHLO dat
+  print $ Atto.parse parseEHLOBS datbs
+  defaultMain
     [ bgroup "parse"
-        [ bench "EHLO" $ whnf (P.parse parseEHLO) dat
+        [ bench "foundation:EHLO" $ whnf (P.parse parseEHLO) dat
+        , bench "attoparsec:EHLO" $ whnf (Atto.parse parseEHLOBS) datbs
         ]
     ]

--- a/benchs/compare-libs/Parser.hs
+++ b/benchs/compare-libs/Parser.hs
@@ -52,10 +52,12 @@ textParserLarge = do
     (:) x <$> A.many1 (A.char ' ' >> textParser)
 
 main = defaultMain
-    [ bgroup "parse"
-        [ bench "foundation:small" $ whnf (forceParserStop foundationParserStr) foundationBufStr
-        , bench "text:small" $ whnf (A.parseOnly textParser) refText
-        , bench "foundation:large" $ whnf (forceParserStop foundationParserStrLarge) foundationBufStrLarge
+    [ bgroup "foundation"
+        [ bench "string:small" $ whnf (forceParserStop foundationParserStr) foundationBufStr
+        , bench "string:large" $ whnf (forceParserStop foundationParserStrLarge) foundationBufStrLarge
+        ]
+    , bgroup "Attoparsec"
+        [ bench "text:small" $ whnf (A.parseOnly textParser) refText
         , bench "text:large" $ whnf (A.parseOnly textParserLarge) refTextLarge
         ]
     ]

--- a/foundation.cabal
+++ b/foundation.cabal
@@ -132,6 +132,7 @@ Test-Suite test-foundation
   Main-is:           Tests.hs
   Other-modules:     ForeignUtils
                      Encoding
+                     Parser
   Build-Depends:     base >= 3 && < 5
                    , mtl
                    , QuickCheck

--- a/foundation.cabal
+++ b/foundation.cabal
@@ -55,6 +55,7 @@ Library
                      Foundation.Primitive
                      Foundation.System.Info
                      Foundation.Strict
+                     Foundation.Parser
   Other-modules:     Foundation.String.Internal
                      Foundation.String.UTF8
                      Foundation.String.Encoding.Encoding

--- a/tests/Parser.hs
+++ b/tests/Parser.hs
@@ -1,0 +1,96 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Parser
+  ( testParsers
+  ) where
+
+import Foundation
+import Foundation.String
+import Foundation.Parser
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+data TestCaseRes a
+    = TestCaseOk String a
+    | TestCaseMore (Maybe String) (TestCaseRes a)
+    | TestCaseFail
+  deriving (Show)
+
+parseTestCase :: (Show a, Eq a)
+              => String
+              -> Parser String a
+              -> TestCaseRes a
+              -> Assertion
+parseTestCase buff parser res = check (parse parser buff) res
+check :: (Show a, Eq a) => Result String a -> TestCaseRes a -> Assertion
+check r e = case (r, e) of
+    (ParseOK remain a, TestCaseOk eRemain ea) -> do
+        assertEqual "remaining buffer" eRemain remain
+        assertEqual "returned value" ea a
+    (ParseMore fr, TestCaseMore mb res') -> check (fr mb) res'
+    (ParseFail _, TestCaseFail) -> return ()
+    _ -> assertFailure $
+            "parseTestCase failed: "
+                <> "expected: " <> show e <> " "
+                <> "buf received: " <> show r
+
+-- Some custom test cases
+parseTestCases :: TestTree
+parseTestCases = testGroup "units"
+    [ testGroup "element"
+        [ testCase "Ok" $ parseTestCase "a" (element 'a') (TestCaseOk "" ())
+        , testCase "Fail" $ parseTestCase "b" (element 'a') TestCaseFail
+        , testCase "MoreOk" $ parseTestCase "" (element 'a') (TestCaseMore (Just "a") (TestCaseOk "" ()))
+        , testCase "MoreFail" $ parseTestCase "" (element 'a') (TestCaseMore Nothing TestCaseFail)
+        ]
+    , testGroup "elements"
+        [ testCase "Ok" $ parseTestCase "abc" (elements "ab") (TestCaseOk "c" ())
+        , testCase "Fail" $ parseTestCase "ac" (elements "ab") TestCaseFail
+        , testCase "MoreOk" $ parseTestCase "a" (elements "abc") (TestCaseMore (Just "bc") (TestCaseOk "" ()))
+        , testCase "MoreMoreOk" $ parseTestCase "a" (elements "abc") (TestCaseMore (Just "b") $ TestCaseMore (Just "c") (TestCaseOk "" ()))
+        , testCase "MoreMoreFail" $ parseTestCase "a" (elements "abc") (TestCaseMore (Just "b") $ TestCaseMore Nothing TestCaseFail)
+        ]
+    , testGroup "anyElement"
+        [ testCase "OK" $ parseTestCase "a"   anyElement (TestCaseOk "" 'a')
+        , testCase "OkRemains" $ parseTestCase "abc" anyElement (TestCaseOk "bc" 'a')
+        , testCase "MoreOk" $ parseTestCase ""    anyElement $ TestCaseMore (Just "abc")(TestCaseOk "bc" 'a')
+        , testCase "MoreFail" $ parseTestCase ""    anyElement $ TestCaseMore Nothing TestCaseFail
+        ]
+    , testGroup "take"
+        [ testCase "OK" $ parseTestCase "a" (take 1) (TestCaseOk "" "a")
+        , testCase "OkRemains" $ parseTestCase "abc" (take 2) (TestCaseOk "c" "ab")
+        , testCase "MoreOk" $ parseTestCase "" (take 2) $ TestCaseMore (Just "abc")(TestCaseOk "c" "ab")
+        , testCase "MoreFail" $ parseTestCase "a" (take 2) $ TestCaseMore Nothing TestCaseFail
+        ]
+    , testGroup "takeWhile"
+        [ testCase "OK" $ parseTestCase "a " (takeWhile (' ' /=)) (TestCaseOk " " "a")
+        , testCase "OkRemains" $ parseTestCase "ab bc" (takeWhile (' ' /=)) (TestCaseOk " bc" "ab")
+        , testCase "MoreOk" $ parseTestCase "ab" (takeWhile (' ' /=)) $ TestCaseMore (Just "cd ")(TestCaseOk " " "abcd")
+        , testCase "MoreFail" $ parseTestCase "aa" (takeWhile (' ' /=)) $ TestCaseMore Nothing TestCaseFail
+        ]
+    , testGroup "takeAll"
+        [ testCase "OK" $ parseTestCase "abc" (takeAll) (TestCaseMore Nothing $ TestCaseOk "" "abc")
+        ]
+    , testGroup "skip"
+        [ testCase "OK" $ parseTestCase "a" (skip 1) (TestCaseOk "" ())
+        , testCase "OkRemains" $ parseTestCase "abc" (skip 2) (TestCaseOk "c" ())
+        , testCase "MoreOk" $ parseTestCase "" (skip 2) $ TestCaseMore (Just "abc")(TestCaseOk "c" ())
+        , testCase "MoreFail" $ parseTestCase "a" (skip 2) $ TestCaseMore Nothing TestCaseFail
+        ]
+    , testGroup "skipWhile"
+        [ testCase "OK" $ parseTestCase "a " (skipWhile (' ' /=)) (TestCaseOk " " ())
+        , testCase "OkRemains" $ parseTestCase "ab bc" (skipWhile (' ' /=)) (TestCaseOk " bc" ())
+        , testCase "MoreOk" $ parseTestCase "ab" (skipWhile (' ' /=)) $ TestCaseMore (Just "cd ")(TestCaseOk " " ())
+        , testCase "MoreFail" $ parseTestCase "aa" (skipWhile (' ' /=)) $ TestCaseMore Nothing TestCaseFail
+        ]
+    , testGroup "skipAll"
+        [ testCase "OK" $ parseTestCase "abc" (skipAll) (TestCaseMore Nothing $ TestCaseOk "abc" ())
+        ]
+    ]
+
+testParsers :: TestTree
+testParsers = testGroup "Parsers"
+    [ parseTestCases
+    ]

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -25,6 +25,7 @@ import qualified Prelude
 
 import           ForeignUtils
 import           Encoding
+import           Parser
 
 data Unicode = Unicode { unUnicode :: LString }
     deriving (Show)
@@ -557,6 +558,7 @@ tests =
             ( testZippableProps (Proxy :: Proxy (Array Int)) (Proxy :: Proxy (Array Char))
                 arbitrary arbitrary )
         ]
+    , testParsers
     ]
 
 testCaseModifiedUTF8 :: [Char] -> String -> Assertion


### PR DESCRIPTION
Port the [memory](https:://github.com/vincenthz/hs-memory)'s Parser into `Foundation`.
This implementation keeps the polymorphic interfaces `memory` provides, but using any `Sequential` types.

fix #89 