### PR TITLE
Refactor tests: try to improve dev compile time

### DIFF
--- a/Foundation/Number.hs
+++ b/Foundation/Number.hs
@@ -63,9 +63,9 @@ class Number a => Signed a where
 -- | Represent class of things that can be added together,
 -- contains a neutral element and is commutative.
 --
--- * x + azero = x
--- * azero + x = x
--- * x + y = y + x
+-- > x + azero = x
+-- > azero + x = x
+-- > x + y = y + x
 --
 class Additive a where
     {-# MINIMAL azero, (+) #-}
@@ -83,8 +83,8 @@ class Additive a where
 
 -- | Represent class of things that can be multiplied together
 --
--- * x * midentity = x
--- * midentity * x = x
+-- > x * midentity = x
+-- > midentity * x = x
 class Multiplicative a where
     {-# MINIMAL midentity, (*) #-}
     -- | Identity element over multiplication
@@ -106,16 +106,17 @@ class Multiplicative a where
 -- as the operand depending on the actual type.
 --
 -- For example:
--- e.g. (-) :: Int -> Int -> Int
---      (-) :: DateTime -> DateTime -> Seconds
---      (-) :: Ptr a -> Ptr a -> PtrDiff
+--
+-- > (-) :: Int -> Int -> Int
+-- > (-) :: DateTime -> DateTime -> Seconds
+-- > (-) :: Ptr a -> Ptr a -> PtrDiff
 class Subtractive a where
     type Difference a
     (-) :: a -> a -> Difference a
 
 -- | Represent class of things that can be divided
 --
--- (x ‘div‘  y) * y + (x ‘mod‘ y) == x
+-- > (x ‘div‘  y) * y + (x ‘mod‘ y) == x
 class Multiplicative a => Divisible a where
     {-# MINIMAL (div, mod) | divMod #-}
     div :: a -> a -> a

--- a/foundation.cabal
+++ b/foundation.cabal
@@ -137,6 +137,7 @@ Test-Suite test-foundation
                      Test.Data.List
                      Test.Data.Unicode
                      Test.Foundation.Collection
+                     Test.Foundation.Number
   Build-Depends:     base >= 3 && < 5
                    , mtl
                    , QuickCheck

--- a/foundation.cabal
+++ b/foundation.cabal
@@ -131,9 +131,9 @@ Test-Suite test-foundation
   type:              exitcode-stdio-1.0
   hs-source-dirs:    tests
   Main-is:           Tests.hs
-  Other-modules:     ForeignUtils
-                     Encoding
+  Other-modules:     Encoding
                      Parser
+                     Test.Utils.Foreign
                      Test.Data.List
                      Test.Data.Unicode
                      Test.Foundation.Collection

--- a/foundation.cabal
+++ b/foundation.cabal
@@ -134,6 +134,9 @@ Test-Suite test-foundation
   Other-modules:     ForeignUtils
                      Encoding
                      Parser
+                     Test.Data.List
+                     Test.Data.Unicode
+                     Test.Foundation.Collection
   Build-Depends:     base >= 3 && < 5
                    , mtl
                    , QuickCheck

--- a/foundation.cabal
+++ b/foundation.cabal
@@ -131,13 +131,13 @@ Test-Suite test-foundation
   type:              exitcode-stdio-1.0
   hs-source-dirs:    tests
   Main-is:           Tests.hs
-  Other-modules:     Encoding
-                     Parser
-                     Test.Utils.Foreign
+  Other-modules:     Test.Utils.Foreign
                      Test.Data.List
                      Test.Data.Unicode
                      Test.Foundation.Collection
                      Test.Foundation.Number
+                     Test.Foundation.Encoding
+                     Test.Foundation.Parser
   Build-Depends:     base >= 3 && < 5
                    , mtl
                    , QuickCheck

--- a/tests/Test/Data/List.hs
+++ b/tests/Test/Data/List.hs
@@ -1,6 +1,7 @@
 module Test.Data.List
     ( generateListOfElement
     , generateListOfElementMaxN
+    , RandomList(..)
     ) where
 
 import Test.Tasty.QuickCheck
@@ -15,3 +16,9 @@ generateListOfElement = generateListOfElementMaxN 100
 -- generator.
 generateListOfElementMaxN :: Int -> Gen e -> Gen [e]
 generateListOfElementMaxN n e = choose (0,n) >>= flip replicateM e
+
+data RandomList = RandomList [Int]
+    deriving (Show,Eq)
+
+instance Arbitrary RandomList where
+    arbitrary = RandomList <$> (choose (100,400) >>= flip replicateM (choose (0,8)))

--- a/tests/Test/Data/List.hs
+++ b/tests/Test/Data/List.hs
@@ -1,0 +1,17 @@
+module Test.Data.List
+    ( generateListOfElement
+    , generateListOfElementMaxN
+    ) where
+
+import Test.Tasty.QuickCheck
+import Control.Monad
+
+-- | convenient function to replicate thegiven Generator of `e` a randomly
+-- choosen amount of time.
+generateListOfElement :: Gen e -> Gen [e]
+generateListOfElement = generateListOfElementMaxN 100
+
+-- | convenient function to generate up to a certain amount of time the given
+-- generator.
+generateListOfElementMaxN :: Int -> Gen e -> Gen [e]
+generateListOfElementMaxN n e = choose (0,n) >>= flip replicateM e

--- a/tests/Test/Data/List.hs
+++ b/tests/Test/Data/List.hs
@@ -1,9 +1,12 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
 module Test.Data.List
     ( generateListOfElement
     , generateListOfElementMaxN
     , RandomList(..)
     ) where
 
+import Foundation
 import Test.Tasty.QuickCheck
 import Control.Monad
 

--- a/tests/Test/Data/Unicode.hs
+++ b/tests/Test/Data/Unicode.hs
@@ -1,0 +1,45 @@
+-- |
+-- Module: Test.Data.Unicode
+--
+
+{-# LANGUAGE TypeFamilies #-}
+
+module Test.Data.Unicode
+    ( LUString(..)
+    , genUnicodeChar
+    ) where
+
+import Test.Tasty.QuickCheck
+import Control.Monad (replicateM)
+import Foundation
+
+-- | a better generator for unicode Character
+genUnicodeChar :: Gen Char
+genUnicodeChar =
+    toEnum <$> oneof
+        [ choose (1, 0xff)
+        , choose (0x100, 0x1000)
+        , choose (0x100, 0x10000)
+        , choose (0x1, 0x1000)
+        ]
+
+-- | data type instance to generate a Lazy String (list of Char `[Char]`) but
+-- with higher probability of generating unicode characters
+data LUString = LUString { toLString :: LString }
+  deriving (Show, Eq, Ord)
+
+instance IsString LUString where
+    fromString = LUString
+instance IsList LUString where
+    type Item LUString = Char
+    fromList = LUString
+    toList (LUString l) = l
+instance Arbitrary LUString where
+    arbitrary = do
+        n <- choose (0,200)
+        oneof
+            [ LUString <$> replicateM n (toEnum <$> choose (1, 0xff))
+            , LUString <$> replicateM n (toEnum <$> choose (0x100, 0x1000))
+            , LUString <$> replicateM n (toEnum <$> choose (0x100, 0x10000))
+            , LUString <$> replicateM n (toEnum <$> choose (0x1, 0x1000))
+            ]

--- a/tests/Test/Foundation/Array.hs
+++ b/tests/Test/Foundation/Array.hs
@@ -1,0 +1,81 @@
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
+module Test.Foundation.Array
+    ( testArrayRefs
+    ) where
+
+import Control.Monad
+import Foundation
+import Foundation.Collection
+import Foundation.Foreign
+
+import Test.Tasty
+import Test.Tasty.QuickCheck
+import Test.QuickCheck.Monadic
+
+import Test.Foundation.Collection
+import Test.Data.List
+import Test.Utils.Foreign
+
+testArrayRefs :: TestTree
+testArrayRefs = testGroup "Array"
+    [ testGroup "Unboxed"
+        [ testCollection "UArray(W8)"  (Proxy :: Proxy (UArray Word8))  arbitrary
+        , testCollection "UArray(W16)" (Proxy :: Proxy (UArray Word16)) arbitrary
+        , testCollection "UArray(W32)" (Proxy :: Proxy (UArray Word32)) arbitrary
+        , testCollection "UArray(W64)" (Proxy :: Proxy (UArray Word64)) arbitrary
+        , testCollection "UArray(I8)"  (Proxy :: Proxy (UArray Int8))   arbitrary
+        , testCollection "UArray(I16)" (Proxy :: Proxy (UArray Int16))  arbitrary
+        , testCollection "UArray(I32)" (Proxy :: Proxy (UArray Int32))  arbitrary
+        , testCollection "UArray(I64)" (Proxy :: Proxy (UArray Int64))  arbitrary
+        , testCollection "UArray(F32)" (Proxy :: Proxy (UArray Float))  arbitrary
+        , testCollection "UArray(F64)" (Proxy :: Proxy (UArray Double)) arbitrary
+        ]
+    , testGroup "Unboxed-Foreign"
+        [ testGroup "UArray(W8)"  (testUnboxedForeign (Proxy :: Proxy (UArray Word8))  arbitrary)
+        , testGroup "UArray(W16)" (testUnboxedForeign (Proxy :: Proxy (UArray Word16)) arbitrary)
+        , testGroup "UArray(W32)" (testUnboxedForeign (Proxy :: Proxy (UArray Word32)) arbitrary)
+        , testGroup "UArray(W64)" (testUnboxedForeign (Proxy :: Proxy (UArray Word64)) arbitrary)
+        , testGroup "UArray(I8)"  (testUnboxedForeign (Proxy :: Proxy (UArray Int8))   arbitrary)
+        , testGroup "UArray(I16)" (testUnboxedForeign (Proxy :: Proxy (UArray Int16))  arbitrary)
+        , testGroup "UArray(I32)" (testUnboxedForeign (Proxy :: Proxy (UArray Int32))  arbitrary)
+        , testGroup "UArray(I64)" (testUnboxedForeign (Proxy :: Proxy (UArray Int64))  arbitrary)
+        , testGroup "UArray(F32)" (testUnboxedForeign (Proxy :: Proxy (UArray Float))  arbitrary)
+        , testGroup "UArray(F64)" (testUnboxedForeign (Proxy :: Proxy (UArray Double)) arbitrary)
+        ]
+    , testGroup "Boxed"
+        [ testCollection "Array(W8)"  (Proxy :: Proxy (Array Word8))  arbitrary
+        , testCollection "Array(W16)" (Proxy :: Proxy (Array Word16)) arbitrary
+        , testCollection "Array(W32)" (Proxy :: Proxy (Array Word32)) arbitrary
+        , testCollection "Array(W64)" (Proxy :: Proxy (Array Word64)) arbitrary
+        , testCollection "Array(I8)"  (Proxy :: Proxy (Array Int8))   arbitrary
+        , testCollection "Array(I16)" (Proxy :: Proxy (Array Int16))  arbitrary
+        , testCollection "Array(I32)" (Proxy :: Proxy (Array Int32))  arbitrary
+        , testCollection "Array(I64)" (Proxy :: Proxy (Array Int64))  arbitrary
+        , testCollection "Array(F32)" (Proxy :: Proxy (Array Float))  arbitrary
+        , testCollection "Array(F64)" (Proxy :: Proxy (Array Double)) arbitrary
+        , testCollection "Array(Int)" (Proxy :: Proxy (Array Int))  arbitrary
+        , testCollection "Array(Int,Int)" (Proxy :: Proxy (Array (Int,Int)))  arbitrary
+        , testCollection "Array(Integer)" (Proxy :: Proxy (Array Integer)) arbitrary
+        ]
+    ]
+
+testUnboxedForeign :: (PrimType e, Show e, Element a ~ e, Storable e)
+                   => Proxy a -> Gen e -> [TestTree]
+testUnboxedForeign proxy genElement =
+    [ testProperty "equal" $ withElementsM $ \fptr l ->
+        return $ toArrayP proxy l == foreignMem fptr (length l)
+    , testProperty "take" $ withElementsM $ \fptr l -> do
+        n <- pick arbitrary
+        return $ take n (toArrayP proxy l) == take n (foreignMem fptr (length l))
+    , testProperty "take" $ withElementsM $ \fptr l -> do
+        n <- pick arbitrary
+        return $ drop n (toArrayP proxy l) == drop n (foreignMem fptr (length l))
+    ]
+  where
+    withElementsM f = monadicIO $ forAllM (generateListOfElement genElement) $ \l -> run (createPtr l) >>= \fptr -> f fptr l
+    toArrayP :: PrimType (Element c) => Proxy c -> [Element c] -> UArray (Element c)
+    toArrayP _ l = fromList l

--- a/tests/Test/Foundation/Collection.hs
+++ b/tests/Test/Foundation/Collection.hs
@@ -1,0 +1,192 @@
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
+module Test.Foundation.Collection
+    ( testCollection
+    , fromListP
+    , toListP
+    ) where
+
+import qualified Prelude
+
+import Test.Tasty
+import Test.Tasty.QuickCheck
+
+import Foundation
+import Foundation.Collection
+import Test.Data.List
+
+-- | internal helper to convert a list of element into a collection
+--
+fromListP :: (IsList c, Item c ~ Element c) => Proxy c -> [Element c] -> c
+fromListP p = \x -> asProxyTypeOf (fromList x) p
+
+-- | internal helper to convert a given Collection into a list of its element
+--
+toListP :: (IsList c, Item c ~ Element c) => Proxy c -> c -> [Element c]
+toListP p x = toList (asProxyTypeOf x p)
+
+-- | test property equality for the given Collection
+--
+-- This does to enforce
+testEquality :: ( Show e
+                , Eq e, Eq a
+                , Element a ~ e
+                , IsList a, Item a ~ Element a
+                )
+             => Proxy a
+             -> Gen e
+             -> TestTree
+testEquality proxy genElement = testGroup "equality"
+    [ testProperty "x == x" $ withElements $ \l -> let col = fromListP proxy l in col == col
+    , testProperty "x == y" $ with2Elements $ \(l1, l2) ->
+        (fromListP proxy l1 == fromListP proxy l2) == (l1 == l2)
+    ]
+  where
+    withElements f = forAll (generateListOfElement genElement) f
+    with2Elements f = forAll ((,) <$> generateListOfElement genElement <*> generateListOfElement genElement) f
+
+
+testOrdering :: ( Show e
+                , Ord a, Ord e
+                , Element a ~ e
+                , IsList a, Item a ~ Element a
+                )
+             => Proxy a
+             -> Gen e
+             -> TestTree
+testOrdering proxy genElement = testGroup "ordering"
+    [ testProperty "x `compare` y" $ with2Elements $ \(l1, l2) ->
+        (fromListP proxy l1 `compare` fromListP proxy l2) == (l1 `compare` l2)
+    ]
+  where
+    with2Elements f = forAll ((,) <$> generateListOfElement genElement <*> generateListOfElement genElement) f
+
+testIsList :: ( Show e
+              , Eq e, Eq a
+              , Element a ~ e
+              , IsList a, Item a ~ Element a
+              )
+           => Proxy a
+           -> Gen e
+           -> TestTree
+testIsList proxy genElement = testGroup "IsList"
+    [ testProperty "fromList . toList == id" $ withElements $ \l -> (toList $ fromListP proxy l) === l
+    ]
+  where
+    withElements f = forAll (generateListOfElement genElement) f
+
+-- | group of all the property a given collection should have
+--
+-- > splitAt == (take, drop)
+--
+-- > revSplitAt == (revTake, revDrop)
+--
+-- > c == [Element c]
+--
+testSequentialProperties :: (Show a, Sequential a, Eq a, e ~ Item a) => Proxy a -> Gen e -> TestTree
+testSequentialProperties proxy genElement = testGroup "Properties"
+    [ testProperty "splitAt == (take, drop)" $ withCollection2 $ \(col, n) ->
+        splitAt n col == (take n col, drop n col)
+    , testProperty "revSplitAt == (revTake, revDrop)" $ withCollection2 $ \(col, n) ->
+        revSplitAt n col == (revTake n col, revDrop n col)
+    ]
+  where
+    withCollection2 f = forAll ((,) <$> (fromListP proxy <$> generateListOfElement genElement) <*> arbitrary) f
+
+testMonoid :: ( Show a, Show e
+              , Eq a, Eq e
+              , Monoid a
+              , Element a ~ e, IsList a, Item a ~ Element a
+              )
+           => Proxy a
+           -> Gen e
+           -> TestTree
+testMonoid proxy genElement = testGroup "Monoid"
+    [ testProperty "mempty <> x == x" $ withElements $ \l -> let col = fromListP proxy l in (col <> mempty) === col
+    , testProperty "x <> mempty == x" $ withElements $ \l -> let col = fromListP proxy l in (mempty <> col) === col
+    , testProperty "x1 <> x2 == x1|x2" $ with2Elements $ \(l1,l2) ->
+        (fromListP proxy l1 <> fromListP proxy l2) === fromListP proxy (l1 <> l2)
+    , testProperty "mconcat [map fromList [e]] = fromList (concat [e])" $ withNElements $ \l ->
+        mconcat (fmap (fromListP proxy) l) === fromListP proxy (mconcat l)
+    ]
+  where
+    withElements f = forAll (generateListOfElement genElement) f
+    with2Elements f = forAll ((,) <$> generateListOfElement genElement <*> generateListOfElement genElement) f
+    withNElements f = forAll (generateListOfElementMaxN 5 (generateListOfElement genElement)) f
+
+testCollection :: ( Sequential a
+                  , Show a, Show (Element a)
+                  , Eq (Element a)
+                  , Ord a, Ord (Item a)
+                  )
+               => LString
+               -> Proxy a
+               -> Gen (Element a)
+               -> TestTree
+testCollection name proxy genElement = testGroup name
+    [ testEquality proxy genElement
+    , testOrdering proxy genElement
+    , testIsList   proxy genElement
+    , testMonoid   proxy genElement
+    , testSequentialOps proxy genElement
+    ]
+
+testSequentialOps :: ( Sequential a
+                     , Show a, Show (Element a)
+                     , Eq (Element a)
+                     , Ord a, Ord (Item a)
+                     )
+                  => Proxy a
+                  -> Gen (Element a)
+                  -> TestTree
+testSequentialOps proxy genElement = testGroup "Sequential"
+    [ testProperty "length" $ withElements $ \l -> (length $ fromListP proxy l) === length l
+    , testProperty "take" $ withElements2 $ \(l, n) -> toList (take n $ fromListP proxy l) === (take n) l
+    , testProperty "drop" $ withElements2 $ \(l, n) -> toList (drop n $ fromListP proxy l) === (drop n) l
+    , testProperty "splitAt" $ withElements2 $ \(l, n) -> toList2 (splitAt n $ fromListP proxy l) === (splitAt n) l
+    , testProperty "revTake" $ withElements2 $ \(l, n) -> toList (revTake n $ fromListP proxy l) === (revTake n) l
+    , testProperty "revDrop" $ withElements2 $ \(l, n) -> toList (revDrop n $ fromListP proxy l) === (revDrop n) l
+    , testProperty "revSplitAt" $ withElements2 $ \(l, n) -> toList2 (revSplitAt n $ fromListP proxy l) === (revSplitAt n) l
+    , testProperty "break" $ withElements2E $ \(l, c) -> toList2 (break (== c) $ fromListP proxy l) === (break (== c)) l
+    , testProperty "breakElem" $ withElements2E $ \(l, c) -> toList2 (breakElem c $ fromListP proxy l) === (breakElem c) l
+    , testProperty "snoc" $ withElements2E $ \(l, c) -> toList (snoc (fromListP proxy l) c) === (l <> [c])
+    , testProperty "cons" $ withElements2E $ \(l, c) -> toList (cons c (fromListP proxy l)) === (c : l)
+    , testProperty "unsnoc" $ withElements $ \l -> fmap toListFirst (unsnoc (fromListP proxy l)) === unsnoc l
+    , testProperty "uncons" $ withElements $ \l -> fmap toListSecond (uncons (fromListP proxy l)) === uncons l
+    , testProperty "splitOn" $ withElements2E $ \(l, ch) ->
+         fmap toList (splitOn (== ch) (fromListP proxy l)) === splitOn (== ch) l
+    , testProperty "intersperse" $ withElements2E $ \(l, c) ->
+        toList (intersperse c (fromListP proxy l)) === intersperse c l
+    , testProperty "intercalate" $ withElements2E $ \(l, c) ->
+        let ls = Prelude.replicate 5 l
+            cs = Prelude.replicate 5 c
+        in toList (intercalate (fromListP proxy cs) (fromListP proxy <$> ls)) === intercalate cs ls
+    , testProperty "sortBy" $ withElements $ \l ->
+        (sortBy compare $ fromListP proxy l) === fromListP proxy (sortBy compare l)
+    , testProperty "reverse" $ withElements $ \l ->
+        (reverse $ fromListP proxy l) === fromListP proxy (reverse l)
+    -- stress slicing
+    , testProperty "take . take" $ withElements3 $ \(l, n1, n2) -> toList (take n2 $ take n1 $ fromListP proxy l) === (take n2 $ take n1 l)
+    , testProperty "drop . take" $ withElements3 $ \(l, n1, n2) -> toList (drop n2 $ take n1 $ fromListP proxy l) === (drop n2 $ take n1 l)
+    , testProperty "drop . drop" $ withElements3 $ \(l, n1, n2) -> toList (drop n2 $ drop n1 $ fromListP proxy l) === (drop n2 $ drop n1 l)
+    , testProperty "drop . take" $ withElements3 $ \(l, n1, n2) -> toList (drop n2 $ take n1 $ fromListP proxy l) === (drop n2 $ take n1 l)
+    , testProperty "second take . splitAt" $ withElements3 $ \(l, n1, n2) ->
+        (toList2 $ (second (take n1) . splitAt n2) $ fromListP proxy l) === (second (take n1) . splitAt n2) l
+    , testSequentialProperties proxy genElement
+    ]
+{-
+    , testProperty "imap" $ \(CharMap (LUString u) i) ->
+        (imap (addChar i) (fromList u) :: String) `assertEq` fromList (Prelude.map (addChar i) u)
+    ]
+-}
+  where
+    toList2 (x,y) = (toList x, toList y)
+    toListFirst (x,y) = (toList x, y)
+    toListSecond (x,y) = (x, toList y)
+    withElements f = forAll (generateListOfElement genElement) f
+    withElements2 f = forAll ((,) <$> generateListOfElement genElement <*> arbitrary) f
+    withElements3 f = forAll ((,,) <$> generateListOfElement genElement <*> arbitrary <*> arbitrary) f
+    withElements2E f = forAll ((,) <$> generateListOfElement genElement <*> genElement) f

--- a/tests/Test/Foundation/Encoding.hs
+++ b/tests/Test/Foundation/Encoding.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 
-module Encoding
+module Test.Foundation.Encoding
   ( EncodedString(..)
   , sample0
   , sample1

--- a/tests/Test/Foundation/Number.hs
+++ b/tests/Test/Foundation/Number.hs
@@ -1,0 +1,103 @@
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
+module Test.Foundation.Number
+    ( testNumber
+    , testNumberRefs
+    ) where
+
+import qualified Prelude
+
+import Test.Tasty
+import Test.Tasty.QuickCheck
+
+import Foundation
+import Foundation.Number hiding (Positive)
+
+testAddNullElementRight :: (Show a, Eq a, Additive a, Arbitrary a)
+                        => Proxy a -> a -> Property
+testAddNullElementRight _ a = a + azero === a
+testAddNullElementLeft :: (Show a, Eq a, Additive a, Arbitrary a)
+                       => Proxy a -> a -> Property
+testAddNullElementLeft  _ a = azero + a === a
+testAddCommutatif :: (Show a, Eq a, Additive a, Arbitrary a)
+                  => Proxy a -> a -> a -> Property
+testAddCommutatif _ a b = a + b === b + a
+
+testMultiplyByIdentityRight :: (Show a, Eq a, Multiplicative a, Arbitrary a)
+                            => Proxy a -> a -> Property
+testMultiplyByIdentityRight _ a = a * midentity === a
+testMultiplyByIdentityLeft :: (Show a, Eq a, Multiplicative a, Arbitrary a)
+                           => Proxy a -> a -> Property
+testMultiplyByIdentityLeft _ a = midentity * a === a
+testDivMulPlusRest :: (Show a, Eq a, Number a, Arbitrary a)
+                   => Proxy a -> a -> (NonZero a) -> Property
+testDivMulPlusRest _ a (NonZero b) =
+    a === (a `div` b) * b + (a `mod` b)
+
+testAdditive :: (Show a, Eq a, Additive a, Arbitrary a)
+             => Proxy a -> TestTree
+testAdditive proxy = testGroup "Additive"
+    [ testProperty "a + azero == a" (testAddNullElementRight proxy)
+    , testProperty "azero + a == a" (testAddNullElementLeft proxy)
+    , testProperty "a + b == b + a" (testAddCommutatif proxy)
+    ]
+
+testMultiplicative :: (Show a, Eq a, Multiplicative a, Arbitrary a)
+                   => Proxy a -> TestTree
+testMultiplicative proxy = testGroup "Multiplicative"
+    [ testProperty "a * midentity == a" (testMultiplyByIdentityRight proxy)
+    , testProperty "midentity * a == a" (testMultiplyByIdentityLeft proxy)
+    ]
+
+testDividible :: (Show a, Eq a, Number a, Arbitrary a)
+              => Proxy a -> TestTree
+testDividible proxy = testGroup "Divisible"
+    [ testProperty "(x `div` y) * y + (x `mod` y) == x" (testDivMulPlusRest proxy)
+    ]
+
+withP3 :: (Show a, Eq a, Number a, Difference a ~ a, Arbitrary a)
+       => Proxy a -> (a -> a -> a -> Property) -> (a -> a -> a -> Property)
+withP3 _ f = f
+withP3Pos2 :: (Show a, Eq a, Number a, Difference a ~ a, Arbitrary a)
+           => Proxy a -> (a -> Positive a -> a -> Property) -> (a -> Positive a -> a -> Property)
+withP3Pos2 _ f = f
+
+testOperatorPrecedence :: (Show a, Eq a, Number a, Difference a ~ a, Arbitrary a) => Proxy a -> TestTree
+testOperatorPrecedence proxy = testGroup "Precedence"
+    [ testProperty "+ and - (1)" $ withP3 proxy $ \a b c -> (a + b - c) === ((a + b) - c)
+    , testProperty "+ and - (2)" $ withP3 proxy $ \a b c -> (a - b + c) === ((a - b) + c)
+    , testProperty "+ and * (1)" $ withP3 proxy $ \a b c -> (a + b * c) === (a + (b * c))
+    , testProperty "+ and * (2)" $ withP3 proxy $ \a b c -> (a * b + c) === ((a * b) + c)
+    , testProperty "- and * (1)" $ withP3 proxy $ \a b c -> (a - b * c) === (a - (b * c))
+    , testProperty "- and * (2)" $ withP3 proxy $ \a b c -> (a * b - c) === ((a * b) - c)
+    , testProperty "* and ^ (1)" $ withP3Pos2 proxy $ \a (Positive b) c -> (a ^ b * c) === ((a ^ b) * c)
+    , testProperty "* and ^ (2)" $ withP3Pos2 proxy $ \a (Positive c) b -> (a * b ^ c) === (a * (b ^ c))
+    ]
+
+
+testNumber :: (Show a, Eq a, Number a, Difference a ~ a, Arbitrary a)
+           => LString -> Proxy a -> TestTree
+testNumber name proxy = testGroup name
+    [ testAdditive proxy
+    , testMultiplicative proxy
+    , testDividible proxy
+    , testOperatorPrecedence proxy
+    ]
+
+testNumberRefs :: [TestTree]
+testNumberRefs =
+    [ testNumber "Int" (Proxy :: Proxy Int)
+    , testNumber "Int8" (Proxy :: Proxy Int8)
+    , testNumber "Int16" (Proxy :: Proxy Int16)
+    , testNumber "Int32" (Proxy :: Proxy Int32)
+    , testNumber "Int64" (Proxy :: Proxy Int64)
+    , testNumber "Integer" (Proxy :: Proxy Integer)
+    , testNumber "Word" (Proxy :: Proxy Word)
+    , testNumber "Word8" (Proxy :: Proxy Word8)
+    , testNumber "Word16" (Proxy :: Proxy Word16)
+    , testNumber "Word32" (Proxy :: Proxy Word32)
+    , testNumber "Word64" (Proxy :: Proxy Word64)
+    ]

--- a/tests/Test/Foundation/Number.hs
+++ b/tests/Test/Foundation/Number.hs
@@ -8,8 +8,6 @@ module Test.Foundation.Number
     , testNumberRefs
     ) where
 
-import qualified Prelude
-
 import Test.Tasty
 import Test.Tasty.QuickCheck
 

--- a/tests/Test/Foundation/Parser.hs
+++ b/tests/Test/Foundation/Parser.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 
-module Parser
+module Test.Foundation.Parser
   ( testParsers
   ) where
 

--- a/tests/Test/Foundation/String.hs
+++ b/tests/Test/Foundation/String.hs
@@ -6,16 +6,6 @@ module Test.Foundation.String
     ( testStringRefs
     ) where
 
-import qualified Prelude
-
-import Test.Data.Unicode
-import Test.Data.List
-
-import Test.Foundation.Collection
-import Test.Foundation.Number
-import Test.Foundation.Array
-import Test.Foundation.Encoding
-import Test.Foundation.Parser
 import Foundation
 import Foundation.String
 import Foundation.Collection
@@ -24,8 +14,8 @@ import Test.Tasty
 import Test.Tasty.QuickCheck
 import Test.Tasty.HUnit
 
-import Test.Data.List
 import Test.Data.Unicode
+import Test.Data.List
 import Test.Foundation.Collection
 import Test.Foundation.Encoding
 

--- a/tests/Test/Foundation/String.hs
+++ b/tests/Test/Foundation/String.hs
@@ -1,0 +1,87 @@
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
+module Test.Foundation.String
+    ( testStringRefs
+    ) where
+
+import qualified Prelude
+
+import Test.Data.Unicode
+import Test.Data.List
+
+import Test.Foundation.Collection
+import Test.Foundation.Number
+import Test.Foundation.Array
+import Test.Foundation.Encoding
+import Test.Foundation.Parser
+import Foundation
+import Foundation.String
+import Foundation.Collection
+
+import Test.Tasty
+import Test.Tasty.QuickCheck
+import Test.Tasty.HUnit
+
+import Test.Data.List
+import Test.Data.Unicode
+import Test.Foundation.Collection
+import Test.Foundation.Encoding
+
+testStringRefs :: TestTree
+testStringRefs = testGroup "String"
+    [ testGroup "UTF8" $
+        [  testCollection "Sequential" (Proxy :: Proxy String) genUnicodeChar ]
+        <> testStringCases
+        <> [ testGroup "Encoding Sample0" (testEncodings sample0)
+           , testGroup "Encoding Sample1" (testEncodings sample1)
+           , testGroup "Encoding Sample2" (testEncodings sample2)
+           ]
+    ]
+
+testStringCases :: [TestTree]
+testStringCases =
+    [ testGroup "Validation"
+        [ testProperty "fromBytes . toBytes == valid" $ \(LUString l) ->
+            let s = fromList l
+             in (fromBytes UTF8 $ toBytes UTF8 s) === (s, Nothing, mempty)
+        , testProperty "Streaming" $ \(LUString l, randomInts) ->
+            let wholeS  = fromList l
+                wholeBA = toBytes UTF8 wholeS
+                reconstruct (prevBa, errs, acc) ba =
+                    let ba' = prevBa `mappend` ba
+                        (s, merr, nextBa) = fromBytes UTF8 ba'
+                     in (nextBa, merr : errs, s : acc)
+
+                (remainingBa, allErrs, chunkS) = foldl reconstruct (mempty, [], []) $ chunks randomInts wholeBA
+             in (catMaybes allErrs === []) .&&. (remainingBa === mempty) .&&. (mconcat (reverse chunkS) === wholeS)
+        ]
+    , testGroup "Cases"
+        [ testGroup "Invalid-UTF8"
+            [ testCase "ff" $ expectFromBytesErr ("", Just InvalidHeader, 0) (fromList [0xff])
+            , testCase "80" $ expectFromBytesErr ("", Just InvalidHeader, 0) (fromList [0x80])
+            , testCase "E2 82 0C" $ expectFromBytesErr ("", Just InvalidContinuation, 0) (fromList [0xE2,0x82,0x0c])
+            , testCase "30 31 E2 82 0C" $ expectFromBytesErr ("01", Just InvalidContinuation, 2) (fromList [0x30,0x31,0xE2,0x82,0x0c])
+            ]
+        ]
+    ]
+  where
+    expectFromBytesErr (expectedString,expectedErr,positionErr) ba = do
+        let (s', merr, ba') = fromBytes UTF8 ba
+        assertEqual "error" expectedErr merr
+        assertEqual "remaining" (drop positionErr ba) ba'
+        assertEqual "string" expectedString (toList s')
+
+chunks :: Sequential c => RandomList -> c -> [c]
+chunks (RandomList randomInts) = loop (randomInts <> [1..])
+  where
+    loop rx c
+        | null c  = []
+        | otherwise =
+            case rx of
+                r:rs ->
+                    let (c1,c2) = splitAt r c
+                     in c1 : loop rs c2
+                [] ->
+                    loop randomInts c

--- a/tests/Test/Utils/Foreign.hs
+++ b/tests/Test/Utils/Foreign.hs
@@ -1,4 +1,4 @@
-module ForeignUtils
+module Test.Utils.Foreign
     ( Ptr
     , Storable
     , createPtr

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -7,20 +7,17 @@ module Main where
 
 import           Test.Tasty
 import           Control.Monad
-import           Test.QuickCheck.Monadic
 import           Test.Tasty.HUnit
 import           Test.Tasty.QuickCheck
 
 import           Foundation hiding (second)
 import           Foundation.Array
 import           Foundation.Collection
-import           Foundation.Foreign
 import           Foundation.String
 import           Foundation.VFS                (Path (..), filename, parent)
 import           Foundation.VFS.FilePath
 import qualified Prelude
 
-import           ForeignUtils
 import           Encoding
 import           Parser
 import Test.Data.Unicode
@@ -28,6 +25,7 @@ import Test.Data.List
 
 import Test.Foundation.Collection
 import Test.Foundation.Number
+import Test.Foundation.Array
 
 data CharMap = CharMap LUString Prelude.Int
     deriving (Show)
@@ -206,24 +204,6 @@ testZippableProps proxyA proxyB genElementA genElementB =
     withList  = forAll (generateListOfElement genElementA)
     withList2 = forAll ((,) <$> generateListOfElement genElementA <*> generateListOfElement genElementB)
 
-testUnboxedForeign :: (PrimType e, Show e, Element a ~ e, Storable e)
-                   => Proxy a -> Gen e -> [TestTree]
-testUnboxedForeign proxy genElement =
-    [ testProperty "equal" $ withElementsM $ \fptr l ->
-        return $ toArrayP proxy l == foreignMem fptr (length l)
-    , testProperty "take" $ withElementsM $ \fptr l -> do
-        n <- pick arbitrary
-        return $ take n (toArrayP proxy l) == take n (foreignMem fptr (length l))
-    , testProperty "take" $ withElementsM $ \fptr l -> do
-        n <- pick arbitrary
-        return $ drop n (toArrayP proxy l) == drop n (foreignMem fptr (length l))
-    ]
-  where
-    withElementsM f = monadicIO $ forAllM (generateListOfElement genElement) $ \l -> run (createPtr l) >>= \fptr -> f fptr l
-    toArrayP :: PrimType (Element c) => Proxy c -> [Element c] -> UArray (Element c)
-    toArrayP _ l = fromList l
-
-
 data RandomList = RandomList [Int]
     deriving (Show,Eq)
 
@@ -279,48 +259,8 @@ testStringCases =
 
 tests :: [TestTree]
 tests =
-    [ testGroup "Array"
-        [ testGroup "Unboxed"
-            [ testCollection "UArray(W8)"  (Proxy :: Proxy (UArray Word8))  arbitrary
-            , testCollection "UArray(W16)" (Proxy :: Proxy (UArray Word16)) arbitrary
-            , testCollection "UArray(W32)" (Proxy :: Proxy (UArray Word32)) arbitrary
-            , testCollection "UArray(W64)" (Proxy :: Proxy (UArray Word64)) arbitrary
-            , testCollection "UArray(I8)"  (Proxy :: Proxy (UArray Int8))   arbitrary
-            , testCollection "UArray(I16)" (Proxy :: Proxy (UArray Int16))  arbitrary
-            , testCollection "UArray(I32)" (Proxy :: Proxy (UArray Int32))  arbitrary
-            , testCollection "UArray(I64)" (Proxy :: Proxy (UArray Int64))  arbitrary
-            , testCollection "UArray(F32)" (Proxy :: Proxy (UArray Float))  arbitrary
-            , testCollection "UArray(F64)" (Proxy :: Proxy (UArray Double)) arbitrary
-            ]
-        , testGroup "Unboxed-Foreign"
-            [ testGroup "UArray(W8)"  (testUnboxedForeign (Proxy :: Proxy (UArray Word8))  arbitrary)
-            , testGroup "UArray(W16)" (testUnboxedForeign (Proxy :: Proxy (UArray Word16)) arbitrary)
-            , testGroup "UArray(W32)" (testUnboxedForeign (Proxy :: Proxy (UArray Word32)) arbitrary)
-            , testGroup "UArray(W64)" (testUnboxedForeign (Proxy :: Proxy (UArray Word64)) arbitrary)
-            , testGroup "UArray(I8)"  (testUnboxedForeign (Proxy :: Proxy (UArray Int8))   arbitrary)
-            , testGroup "UArray(I16)" (testUnboxedForeign (Proxy :: Proxy (UArray Int16))  arbitrary)
-            , testGroup "UArray(I32)" (testUnboxedForeign (Proxy :: Proxy (UArray Int32))  arbitrary)
-            , testGroup "UArray(I64)" (testUnboxedForeign (Proxy :: Proxy (UArray Int64))  arbitrary)
-            , testGroup "UArray(F32)" (testUnboxedForeign (Proxy :: Proxy (UArray Float))  arbitrary)
-            , testGroup "UArray(F64)" (testUnboxedForeign (Proxy :: Proxy (UArray Double)) arbitrary)
-            ]
-        , testGroup "Boxed"
-            [ testCollection "Array(W8)"  (Proxy :: Proxy (Array Word8))  arbitrary
-            , testCollection "Array(W16)" (Proxy :: Proxy (Array Word16)) arbitrary
-            , testCollection "Array(W32)" (Proxy :: Proxy (Array Word32)) arbitrary
-            , testCollection "Array(W64)" (Proxy :: Proxy (Array Word64)) arbitrary
-            , testCollection "Array(I8)"  (Proxy :: Proxy (Array Int8))   arbitrary
-            , testCollection "Array(I16)" (Proxy :: Proxy (Array Int16))  arbitrary
-            , testCollection "Array(I32)" (Proxy :: Proxy (Array Int32))  arbitrary
-            , testCollection "Array(I64)" (Proxy :: Proxy (Array Int64))  arbitrary
-            , testCollection "Array(F32)" (Proxy :: Proxy (Array Float))  arbitrary
-            , testCollection "Array(F64)" (Proxy :: Proxy (Array Double)) arbitrary
-            , testCollection "Array(Int)" (Proxy :: Proxy (Array Int))  arbitrary
-            , testCollection "Array(Int,Int)" (Proxy :: Proxy (Array (Int,Int)))  arbitrary
-            , testCollection "Array(Integer)" (Proxy :: Proxy (Array Integer)) arbitrary
-            ]
-        , testCollection "Bitmap"  (Proxy :: Proxy (Bitmap))  arbitrary
-        ]
+    [ testArrayRefs
+    , testCollection "Bitmap"  (Proxy :: Proxy (Bitmap))  arbitrary
     , testGroup "String" $
         [  testCollection "UTF8" (Proxy :: Proxy String) genUnicodeChar ]
         <> testStringCases

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -13,7 +13,6 @@ import           Test.Tasty.QuickCheck
 import           Foundation hiding (second)
 import           Foundation.Array
 import           Foundation.Collection
-import           Foundation.String
 import           Foundation.VFS                (Path (..), filename, parent)
 import           Foundation.VFS.FilePath
 import qualified Prelude
@@ -25,7 +24,6 @@ import Test.Foundation.Collection
 import Test.Foundation.Number
 import Test.Foundation.Array
 import Test.Foundation.String
-import Test.Foundation.Encoding
 import Test.Foundation.Parser
 
 data CharMap = CharMap LUString Prelude.Int

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -27,6 +27,7 @@ import Test.Data.Unicode
 import Test.Data.List
 
 import Test.Foundation.Collection
+import Test.Foundation.Number
 
 data CharMap = CharMap LUString Prelude.Int
     deriving (Show)
@@ -330,18 +331,7 @@ tests =
     , testGroup "VFS"
         [ testGroup "FilePath" $ testCaseFilePath <> (testPath (arbitrary :: Gen FilePath))
         ]
-    , testGroup "Number"
-        [ testGroup "Precedence"
-            [ testProperty "+ and - (1)" $ \a (b :: Int) (c :: Int) -> (a + b - c) === ((a + b) - c)
-            , testProperty "+ and - (2)" $ \a (b :: Int) (c :: Int) -> (a - b + c) === ((a - b) + c)
-            , testProperty "+ and * (1)" $ \a b (c :: Int) -> (a + b * c) === (a + (b * c))
-            , testProperty "+ and * (2)" $ \a b (c :: Int) -> (a * b + c) === ((a * b) + c)
-            , testProperty "- and * (1)" $ \a b (c :: Int) -> (a - b * c) === (a - (b * c))
-            , testProperty "- and * (2)" $ \a b (c :: Int) -> (a * b - c) === ((a * b) - c)
-            , testProperty "* and ^ (1)" $ \a (Positive b :: Positive Int) (c :: Int) -> (a ^ b * c) === ((a ^ b) * c)
-            , testProperty "* and ^ (2)" $ \a (b :: Int) (Positive c :: Positive Int) -> (a * b ^ c) === (a * (b ^ c))
-            ]
-        ]
+    , testGroup "Number" testNumberRefs
     , testGroup "ModifiedUTF8"
         [ testCase "The foundation Serie" $ testCaseModifiedUTF8 "基地系列" "基地系列"
         , testCase "has null bytes" $ testCaseModifiedUTF8 "let's\0 do \0 it" "let's\0 do \0 it"

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -18,14 +18,15 @@ import           Foundation.VFS                (Path (..), filename, parent)
 import           Foundation.VFS.FilePath
 import qualified Prelude
 
-import           Encoding
-import           Parser
 import Test.Data.Unicode
 import Test.Data.List
 
 import Test.Foundation.Collection
 import Test.Foundation.Number
 import Test.Foundation.Array
+import Test.Foundation.String
+import Test.Foundation.Encoding
+import Test.Foundation.Parser
 
 data CharMap = CharMap LUString Prelude.Int
     deriving (Show)
@@ -204,70 +205,12 @@ testZippableProps proxyA proxyB genElementA genElementB =
     withList  = forAll (generateListOfElement genElementA)
     withList2 = forAll ((,) <$> generateListOfElement genElementA <*> generateListOfElement genElementB)
 
-data RandomList = RandomList [Int]
-    deriving (Show,Eq)
-
-instance Arbitrary RandomList where
-    arbitrary = RandomList <$> (choose (100,400) >>= flip replicateM (choose (0,8)))
-
-chunks :: Sequential c => RandomList -> c -> [c]
-chunks (RandomList randomInts) = loop (randomInts <> [1..])
-  where
-    loop rx c
-        | null c  = []
-        | otherwise =
-            case rx of
-                r:rs ->
-                    let (c1,c2) = splitAt r c
-                     in c1 : loop rs c2
-                [] ->
-                    loop randomInts c
-
-
-testStringCases :: [TestTree]
-testStringCases =
-    [ testGroup "Validation"
-        [ testProperty "fromBytes . toBytes == valid" $ \(LUString l) ->
-            let s = fromList l
-             in (fromBytes UTF8 $ toBytes UTF8 s) === (s, Nothing, mempty)
-        , testProperty "Streaming" $ \(LUString l, randomInts) ->
-            let wholeS  = fromList l
-                wholeBA = toBytes UTF8 wholeS
-                reconstruct (prevBa, errs, acc) ba =
-                    let ba' = prevBa `mappend` ba
-                        (s, merr, nextBa) = fromBytes UTF8 ba'
-                     in (nextBa, merr : errs, s : acc)
-
-                (remainingBa, allErrs, chunkS) = foldl reconstruct (mempty, [], []) $ chunks randomInts wholeBA
-             in (catMaybes allErrs === []) .&&. (remainingBa === mempty) .&&. (mconcat (reverse chunkS) === wholeS)
-        ]
-    , testGroup "Cases"
-        [ testGroup "Invalid-UTF8"
-            [ testCase "ff" $ expectFromBytesErr ("", Just InvalidHeader, 0) (fromList [0xff])
-            , testCase "80" $ expectFromBytesErr ("", Just InvalidHeader, 0) (fromList [0x80])
-            , testCase "E2 82 0C" $ expectFromBytesErr ("", Just InvalidContinuation, 0) (fromList [0xE2,0x82,0x0c])
-            , testCase "30 31 E2 82 0C" $ expectFromBytesErr ("01", Just InvalidContinuation, 2) (fromList [0x30,0x31,0xE2,0x82,0x0c])
-            ]
-        ]
-    ]
-  where
-    expectFromBytesErr (expectedString,expectedErr,positionErr) ba = do
-        let (s', merr, ba') = fromBytes UTF8 ba
-        assertEqual "error" expectedErr merr
-        assertEqual "remaining" (drop positionErr ba) ba'
-        assertEqual "string" expectedString (toList s')
 
 tests :: [TestTree]
 tests =
     [ testArrayRefs
     , testCollection "Bitmap"  (Proxy :: Proxy (Bitmap))  arbitrary
-    , testGroup "String" $
-        [  testCollection "UTF8" (Proxy :: Proxy String) genUnicodeChar ]
-        <> testStringCases
-        <> [ testGroup "Encoding Sample0" (testEncodings sample0)
-           , testGroup "Encoding Sample1" (testEncodings sample1)
-           , testGroup "Encoding Sample2" (testEncodings sample2)
-           ]
+    , testStringRefs
     , testGroup "VFS"
         [ testGroup "FilePath" $ testCaseFilePath <> (testPath (arbitrary :: Gen FilePath))
         ]


### PR DESCRIPTION
Testing has been a bit long so far:

Before:

```stack test  128.66s user 5.99s system 94% cpu 2:21.96 total```

After:

```stack test  85.86s user 5.30s system 97% cpu 1:33.84 total```

Also, contributors will find that, when working on a specific test, it will be a bit faster as well to generate the test.

I have also added a couple of test of the `Number` type class, mainly to validate the property specified in the documentation (associativity of the `Additive`...)