### PR TITLE
[#87] unboxed array unpinning heuristic

### DIFF
--- a/Foundation/Internal/Environment.hs
+++ b/Foundation/Internal/Environment.hs
@@ -28,8 +28,7 @@ import           Text.Read
 --
 -- TODO The default value of 1024 bytes is arbitrarily chosen for now.
 unsafeUArrayUnpinnedMaxSize :: Size8
-unsafeUArrayUnpinnedMaxSize = maybe (Size 1024) Size maxSize
-  where
-    fromEnv = unsafePerformIO $ lookupEnv "HS_FOUNDATION_UARRAY_UNPINNED_MAX"
-    maxSize = fromEnv >>= readMaybe
+unsafeUArrayUnpinnedMaxSize = unsafePerformIO $ do
+    maxSize <- (>>= readMaybe) <$> lookupEnv "HS_FOUNDATION_UARRAY_UNPINNED_MAX"
+    return $ maybe (Size 1024) Size maxSize
 {-# NOINLINE unsafeUArrayUnpinnedMaxSize #-}

--- a/Foundation/Internal/Environment.hs
+++ b/Foundation/Internal/Environment.hs
@@ -1,0 +1,35 @@
+-- |
+-- Module      : Foundation.Internal.Environment
+-- License     : BSD-style
+-- Maintainer  : foundation
+-- Stability   : experimental
+-- Portability : portable
+--
+-- Global configuration environment
+module Foundation.Internal.Environment
+    ( unsafeUArrayUnpinnedMaxSize
+    ) where
+
+import           Foundation.Internal.Base
+import           Foundation.Internal.Types
+import           System.Environment
+import           System.IO.Unsafe          (unsafePerformIO)
+import           Text.Read
+
+-- | Defines the maximum size in bytes of unpinned arrays.
+--
+-- You can change this value by setting the environment variable
+-- @HS_FOUNDATION_UARRAY_UNPINNED_MAX@ to an unsigned integer number.
+--
+-- Note: We use 'unsafePerformIO' here. If the environment variable
+-- changes during runtime and the runtime system decides to recompute
+-- this value, referential transparency is violated (like the First
+-- Order violated the Galactic Concordance!).
+--
+-- TODO The default value of 1024 bytes is arbitrarily chosen for now.
+unsafeUArrayUnpinnedMaxSize :: Size8
+unsafeUArrayUnpinnedMaxSize = maybe (Size 1024) Size maxSize
+  where
+    fromEnv = unsafePerformIO $ lookupEnv "HS_FOUNDATION_UARRAY_UNPINNED_MAX"
+    maxSize = fromEnv >>= readMaybe
+{-# NOINLINE unsafeUArrayUnpinnedMaxSize #-}

--- a/Foundation/String/UTF8.hs
+++ b/Foundation/String/UTF8.hs
@@ -734,15 +734,15 @@ intersperse sep src
     !srcLen   = length src
     dstBytes = srcBytes + ((srcLen - 1) `scale` charToBytes (fromEnum sep))
 
-    lastSrc :: Offset Char
-    lastSrc = Offset 0 `offsetPlusE` Size srcLen
+    lastSrcI :: Offset Char
+    lastSrcI = Offset 0 `offsetPlusE` Size (srcLen - 1)
 
     go :: Char -> String -> Offset Char -> Offset8 -> MutableString s -> Offset8 -> ST s (Offset8, Offset8)
     go sep' src' srcI srcIdx dst dstIdx
-        | srcI == lastSrc = do
+        | srcI == lastSrcI = do
             nextDstIdx <- write dst dstIdx c
             return (nextSrcIdx, nextDstIdx)
-        | otherwise          = do
+        | otherwise        = do
             nextDstIdx  <- write dst dstIdx c
             nextDstIdx' <- write dst nextDstIdx sep'
             return (nextSrcIdx, nextDstIdx')

--- a/README.md
+++ b/README.md
@@ -17,8 +17,11 @@ Goals
 * provide better data-types: packed unicode string by default, arrays.
 * Better numerical classes that better represent mathematical things (No more all-in-one Num).
 
+Usage
+=====
+
 How to use with the normal Prelude
-==================================
+----------------------------------
 
 Add the `foundation` package in your cabal file, and it's recommended to import Foundation qualified if
 you're planning to use with the normal Prelude:
@@ -33,7 +36,7 @@ It's also recommended if you're going to deal with packages using text, bytestri
 the `foundation-edge` package.
 
 How to use fully without Prelude
-================================
+--------------------------------
 
 Disable the built-in prelude at the top of your file:
 
@@ -53,6 +56,13 @@ Then in your modules:
 import Foundation
 ```
 
+Advanced settings
+----------------------
+
+Please check out the chapter [Advanced Usage Options](docs/Advanced.md) in the
+documentation.
+
+
 How to contribute
 =================
 
@@ -66,7 +76,7 @@ Any contributions is welcome, but a short list includes:
 * Make your project use foundation instead of base, report the missing coverage (IO, types, etc.), or what functionality is missing to make a succesful transition
 
 Profiling
-=========
+---------
 
 If you want to see the core (simpl step) or the assembly (asm step), then you can build with
 
@@ -88,7 +98,7 @@ For profiling individual programs, the following command is useful:
     stack ghc -- -O --make X.hs -prof -auto-all -caf-all -fforce-recomp
 
 Benchmarking
-============
+------------
 
 To get the list of benchmark:
 
@@ -112,9 +122,9 @@ Foundation started on the simple idea of trying to put everything I need in one
 simple and consistent package. The amazing haskell ecosystem is extremely
 fragmented and maintained by different people with different goals, free time,
 and style. The overall scare of not trying to change anything relatively
-central (base, bytestring, text, vector ..) for a promise of stability has pushed
-many people to work on their own thing, leading to unnecessary work duplication
-and further fragmentation.
+central (`base`, `bytestring`, `text`, `vector`, ...) for a promise of stability
+has pushed many people to work on their own thing, leading to unnecessary work
+duplication and further fragmentation.
 
 
 Foundation uses and abuses type families.

--- a/docs/Advanced.md
+++ b/docs/Advanced.md
@@ -1,0 +1,16 @@
+# Advanced Usage Options
+
+## Environment Variables
+
+You can override some of the constants used by *Foundation* using environment
+variables:
+
+### Maximum size of unpinned arrays (in bytes)
+
+- Environment Variable: `HS_FOUNDATION_UARRAY_UNPINNED_MAX`
+- Default: `1024`
+
+When memory for a new array is allocated, we decide if that memory region should
+be **pinned** (will not be copied around by GC) or **unpinned** (can be moved
+around by GC) depending on the size of the memory region. This value specifies
+up to which size **unpinned** memory will be used.

--- a/foundation.cabal
+++ b/foundation.cabal
@@ -85,6 +85,7 @@ Library
                      Foundation.Collection.Mutable
                      Foundation.Collection.Zippable
                      Foundation.Internal.Base
+                     Foundation.Internal.Environment
                      Foundation.Internal.Primitive
                      Foundation.Internal.IsList
                      Foundation.Internal.Identity


### PR DESCRIPTION
- [x] Add heuristics to choose pinned or unpinned memory for `UArray`s
- [x] Introduce environment variable `HS_FOUNDATION_UARRAY_UNPINNED_MAX`
to alter the default threshold value used
- [x] Document environment variable

Currently the default value is arbitrarily set to 1 kB.

If someone can come up with a better alternative to using `unsafePerformIO` for reading the environment variable, please come forward. :)

![I'm all ears!](https://media.makeameme.org/created/im-all-ears.png)
