### PR TITLE
Implement Storable and StorableFixed interfaces

### DIFF
--- a/Foundation.hs
+++ b/Foundation.hs
@@ -74,6 +74,7 @@ module Foundation
     , Prelude.Rational
     , Prelude.Float
     , Prelude.Double
+    , Size(..), Offset(..)
       -- ** Collection types
     , UArray
     , PrimType
@@ -156,6 +157,7 @@ import qualified Foundation.Partial
 import           Foundation.Tuple
 
 import qualified Foundation.Class.Bifunctor
+import Foundation.Internal.Types (Size(..), Offset(..))
 
 import qualified Data.Maybe
 import qualified Data.Either

--- a/Foundation/Class/Storable.hs
+++ b/Foundation/Class/Storable.hs
@@ -1,0 +1,126 @@
+-- |
+-- Module      : Foundation.Class.Storable
+-- License     : BSD-style
+-- Maintainer  : Haskell Foundation
+-- Stability   : experimental
+-- Portability : portable
+--
+-- <https://github.com/haskell-foundation/issues/111>
+--
+--
+
+module Foundation.Class.Storable
+    ( Storable(..)
+    , StorableFixed(..)
+
+    , Ptr, plusPtr, castPtr
+    , peekOff, pokeOff
+    ) where
+
+import GHC.Types (Double, Float)
+
+import Foreign.Ptr (castPtr)
+import qualified Foreign.Ptr
+
+import Foundation.Internal.Base
+import Foundation.Internal.Types
+import Foundation.Internal.Proxy
+import Foundation.Primitive.Types
+import Foundation.Number
+
+toProxy :: proxy ty -> Proxy ty
+toProxy _ = Proxy
+
+-- | Storable type of self determined size.
+--
+class Storable a where
+    peek :: Ptr a -> IO a
+    poke :: Ptr a -> a -> IO ()
+
+-- | Extending the Storable type class to the types that can be sequenced
+-- in a structure.
+--
+class Storable a => StorableFixed a where
+    size :: proxy a -> Size Word8
+    alignment :: proxy a -> Size Word8
+
+plusPtr :: StorableFixed a => Ptr a -> Size a -> Ptr a
+plusPtr ptr (Size num) = ptr `Foreign.Ptr.plusPtr` (num * (size ptr `align` alignment ptr))
+  where
+    align (Size sz) (Size a) = sz + (sz `mod` a)
+
+-- | like `peek` but at a given offset.
+peekOff :: StorableFixed a => Ptr a -> Offset a -> IO a
+peekOff ptr off = peek (ptr `plusPtr` offsetAsSize off)
+
+-- | like `poke` but at a given offset.
+pokeOff :: StorableFixed a => Ptr a -> Offset a -> a -> IO ()
+pokeOff ptr off = poke (ptr `plusPtr` offsetAsSize off)
+
+instance Storable Char where
+    peek (Ptr addr) = primAddrRead addr (Offset 0)
+    poke (Ptr addr) = primAddrWrite addr (Offset 0)
+instance Storable Double where
+    peek (Ptr addr) = primAddrRead addr (Offset 0)
+    poke (Ptr addr) = primAddrWrite addr (Offset 0)
+instance Storable Float where
+    peek (Ptr addr) = primAddrRead addr (Offset 0)
+    poke (Ptr addr) = primAddrWrite addr (Offset 0)
+instance Storable Int8 where
+    peek (Ptr addr) = primAddrRead addr (Offset 0)
+    poke (Ptr addr) = primAddrWrite addr (Offset 0)
+instance Storable Int16 where
+    peek (Ptr addr) = primAddrRead addr (Offset 0)
+    poke (Ptr addr) = primAddrWrite addr (Offset 0)
+instance Storable Int32 where
+    peek (Ptr addr) = primAddrRead addr (Offset 0)
+    poke (Ptr addr) = primAddrWrite addr (Offset 0)
+instance Storable Int64 where
+    peek (Ptr addr) = primAddrRead addr (Offset 0)
+    poke (Ptr addr) = primAddrWrite addr (Offset 0)
+instance Storable Word8 where
+    peek (Ptr addr) = primAddrRead addr (Offset 0)
+    poke (Ptr addr) = primAddrWrite addr (Offset 0)
+instance Storable Word16 where
+    peek (Ptr addr) = primAddrRead addr (Offset 0)
+    poke (Ptr addr) = primAddrWrite addr (Offset 0)
+instance Storable Word32 where
+    peek (Ptr addr) = primAddrRead addr (Offset 0)
+    poke (Ptr addr) = primAddrWrite addr (Offset 0)
+instance Storable Word64 where
+    peek (Ptr addr) = primAddrRead addr (Offset 0)
+    poke (Ptr addr) = primAddrWrite addr (Offset 0)
+
+instance StorableFixed Char where
+    size      = primSizeInBytes . toProxy
+    alignment = primSizeInBytes . toProxy
+instance StorableFixed Double where
+    size      = primSizeInBytes . toProxy
+    alignment = primSizeInBytes . toProxy
+instance StorableFixed Float where
+    size      = primSizeInBytes . toProxy
+    alignment = primSizeInBytes . toProxy
+instance StorableFixed Int8 where
+    size      = primSizeInBytes . toProxy
+    alignment = primSizeInBytes . toProxy
+instance StorableFixed Int16 where
+    size      = primSizeInBytes . toProxy
+    alignment = primSizeInBytes . toProxy
+instance StorableFixed Int32 where
+    size      = primSizeInBytes . toProxy
+    alignment = primSizeInBytes . toProxy
+instance StorableFixed Int64 where
+    size      = primSizeInBytes . toProxy
+    alignment = primSizeInBytes . toProxy
+instance StorableFixed Word8 where
+    size      = primSizeInBytes . toProxy
+    alignment = primSizeInBytes . toProxy
+instance StorableFixed Word16 where
+    size      = primSizeInBytes . toProxy
+    alignment = primSizeInBytes . toProxy
+instance StorableFixed Word32 where
+    size      = primSizeInBytes . toProxy
+    alignment = primSizeInBytes . toProxy
+instance StorableFixed Word64 where
+    size      = primSizeInBytes . toProxy
+    alignment = primSizeInBytes . toProxy

--- a/foundation.cabal
+++ b/foundation.cabal
@@ -48,6 +48,7 @@ Library
                      Foundation.Array
                      Foundation.Array.Internal
                      Foundation.Class.Bifunctor
+                     Foundation.Class.Storable
                      Foundation.Convertible
                      Foundation.String
                      Foundation.IO
@@ -146,6 +147,7 @@ Test-Suite test-foundation
                      Test.Foundation.Encoding
                      Test.Foundation.Parser
                      Test.Foundation.String
+                     Test.Foundation.Storable
   Build-Depends:     base >= 3 && < 5
                    , mtl
                    , QuickCheck

--- a/tests/Test/Foundation/Storable.hs
+++ b/tests/Test/Foundation/Storable.hs
@@ -1,0 +1,127 @@
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
+module Test.Foundation.Storable
+    ( testForeignStorableRefs
+    ) where
+
+import Foundation
+import Foundation.Class.Storable
+
+import qualified Foreign.Storable
+import qualified Foreign.Marshal.Alloc
+import qualified Foreign.Marshal.Array
+
+import Test.Tasty
+import Test.Tasty.QuickCheck
+import Test.QuickCheck.Monadic
+
+testForeignStorableRefs :: TestTree
+testForeignStorableRefs = testGroup "Storable"
+    [ testGroup "Storable"
+        [ testPropertyStorable "Word8" (Proxy :: Proxy Word8)
+        , testPropertyStorable "Word16" (Proxy :: Proxy Word16)
+        , testPropertyStorable "Word32" (Proxy :: Proxy Word32)
+        , testPropertyStorable "Word64" (Proxy :: Proxy Word64)
+        , testPropertyStorable "Int8" (Proxy :: Proxy Int8)
+        , testPropertyStorable "Int16" (Proxy :: Proxy Int16)
+        , testPropertyStorable "Int32" (Proxy :: Proxy Int32)
+        , testPropertyStorable "Int64" (Proxy :: Proxy Int64)
+        , testPropertyStorable "Char" (Proxy :: Proxy Char)
+        , testPropertyStorable "Double" (Proxy :: Proxy Double)
+        , testPropertyStorable "Float" (Proxy :: Proxy Float)
+        ]
+    , testGroup "StorableFixed"
+        [ testPropertyStorableFixed "Word8" (Proxy :: Proxy Word8)
+        , testPropertyStorableFixed "Word16" (Proxy :: Proxy Word16)
+        , testPropertyStorableFixed "Word32" (Proxy :: Proxy Word32)
+        , testPropertyStorableFixed "Word64" (Proxy :: Proxy Word64)
+        , testPropertyStorableFixed "Int8" (Proxy :: Proxy Int8)
+        , testPropertyStorableFixed "Int16" (Proxy :: Proxy Int16)
+        , testPropertyStorableFixed "Int32" (Proxy :: Proxy Int32)
+        , testPropertyStorableFixed "Int64" (Proxy :: Proxy Int64)
+        , testPropertyStorableFixed "Char" (Proxy :: Proxy Char)
+        , testPropertyStorableFixed "Double" (Proxy :: Proxy Double)
+        , testPropertyStorableFixed "Float" (Proxy :: Proxy Float)
+        ]
+    ]
+
+testPropertyStorable :: (Storable a, Foreign.Storable.Storable a, Arbitrary a, Eq a, Show a)
+                     => LString
+                     -> Proxy a
+                     -> TestTree
+testPropertyStorable name p = testGroup name
+    [ testProperty "peek" $ testPropertyStorablePeek p
+    , testProperty "poke" $ testPropertyStorablePoke p
+    ]
+
+testPropertyStorableFixed :: (StorableFixed a, Foreign.Storable.Storable a, Arbitrary a, Eq a, Show a)
+                          => LString
+                          -> Proxy a
+                          -> TestTree
+testPropertyStorableFixed name p = testGroup name
+    [ testProperty "size"      $ withProxy p $ \a -> size p === (Size $ Foreign.Storable.sizeOf a)
+    , testProperty "alignment" $ withProxy p $ \a -> alignment p === (Size $ Foreign.Storable.alignment a)
+    , testProperty "peekOff"   $ testPropertyStorableFixedPeekOff p
+    , testProperty "pokeOff"   $ testPropertyStorableFixedPokeOff p
+    ]
+  where
+    withProxy :: (Arbitrary a, Storable a, Show a, Eq a, Foreign.Storable.Storable a)
+              => Proxy a -> (a -> Property) -> (a -> Property)
+    withProxy _ f = f
+
+testPropertyStorablePeek :: (Storable a, Foreign.Storable.Storable a, Arbitrary a, Eq a, Show a)
+                         => Proxy a
+                         -> a
+                         -> Property
+testPropertyStorablePeek _ v = monadicIO $ do
+    v' <- run $ Foreign.Marshal.Alloc.alloca $ \ptr -> do
+            Foreign.Storable.poke ptr v
+            peek ptr
+    assert $ v == v'
+
+testPropertyStorablePoke :: (Storable a, Foreign.Storable.Storable a, Arbitrary a, Eq a, Show a)
+                         => Proxy a
+                         -> a
+                         -> Property
+testPropertyStorablePoke _ v = monadicIO $ do
+    v' <- run $ Foreign.Marshal.Alloc.alloca $ \ptr -> do
+            poke ptr v
+            Foreign.Storable.peek ptr
+    assert $ v == v'
+
+data SomeWhereInArray a = SomeWhereInArray a Int Int
+    deriving (Show, Eq)
+instance (StorableFixed a, Arbitrary a) => Arbitrary (SomeWhereInArray a) where
+    arbitrary = do
+        a  <- arbitrary
+        let p = toProxy a
+            (Size minsz) = size p + (alignment p - size p)
+        sz <- choose (minsz, 512)
+        o  <- choose (0, sz - minsz)
+        return $ SomeWhereInArray a sz o
+      where
+        toProxy :: a -> Proxy a
+        toProxy _ = Proxy
+
+testPropertyStorableFixedPeekOff :: (StorableFixed a, Foreign.Storable.Storable a, Arbitrary a, Eq a, Show a)
+                         => Proxy a
+                         -> SomeWhereInArray a
+                         -> Property
+testPropertyStorableFixedPeekOff _ r@(SomeWhereInArray v sz off) = monadicIO $ do
+    v' <- run $ Foreign.Marshal.Array.allocaArray sz $ \ptr -> do
+            Foreign.Storable.pokeElemOff ptr off v
+            peekOff ptr (Offset off)
+    assert $ v == v'
+
+testPropertyStorableFixedPokeOff :: (StorableFixed a, Foreign.Storable.Storable a, Arbitrary a, Eq a, Show a)
+                         => Proxy a
+                         -> SomeWhereInArray a
+                         -> Property
+testPropertyStorableFixedPokeOff _ r@(SomeWhereInArray v sz off) = monadicIO $ do
+    v' <- run $ Foreign.Marshal.Array.allocaArray sz $ \ptr -> do
+            pokeOff ptr (Offset off) v
+            Foreign.Storable.peekElemOff ptr off
+    assert $ v == v'

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -26,6 +26,7 @@ import Test.Foundation.Number
 import Test.Foundation.Array
 import Test.Foundation.String
 import Test.Foundation.Parser
+import Test.Foundation.Storable
 
 data CharMap = CharMap LUString Prelude.Int
     deriving (Show)
@@ -311,6 +312,7 @@ tests =
                 arbitrary arbitrary )
         ]
     , testParsers
+    , testForeignStorableRefs
     ]
 
 testCaseModifiedUTF8 :: [Char] -> String -> Assertion


### PR DESCRIPTION
Fix #111 

Also export `Offset` and `Size` for consistency of the interface.
So far, we only provide instances for `PrimType` types. 