### PR TITLE
Use as Coverage badge the one endorsed by Coveralls.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Foundation
 ==========
 
 [![Build Status](https://travis-ci.org/haskell-foundation/foundation.png?branch=master)](https://travis-ci.org/haskell-foundation/foundation)
-[![Coverage](https://coveralls.io/repos/github/haskell-foundation/foundation/badge.svg?branch=master)](https://coveralls.io/github/haskell-foundation/foundation?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/haskell-foundation/foundation/badge.svg?branch=master)](https://coveralls.io/github/haskell-foundation/foundation?branch=master)
 [![BSD](http://b.repl.ca/v1/license-BSD-blue.png)](http://en.wikipedia.org/wiki/BSD_licenses)
 [![Haskell](http://b.repl.ca/v1/language-haskell-lightgrey.png)](http://haskell.org)
 


### PR DESCRIPTION
Coverall seems to think we do not have a badge on the homepage:

<img width="850" alt="screen shot 2016-09-03 at 17 02 34" src="https://cloud.githubusercontent.com/assets/442035/18225670/3b603bae-71f8-11e6-8b55-20ce436a6008.png">

I think that was just either the fact it's being slow to catch up, or that the "alt" message in the markdown was "Coverage" and not "Coverage Status". Either way, this PR should fix it.