### PR TITLE
[WIP] Fixed #98, add Coveralls integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -133,7 +133,7 @@ install:
   set -ex
   case "$BUILD" in
     stack)
-      stack --no-terminal --install-ghc $ARGS test --bench --only-dependencies
+      stack --no-terminal --install-ghc $ARGS test --coverage --bench --only-dependencies
       ;;
     cabal)
       cabal --version
@@ -148,7 +148,7 @@ script:
   set -ex
   case "$BUILD" in
     stack)
-      stack --no-terminal $ARGS test --bench --no-run-benchmarks --haddock --no-haddock-deps
+      stack --no-terminal $ARGS test --coverage --bench --no-run-benchmarks --haddock --no-haddock-deps
       ;;
     cabal)
       cabal install --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS $PACKAGES

--- a/.travis.yml
+++ b/.travis.yml
@@ -166,3 +166,6 @@ script:
       ;;
   esac
   set +ex
+after_script:
+    - travis_retry curl -L https://github.com/rubik/stack-hpc-coveralls/releases/download/v0.0.3.0/shc-linux-x64-$GHCVER.tar.bz2 | tar -xj
+    - ./shc foundation test-foundation

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Foundation
 ==========
 
 [![Build Status](https://travis-ci.org/haskell-foundation/foundation.png?branch=master)](https://travis-ci.org/haskell-foundation/foundation)
+[![Coverage](https://coveralls.io/repos/github/haskell-foundation/foundation/badge.svg?branch=master)](https://coveralls.io/github/haskell-foundation/foundation?branch=master)
 [![BSD](http://b.repl.ca/v1/license-BSD-blue.png)](http://en.wikipedia.org/wiki/BSD_licenses)
 [![Haskell](http://b.repl.ca/v1/language-haskell-lightgrey.png)](http://haskell.org)
 


### PR DESCRIPTION
I copied verbatim the options from my other repo, so that should do the trick, but I think we
will need to explicitly enable Foundation in [Coveralls](https://coveralls.io).

I think this requires one of the owner of the foundation repo (probably Vincent) to sign up and add the project, as I (as a member) can only enable _my own fork_, not the real deal:

<img width="561" alt="screen shot 2016-09-03 at 09 39 46" src="https://cloud.githubusercontent.com/assets/442035/18223530/7e529eb8-71ba-11e6-8a8a-2255abb8d001.png">
