### PR TITLE
Add bounds check for bytearray and mutable byte array

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -133,7 +133,7 @@ install:
   set -ex
   case "$BUILD" in
     stack)
-      stack --no-terminal --install-ghc $ARGS test --coverage --bench --only-dependencies
+      stack --no-terminal --install-ghc $ARGS test --flag foundation:bounds-check --coverage --bench --only-dependencies
       ;;
     cabal)
       cabal --version

--- a/Foundation/Array/Boxed.hs
+++ b/Foundation/Array/Boxed.hs
@@ -214,7 +214,7 @@ index array n
 -- Reading from invalid memory can return unpredictable and invalid values.
 -- use 'index' if unsure.
 unsafeIndex :: Array ty -> Int -> ty
-unsafeIndex (Array (Offset (I# ofs)) _ a) (I# i) = let (# v #) = indexArray# a (ofs +# i) in v
+unsafeIndex (Array start _ a) ofs = primArrayIndex a (start+Offset ofs)
 {-# INLINE unsafeIndex #-}
 
 -- | read a cell in a mutable array.
@@ -232,8 +232,7 @@ read array n
 -- Reading from invalid memory can return unpredictable and invalid values.
 -- use 'read' if unsure.
 unsafeRead :: PrimMonad prim => MArray ty (PrimState prim) -> Int -> prim ty
-unsafeRead (MArray (Offset (I# ofs)) _ ma) (I# i) = primitive $ \s1 -> readArray# ma (ofs +# i) s1
---readArray# :: MutableArray# s a -> Int# -> State# s -> (#State# s, a#)
+unsafeRead (MArray start _ ma) i = primMutableArrayRead ma (start + Offset i)
 {-# INLINE unsafeRead #-}
 
 -- | Write to a cell in a mutable array.
@@ -251,8 +250,8 @@ write array n val
 -- Writing with invalid bounds will corrupt memory and your program will
 -- become unreliable. use 'write' if unsure.
 unsafeWrite :: PrimMonad prim => MArray ty (PrimState prim) -> Int -> ty -> prim ()
-unsafeWrite (MArray (Offset (I# ofs)) _ ma) (I# i) v =
-    primitive $ \s1 -> let !s2 = writeArray# ma (ofs +# i) v s1 in (# s2, () #)
+unsafeWrite (MArray start _ ma) ofs v =
+    primMutableArrayWrite ma (start + Offset ofs) v
 {-# INLINE unsafeWrite #-}
 
 -- | Freeze a mutable array into an array.

--- a/Foundation/Array/Unboxed.hs
+++ b/Foundation/Array/Unboxed.hs
@@ -589,7 +589,7 @@ splitElem !ty r@(UVecBA start len pinst ba)
     !k = loop start
     loop !i | i < end && t /= ty = loop (i+Offset 1)
             | otherwise          = i
-        where !t                 = primBaIndex ba i
+        where t                  = primBaIndex ba i
 splitElem !ty r@(UVecAddr start len fptr)
     | k == end  = (# r, empty #)
     | otherwise =
@@ -698,7 +698,7 @@ elem !ty (UVecBA start len _ ba)
     !k = loop start
     loop !i | i < end && t /= ty = loop (i+Offset 1)
             | otherwise          = i
-        where !t                 = primBaIndex ba i
+        where t                  = primBaIndex ba i
 elem ty (UVecAddr start len fptr)
     | k == end  = False
     | otherwise = True

--- a/Foundation/Internal/CallStack.hs
+++ b/Foundation/Internal/CallStack.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE CPP #-}
+module Foundation.Internal.CallStack
+    ( HasCallStack
+    ) where
+
+#if MIN_VERSION_base(4,9,0)
+
+import GHC.Stack (HasCallStack)
+
+#elif MIN_VERSION_base(4,8,0)
+
+import qualified GHC.Stack
+
+type HasCallStack = (?callStack :: GHC.Stack.CallStack)
+
+#else
+
+import GHC.Exts (Constraint)
+
+type HasCallStack = (() :: Constraint)
+
+#endif

--- a/Foundation/Internal/CallStack.hs
+++ b/Foundation/Internal/CallStack.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE ConstraintKinds #-}
 module Foundation.Internal.CallStack
     ( HasCallStack
     ) where

--- a/Foundation/Primitive/Types.hs
+++ b/Foundation/Primitive/Types.hs
@@ -34,8 +34,6 @@ import           Foundation.Internal.Types
 import           Foundation.Primitive.Monad
 import qualified Prelude (quot)
 
-#define FOUNDATION_BOUNDS_CHECK
-
 #ifdef FOUNDATION_BOUNDS_CHECK
 
 divBytes :: PrimType ty => Offset ty -> (Int -> Int)

--- a/Foundation/Primitive/Types.hs
+++ b/Foundation/Primitive/Types.hs
@@ -124,7 +124,7 @@ primArrayIndex :: Array# ty -> Offset ty -> ty
 primArrayIndex a (Offset (I# ofs)) = let (# v #) = indexArray# a ofs in v
 {-# INLINE primArrayIndex #-}
 
-primMutableArrayRead :: PrimMonad prim => MutableArray# (PrimState prim) ty -> Offset ty -> prim a
+primMutableArrayRead :: PrimMonad prim => MutableArray# (PrimState prim) ty -> Offset ty -> prim ty
 primMutableArrayRead ma (Offset (I# ofs)) = primitive $ \s1 -> readArray# ma ofs s1
 {-# INLINE primMutableArrayRead #-}
 

--- a/Foundation/Primitive/Types.hs
+++ b/Foundation/Primitive/Types.hs
@@ -7,8 +7,12 @@
 --
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE CPP #-}
 module Foundation.Primitive.Types
     ( PrimType(..)
+    , primBaIndex
+    , primMbaRead
+    , primMbaWrite
     , primOffsetOfE
     , primOffsetRecast
     , sizeRecast
@@ -27,6 +31,63 @@ import           Foundation.Internal.Types
 import           Foundation.Primitive.Monad
 import qualified Prelude (quot)
 
+#define FOUNDATION_BOUNDS_CHECK
+
+#ifdef FOUNDATION_BOUNDS_CHECK
+
+tyToSize :: PrimType ty => Proxy ty -> Offset ty -> Size8
+tyToSize p _ = primSizeInBytes p
+
+baLenBytes :: ByteArray# -> Int
+baLenBytes ba = I# (sizeofByteArray# ba)
+
+mbaLenBytes :: MutableByteArray# st -> Int
+mbaLenBytes ba = I# (sizeofMutableByteArray# ba)
+
+boundCheckError :: [Char] -> Offset ty -> Int -> a
+boundCheckError ty (Offset ofs) len =
+    error (ty <> " offset=" <> show ofs <> " len=" <> show len)
+
+baCheck :: ByteArray# -> Offset ty -> Bool
+baCheck ba (Offset o) = o < 0 || o >= baLenBytes ba
+
+mbaCheck :: MutableByteArray# st -> Offset ty -> Bool
+mbaCheck mba (Offset o) = o < 0 || o >= mbaLenBytes mba
+
+primBaIndex :: PrimType ty => ByteArray# -> Offset ty -> ty
+primBaIndex ba ofs
+    | baCheck ba ofs = boundCheckError "bytearray-index" ofs (baLenBytes ba)
+    | otherwise      = primBaUIndex ba ofs
+{-# NOINLINE primBaIndex #-}
+
+primMbaRead :: (PrimType ty, PrimMonad prim) => MutableByteArray# (PrimState prim) -> Offset ty -> prim ty
+primMbaRead mba ofs
+    | mbaCheck mba ofs = boundCheckError "mutablebytearray-read" ofs (mbaLenBytes mba)
+    | otherwise        = primMbaURead mba ofs
+{-# NOINLINE primMbaRead #-}
+
+primMbaWrite :: (PrimType ty, PrimMonad prim) => MutableByteArray# (PrimState prim) -> Offset ty -> ty -> prim ()
+primMbaWrite mba ofs ty
+    | mbaCheck mba ofs = boundCheckError "mutablebytearray-write" ofs (mbaLenBytes mba)
+    | otherwise        = primMbaUWrite mba ofs ty
+{-# NOINLINE primMbaWrite #-}
+
+#else
+
+primBaIndex :: PrimType ty => ByteArray# -> Offset ty -> ty
+primBaIndex = primBaUIndex
+{-# INLINE primBaIndex #-}
+
+primMbaRead :: (PrimType ty, PrimMonad prim) => MutableByteArray# (PrimState prim) -> Offset ty -> prim ty
+primMbaRead = primMbaURead
+{-# INLINE primMbaRead #-}
+
+primMbaWrite :: (PrimType ty, PrimMonad prim) => MutableByteArray# (PrimState prim) -> Offset ty -> ty -> prim ()
+primMbaWrite = primMbaUWrite
+{-# INLINE primMbaWrite #-}
+
+#endif
+
 -- | Represent the accessor for types that can be stored in the UArray and MUArray.
 --
 -- Types need to be a instance of storable and have fixed sized.
@@ -39,20 +100,20 @@ class Eq ty => PrimType ty where
     -----
 
     -- | return the element stored at a specific index
-    primBaIndex :: ByteArray# -> Offset ty -> ty
+    primBaUIndex :: ByteArray# -> Offset ty -> ty
 
     -----
     -- MutableByteArray section
     -----
 
     -- | Read an element at an index in a mutable array
-    primMbaRead :: PrimMonad prim
+    primMbaURead :: PrimMonad prim
                 => MutableByteArray# (PrimState prim) -- ^ mutable array to read from
                 -> Offset ty                         -- ^ index of the element to retrieve
                 -> prim ty                           -- ^ the element returned
 
     -- | Write an element to a specific cell in a mutable array.
-    primMbaWrite :: PrimMonad prim
+    primMbaUWrite :: PrimMonad prim
                  => MutableByteArray# (PrimState prim) -- ^ mutable array to modify
                  -> Offset ty                         -- ^ index of the element to modify
                  -> ty                                 -- ^ the new value to store
@@ -78,17 +139,17 @@ class Eq ty => PrimType ty where
                   -> ty
                   -> prim ()
 
-{-# SPECIALIZE [3] primBaIndex :: ByteArray# -> Offset Word8 -> Word8 #-}
+{-# SPECIALIZE [3] primBaUIndex :: ByteArray# -> Offset Word8 -> Word8 #-}
 
 instance PrimType Word8 where
     primSizeInBytes _ = Size 1
     {-# INLINE primSizeInBytes #-}
-    primBaIndex ba (Offset (I# n)) = W8# (indexWord8Array# ba n)
-    {-# INLINE primBaIndex #-}
-    primMbaRead mba (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readWord8Array# mba n s1 in (# s2, W8# r #)
-    {-# INLINE primMbaRead #-}
-    primMbaWrite mba (Offset (I# n)) (W8# w) = primitive $ \s1 -> (# writeWord8Array# mba n w s1, () #)
-    {-# INLINE primMbaWrite #-}
+    primBaUIndex ba (Offset (I# n)) = W8# (indexWord8Array# ba n)
+    {-# INLINE primBaUIndex #-}
+    primMbaURead mba (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readWord8Array# mba n s1 in (# s2, W8# r #)
+    {-# INLINE primMbaURead #-}
+    primMbaUWrite mba (Offset (I# n)) (W8# w) = primitive $ \s1 -> (# writeWord8Array# mba n w s1, () #)
+    {-# INLINE primMbaUWrite #-}
     primAddrIndex addr (Offset (I# n)) = W8# (indexWord8OffAddr# addr n)
     {-# INLINE primAddrIndex #-}
     primAddrRead addr (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readWord8OffAddr# addr n s1 in (# s2, W8# r #)
@@ -99,12 +160,12 @@ instance PrimType Word8 where
 instance PrimType Word16 where
     primSizeInBytes _ = Size 2
     {-# INLINE primSizeInBytes #-}
-    primBaIndex ba (Offset (I# n)) = W16# (indexWord16Array# ba n)
-    {-# INLINE primBaIndex #-}
-    primMbaRead mba (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readWord16Array# mba n s1 in (# s2, W16# r #)
-    {-# INLINE primMbaRead #-}
-    primMbaWrite mba (Offset (I# n)) (W16# w) = primitive $ \s1 -> (# writeWord16Array# mba n w s1, () #)
-    {-# INLINE primMbaWrite #-}
+    primBaUIndex ba (Offset (I# n)) = W16# (indexWord16Array# ba n)
+    {-# INLINE primBaUIndex #-}
+    primMbaURead mba (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readWord16Array# mba n s1 in (# s2, W16# r #)
+    {-# INLINE primMbaURead #-}
+    primMbaUWrite mba (Offset (I# n)) (W16# w) = primitive $ \s1 -> (# writeWord16Array# mba n w s1, () #)
+    {-# INLINE primMbaUWrite #-}
     primAddrIndex addr (Offset (I# n)) = W16# (indexWord16OffAddr# addr n)
     {-# INLINE primAddrIndex #-}
     primAddrRead addr (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readWord16OffAddr# addr n s1 in (# s2, W16# r #)
@@ -114,12 +175,12 @@ instance PrimType Word16 where
 instance PrimType Word32 where
     primSizeInBytes _ = Size 4
     {-# INLINE primSizeInBytes #-}
-    primBaIndex ba (Offset (I# n)) = W32# (indexWord32Array# ba n)
-    {-# INLINE primBaIndex #-}
-    primMbaRead mba (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readWord32Array# mba n s1 in (# s2, W32# r #)
-    {-# INLINE primMbaRead #-}
-    primMbaWrite mba (Offset (I# n)) (W32# w) = primitive $ \s1 -> (# writeWord32Array# mba n w s1, () #)
-    {-# INLINE primMbaWrite #-}
+    primBaUIndex ba (Offset (I# n)) = W32# (indexWord32Array# ba n)
+    {-# INLINE primBaUIndex #-}
+    primMbaURead mba (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readWord32Array# mba n s1 in (# s2, W32# r #)
+    {-# INLINE primMbaURead #-}
+    primMbaUWrite mba (Offset (I# n)) (W32# w) = primitive $ \s1 -> (# writeWord32Array# mba n w s1, () #)
+    {-# INLINE primMbaUWrite #-}
     primAddrIndex addr (Offset (I# n)) = W32# (indexWord32OffAddr# addr n)
     {-# INLINE primAddrIndex #-}
     primAddrRead addr (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readWord32OffAddr# addr n s1 in (# s2, W32# r #)
@@ -129,12 +190,12 @@ instance PrimType Word32 where
 instance PrimType Word64 where
     primSizeInBytes _ = Size 8
     {-# INLINE primSizeInBytes #-}
-    primBaIndex ba (Offset (I# n)) = W64# (indexWord64Array# ba n)
-    {-# INLINE primBaIndex #-}
-    primMbaRead mba (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readWord64Array# mba n s1 in (# s2, W64# r #)
-    {-# INLINE primMbaRead #-}
-    primMbaWrite mba (Offset (I# n)) (W64# w) = primitive $ \s1 -> (# writeWord64Array# mba n w s1, () #)
-    {-# INLINE primMbaWrite #-}
+    primBaUIndex ba (Offset (I# n)) = W64# (indexWord64Array# ba n)
+    {-# INLINE primBaUIndex #-}
+    primMbaURead mba (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readWord64Array# mba n s1 in (# s2, W64# r #)
+    {-# INLINE primMbaURead #-}
+    primMbaUWrite mba (Offset (I# n)) (W64# w) = primitive $ \s1 -> (# writeWord64Array# mba n w s1, () #)
+    {-# INLINE primMbaUWrite #-}
     primAddrIndex addr (Offset (I# n)) = W64# (indexWord64OffAddr# addr n)
     {-# INLINE primAddrIndex #-}
     primAddrRead addr (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readWord64OffAddr# addr n s1 in (# s2, W64# r #)
@@ -144,12 +205,12 @@ instance PrimType Word64 where
 instance PrimType Int8 where
     primSizeInBytes _ = Size 1
     {-# INLINE primSizeInBytes #-}
-    primBaIndex ba (Offset (I# n)) = I8# (indexInt8Array# ba n)
-    {-# INLINE primBaIndex #-}
-    primMbaRead mba (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readInt8Array# mba n s1 in (# s2, I8# r #)
-    {-# INLINE primMbaRead #-}
-    primMbaWrite mba (Offset (I# n)) (I8# w) = primitive $ \s1 -> (# writeInt8Array# mba n w s1, () #)
-    {-# INLINE primMbaWrite #-}
+    primBaUIndex ba (Offset (I# n)) = I8# (indexInt8Array# ba n)
+    {-# INLINE primBaUIndex #-}
+    primMbaURead mba (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readInt8Array# mba n s1 in (# s2, I8# r #)
+    {-# INLINE primMbaURead #-}
+    primMbaUWrite mba (Offset (I# n)) (I8# w) = primitive $ \s1 -> (# writeInt8Array# mba n w s1, () #)
+    {-# INLINE primMbaUWrite #-}
     primAddrIndex addr (Offset (I# n)) = I8# (indexInt8OffAddr# addr n)
     {-# INLINE primAddrIndex #-}
     primAddrRead addr (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readInt8OffAddr# addr n s1 in (# s2, I8# r #)
@@ -159,12 +220,12 @@ instance PrimType Int8 where
 instance PrimType Int16 where
     primSizeInBytes _ = Size 2
     {-# INLINE primSizeInBytes #-}
-    primBaIndex ba (Offset (I# n)) = I16# (indexInt16Array# ba n)
-    {-# INLINE primBaIndex #-}
-    primMbaRead mba (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readInt16Array# mba n s1 in (# s2, I16# r #)
-    {-# INLINE primMbaRead #-}
-    primMbaWrite mba (Offset (I# n)) (I16# w) = primitive $ \s1 -> (# writeInt16Array# mba n w s1, () #)
-    {-# INLINE primMbaWrite #-}
+    primBaUIndex ba (Offset (I# n)) = I16# (indexInt16Array# ba n)
+    {-# INLINE primBaUIndex #-}
+    primMbaURead mba (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readInt16Array# mba n s1 in (# s2, I16# r #)
+    {-# INLINE primMbaURead #-}
+    primMbaUWrite mba (Offset (I# n)) (I16# w) = primitive $ \s1 -> (# writeInt16Array# mba n w s1, () #)
+    {-# INLINE primMbaUWrite #-}
     primAddrIndex addr (Offset (I# n)) = I16# (indexInt16OffAddr# addr n)
     {-# INLINE primAddrIndex #-}
     primAddrRead addr (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readInt16OffAddr# addr n s1 in (# s2, I16# r #)
@@ -174,12 +235,12 @@ instance PrimType Int16 where
 instance PrimType Int32 where
     primSizeInBytes _ = Size 4
     {-# INLINE primSizeInBytes #-}
-    primBaIndex ba (Offset (I# n)) = I32# (indexInt32Array# ba n)
-    {-# INLINE primBaIndex #-}
-    primMbaRead mba (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readInt32Array# mba n s1 in (# s2, I32# r #)
-    {-# INLINE primMbaRead #-}
-    primMbaWrite mba (Offset (I# n)) (I32# w) = primitive $ \s1 -> (# writeInt32Array# mba n w s1, () #)
-    {-# INLINE primMbaWrite #-}
+    primBaUIndex ba (Offset (I# n)) = I32# (indexInt32Array# ba n)
+    {-# INLINE primBaUIndex #-}
+    primMbaURead mba (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readInt32Array# mba n s1 in (# s2, I32# r #)
+    {-# INLINE primMbaURead #-}
+    primMbaUWrite mba (Offset (I# n)) (I32# w) = primitive $ \s1 -> (# writeInt32Array# mba n w s1, () #)
+    {-# INLINE primMbaUWrite #-}
     primAddrIndex addr (Offset (I# n)) = I32# (indexInt32OffAddr# addr n)
     {-# INLINE primAddrIndex #-}
     primAddrRead addr (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readInt32OffAddr# addr n s1 in (# s2, I32# r #)
@@ -189,12 +250,12 @@ instance PrimType Int32 where
 instance PrimType Int64 where
     primSizeInBytes _ = Size 8
     {-# INLINE primSizeInBytes #-}
-    primBaIndex ba (Offset (I# n)) = I64# (indexInt64Array# ba n)
-    {-# INLINE primBaIndex #-}
-    primMbaRead mba (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readInt64Array# mba n s1 in (# s2, I64# r #)
-    {-# INLINE primMbaRead #-}
-    primMbaWrite mba (Offset (I# n)) (I64# w) = primitive $ \s1 -> (# writeInt64Array# mba n w s1, () #)
-    {-# INLINE primMbaWrite #-}
+    primBaUIndex ba (Offset (I# n)) = I64# (indexInt64Array# ba n)
+    {-# INLINE primBaUIndex #-}
+    primMbaURead mba (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readInt64Array# mba n s1 in (# s2, I64# r #)
+    {-# INLINE primMbaURead #-}
+    primMbaUWrite mba (Offset (I# n)) (I64# w) = primitive $ \s1 -> (# writeInt64Array# mba n w s1, () #)
+    {-# INLINE primMbaUWrite #-}
     primAddrIndex addr (Offset (I# n)) = I64# (indexInt64OffAddr# addr n)
     {-# INLINE primAddrIndex #-}
     primAddrRead addr (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readInt64OffAddr# addr n s1 in (# s2, I64# r #)
@@ -205,12 +266,12 @@ instance PrimType Int64 where
 instance PrimType Float where
     primSizeInBytes _ = Size 4
     {-# INLINE primSizeInBytes #-}
-    primBaIndex ba (Offset (I# n)) = F# (indexFloatArray# ba n)
-    {-# INLINE primBaIndex #-}
-    primMbaRead mba (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readFloatArray# mba n s1 in (# s2, F# r #)
-    {-# INLINE primMbaRead #-}
-    primMbaWrite mba (Offset (I# n)) (F# w) = primitive $ \s1 -> (# writeFloatArray# mba n w s1, () #)
-    {-# INLINE primMbaWrite #-}
+    primBaUIndex ba (Offset (I# n)) = F# (indexFloatArray# ba n)
+    {-# INLINE primBaUIndex #-}
+    primMbaURead mba (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readFloatArray# mba n s1 in (# s2, F# r #)
+    {-# INLINE primMbaURead #-}
+    primMbaUWrite mba (Offset (I# n)) (F# w) = primitive $ \s1 -> (# writeFloatArray# mba n w s1, () #)
+    {-# INLINE primMbaUWrite #-}
     primAddrIndex addr (Offset (I# n)) = F# (indexFloatOffAddr# addr n)
     {-# INLINE primAddrIndex #-}
     primAddrRead addr (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readFloatOffAddr# addr n s1 in (# s2, F# r #)
@@ -220,12 +281,12 @@ instance PrimType Float where
 instance PrimType Double where
     primSizeInBytes _ = Size 8
     {-# INLINE primSizeInBytes #-}
-    primBaIndex ba (Offset (I# n)) = D# (indexDoubleArray# ba n)
-    {-# INLINE primBaIndex #-}
-    primMbaRead mba (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readDoubleArray# mba n s1 in (# s2, D# r #)
-    {-# INLINE primMbaRead #-}
-    primMbaWrite mba (Offset (I# n)) (D# w) = primitive $ \s1 -> (# writeDoubleArray# mba n w s1, () #)
-    {-# INLINE primMbaWrite #-}
+    primBaUIndex ba (Offset (I# n)) = D# (indexDoubleArray# ba n)
+    {-# INLINE primBaUIndex #-}
+    primMbaURead mba (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readDoubleArray# mba n s1 in (# s2, D# r #)
+    {-# INLINE primMbaURead #-}
+    primMbaUWrite mba (Offset (I# n)) (D# w) = primitive $ \s1 -> (# writeDoubleArray# mba n w s1, () #)
+    {-# INLINE primMbaUWrite #-}
     primAddrIndex addr (Offset (I# n)) = D# (indexDoubleOffAddr# addr n)
     {-# INLINE primAddrIndex #-}
     primAddrRead addr (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readDoubleOffAddr# addr n s1 in (# s2, D# r #)
@@ -236,12 +297,12 @@ instance PrimType Double where
 instance PrimType Char where
     primSizeInBytes _ = Size 4
     {-# INLINE primSizeInBytes #-}
-    primBaIndex ba (Offset (I# n)) = C# (indexWideCharArray# ba n)
-    {-# INLINE primBaIndex #-}
-    primMbaRead mba (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readWideCharArray# mba n s1 in (# s2, C# r #)
-    {-# INLINE primMbaRead #-}
-    primMbaWrite mba (Offset (I# n)) (C# w) = primitive $ \s1 -> (# writeWideCharArray# mba n w s1, () #)
-    {-# INLINE primMbaWrite #-}
+    primBaUIndex ba (Offset (I# n)) = C# (indexWideCharArray# ba n)
+    {-# INLINE primBaUIndex #-}
+    primMbaURead mba (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readWideCharArray# mba n s1 in (# s2, C# r #)
+    {-# INLINE primMbaURead #-}
+    primMbaUWrite mba (Offset (I# n)) (C# w) = primitive $ \s1 -> (# writeWideCharArray# mba n w s1, () #)
+    {-# INLINE primMbaUWrite #-}
     primAddrIndex addr (Offset (I# n)) = C# (indexWideCharOffAddr# addr n)
     {-# INLINE primAddrIndex #-}
     primAddrRead addr (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readWideCharOffAddr# addr n s1 in (# s2, C# r #)
@@ -252,12 +313,12 @@ instance PrimType Char where
 instance PrimType CChar where
     primSizeInBytes _ = Size 1
     {-# INLINE primSizeInBytes #-}
-    primBaIndex ba (Offset n) = CChar (primBaIndex ba (Offset n :: Offset Int8))
-    {-# INLINE primBaIndex #-}
-    primMbaRead mba (Offset n) = CChar <$> primMbaRead mba (Offset n :: Offset Int8)
-    {-# INLINE primMbaRead #-}
-    primMbaWrite mba (Offset n) (CChar int8) = primMbaWrite mba (Offset n) int8
-    {-# INLINE primMbaWrite #-}
+    primBaUIndex ba (Offset n) = CChar (primBaUIndex ba (Offset n :: Offset Int8))
+    {-# INLINE primBaUIndex #-}
+    primMbaURead mba (Offset n) = CChar <$> primMbaURead mba (Offset n :: Offset Int8)
+    {-# INLINE primMbaURead #-}
+    primMbaUWrite mba (Offset n) (CChar int8) = primMbaUWrite mba (Offset n) int8
+    {-# INLINE primMbaUWrite #-}
     primAddrIndex addr (Offset n) = CChar $ primAddrIndex addr (Offset n :: Offset Int8)
     {-# INLINE primAddrIndex #-}
     primAddrRead addr (Offset n) = CChar <$> primAddrRead addr (Offset n :: Offset Int8)
@@ -267,19 +328,18 @@ instance PrimType CChar where
 instance PrimType CUChar where
     primSizeInBytes _ = Size 1
     {-# INLINE primSizeInBytes #-}
-    primBaIndex ba (Offset n) = CUChar (primBaIndex ba (Offset n :: Offset Word8))
-    {-# INLINE primBaIndex #-}
-    primMbaRead mba (Offset n) = CUChar <$> primMbaRead mba (Offset n :: Offset Word8)
-    {-# INLINE primMbaRead #-}
-    primMbaWrite mba (Offset n) (CUChar w8) = primMbaWrite mba (Offset n) w8
-    {-# INLINE primMbaWrite #-}
+    primBaUIndex ba (Offset n) = CUChar (primBaUIndex ba (Offset n :: Offset Word8))
+    {-# INLINE primBaUIndex #-}
+    primMbaURead mba (Offset n) = CUChar <$> primMbaURead mba (Offset n :: Offset Word8)
+    {-# INLINE primMbaURead #-}
+    primMbaUWrite mba (Offset n) (CUChar w8) = primMbaUWrite mba (Offset n) w8
+    {-# INLINE primMbaUWrite #-}
     primAddrIndex addr (Offset n) = CUChar $ primAddrIndex addr (Offset n :: Offset Word8)
     {-# INLINE primAddrIndex #-}
     primAddrRead addr (Offset n) = CUChar <$> primAddrRead addr (Offset n :: Offset Word8)
     {-# INLINE primAddrRead #-}
     primAddrWrite addr (Offset n) (CUChar w8) = primAddrWrite addr (Offset n) w8
     {-# INLINE primAddrWrite #-}
-
 
 -- | Cast a Size linked to type A (Size A) to a Size linked to type B (Size B)
 sizeRecast :: (PrimType a, PrimType b) => Size a -> Size b

--- a/Foundation/String/UTF8.hs
+++ b/Foundation/String/UTF8.hs
@@ -162,7 +162,7 @@ instance Buildable String where
   {-# INLINE append #-}
 
   build sizeChunksI sb
-    | sizeChunksI <= 0 = build 64 sb
+    | sizeChunksI <= 3 = build 64 sb
     | otherwise        = do
         first         <- new sizeChunks
         ((), (i, st)) <- runState (runBuilder sb) (Offset 0, BuildingState [] (Size 0) first sizeChunks)

--- a/foundation.cabal
+++ b/foundation.cabal
@@ -96,6 +96,7 @@ Library
                      Foundation.Collection.Mutable
                      Foundation.Collection.Zippable
                      Foundation.Internal.Base
+                     Foundation.Internal.CallStack
                      Foundation.Internal.Environment
                      Foundation.Internal.Primitive
                      Foundation.Internal.IsList

--- a/foundation.cabal
+++ b/foundation.cabal
@@ -43,6 +43,11 @@ Flag bench-all
   Default:           False
   Manual:            True
 
+Flag bounds-check
+  Description:       Add extra friendly boundary check for unsafe array operations
+  Default:           False
+  Manual:            True
+
 Library
   Exposed-modules:   Foundation
                      Foundation.Numerical
@@ -165,6 +170,8 @@ Library
   default-language:  Haskell2010
   if impl(ghc >= 8.0)
     ghc-options:     -Wno-redundant-constraints
+  if flag(bounds-check)
+    CPP-options: -DFOUNDATION_BOUNDS_CHECK
 
 Test-Suite test-foundation
   type:              exitcode-stdio-1.0


### PR DESCRIPTION
* [x] Add ByteArray# and MutableByteArray# bounds check
* [x] Create a cabal flag that will be off by default (currently on unconditionally)
* [x] Need to be automatically tested 'on' by travis
* [x] Add Array# and MutableArray# bounds check
* [x] Resolve the out of bounds issues (already found and to come)

fix #128 