### PR TITLE
Fixed #94 (Add Bifunctor to Foundation)

### DIFF
--- a/Foundation.hs
+++ b/Foundation.hs
@@ -46,6 +46,7 @@ module Foundation
     , Prelude.Bounded (..)
     , Prelude.Enum (..)
     , Prelude.Functor (..)
+    , Foundation.Class.Bifunctor.Bifunctor (..)
     , Control.Applicative.Applicative (..)
     , Prelude.Monad (..)
     , (Control.Monad.=<<)
@@ -153,6 +154,8 @@ import qualified Foundation.Internal.Proxy
 import qualified Foundation.Number
 import qualified Foundation.Partial
 import           Foundation.Tuple
+
+import qualified Foundation.Class.Bifunctor
 
 import qualified Data.Maybe
 import qualified Data.Either

--- a/Foundation/Bifunctor.hs
+++ b/Foundation/Bifunctor.hs
@@ -34,19 +34,19 @@ class Bifunctor p where
 
     -- | Map over both arguments at the same time.
     --
-    -- @'bimap' f g â‰¡ 'first' f '.' 'second' g@
+    -- @'bimap' f g ≡ 'first' f '.' 'second' g@
     bimap :: (a -> b) -> (c -> d) -> p a c -> p b d
     bimap f g = first f P.. second g
 
     -- | Map covariantly over the first argument.
     --
-    -- @'first' f â‰¡ 'bimap' f 'id'@
+    -- @'first' f ≡ 'bimap' f 'id'@
     first :: (a -> b) -> p a c -> p b c
     first f = bimap f P.id
 
     -- | Map covariantly over the second argument.
     --
-    -- @'second' â‰¡ 'bimap' 'id'@
+    -- @'second' ≡ 'bimap' 'id'@
     second :: (b -> c) -> p a b -> p a c
     second = bimap P.id
 

--- a/Foundation/Bifunctor.hs
+++ b/Foundation/Bifunctor.hs
@@ -1,0 +1,83 @@
+-- |
+-- Module      : Foundation.Bifunctor
+-- License     : BSD-style
+-- Maintainer  : Vincent Hanquez <vincent@snarc.org>
+-- Stability   : experimental
+-- Portability : portable
+--
+-- Formally, the class 'Bifunctor' represents a bifunctor
+-- from @Hask@ -> @Hask@.
+--
+-- Intuitively it is a bifunctor where both the first and second
+-- arguments are covariant.
+--
+-- You can define a 'Bifunctor' by either defining 'bimap' or by
+-- defining both 'first' and 'second'.
+--
+{-# LANGUAGE CPP #-}
+module Foundation.Bifunctor
+  ( Bifunctor(..)
+  ) where
+
+#if MIN_VERSION_base(4,8,0)
+
+import Data.Bifunctor (Bifunctor(..))
+
+#else
+
+import           Control.Applicative ( Const(..) )
+import           GHC.Generics ( K1(..) )
+import qualified Prelude as P
+
+class Bifunctor p where
+    {-# MINIMAL bimap | first, second #-}
+
+    -- | Map over both arguments at the same time.
+    --
+    -- @'bimap' f g â‰¡ 'first' f '.' 'second' g@
+    bimap :: (a -> b) -> (c -> d) -> p a c -> p b d
+    bimap f g = first f P.. second g
+
+    -- | Map covariantly over the first argument.
+    --
+    -- @'first' f â‰¡ 'bimap' f 'id'@
+    first :: (a -> b) -> p a c -> p b c
+    first f = bimap f P.id
+
+    -- | Map covariantly over the second argument.
+    --
+    -- @'second' â‰¡ 'bimap' 'id'@
+    second :: (b -> c) -> p a b -> p a c
+    second = bimap P.id
+
+
+instance Bifunctor (,) where
+    bimap f g ~(a, b) = (f a, g b)
+
+instance Bifunctor ((,,) x1) where
+    bimap f g ~(x1, a, b) = (x1, f a, g b)
+
+instance Bifunctor ((,,,) x1 x2) where
+    bimap f g ~(x1, x2, a, b) = (x1, x2, f a, g b)
+
+instance Bifunctor ((,,,,) x1 x2 x3) where
+    bimap f g ~(x1, x2, x3, a, b) = (x1, x2, x3, f a, g b)
+
+instance Bifunctor ((,,,,,) x1 x2 x3 x4) where
+    bimap f g ~(x1, x2, x3, x4, a, b) = (x1, x2, x3, x4, f a, g b)
+
+instance Bifunctor ((,,,,,,) x1 x2 x3 x4 x5) where
+    bimap f g ~(x1, x2, x3, x4, x5, a, b) = (x1, x2, x3, x4, x5, f a, g b)
+
+
+instance Bifunctor P.Either where
+    bimap f _ (P.Left a) = P.Left (f a)
+    bimap _ g (P.Right b) = P.Right (g b)
+
+instance Bifunctor Const where
+    bimap f _ (Const a) = Const (f a)
+
+instance Bifunctor (K1 i) where
+    bimap f _ (K1 c) = K1 (f c)
+
+#endif

--- a/Foundation/Class/Bifunctor.hs
+++ b/Foundation/Class/Bifunctor.hs
@@ -15,7 +15,7 @@
 -- defining both 'first' and 'second'.
 --
 {-# LANGUAGE CPP #-}
-module Foundation.Bifunctor
+module Foundation.Class.Bifunctor
   ( Bifunctor(..)
   ) where
 

--- a/Foundation/Class/Bifunctor.hs
+++ b/Foundation/Class/Bifunctor.hs
@@ -1,5 +1,5 @@
 -- |
--- Module      : Foundation.Bifunctor
+-- Module      : Foundation.Class.Bifunctor
 -- License     : BSD-style
 -- Maintainer  : Vincent Hanquez <vincent@snarc.org>
 -- Stability   : experimental

--- a/foundation.cabal
+++ b/foundation.cabal
@@ -42,7 +42,7 @@ Library
                      Foundation.Number
                      Foundation.Array
                      Foundation.Array.Internal
-                     Foundation.Bifunctor
+                     Foundation.Class.Bifunctor
                      Foundation.Convertible
                      Foundation.String
                      Foundation.IO

--- a/foundation.cabal
+++ b/foundation.cabal
@@ -42,6 +42,7 @@ Library
                      Foundation.Number
                      Foundation.Array
                      Foundation.Array.Internal
+                     Foundation.Bifunctor
                      Foundation.Convertible
                      Foundation.String
                      Foundation.IO

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -13,7 +13,7 @@ import           Test.QuickCheck.Monadic
 import           Test.Tasty.HUnit
 import           Test.Tasty.QuickCheck
 
-import           Foundation
+import           Foundation hiding (second)
 import           Foundation.Array
 import           Foundation.Collection
 import           Foundation.Foreign


### PR DESCRIPTION
I wouldn't be surprised if this PR needs amending both in terms of coding convention and package hierarchy conventions 😉 

I backported `Data.Bifunctor` from base using CPP for GHC older than 4.8.0.