### PR TITLE
Older versions of `base` don't have `GHC.Char`

### DIFF
--- a/Foundation/String/UTF8.hs
+++ b/Foundation/String/UTF8.hs
@@ -59,7 +59,9 @@ import           GHC.Prim
 import           GHC.ST
 import           GHC.Types
 import           GHC.Word
+#if MIN_VERSION_base(4,9,0)
 import           GHC.Char
+#endif
 
  -- temporary
 import qualified Data.List


### PR DESCRIPTION
fix #170 

In `String.Utf8` we uses `eqChar` from `GHC.Char` (only available from `base-4.9.0`)

This is the [existing code](https://github.com/haskell-foundation/foundation/blob/master/Foundation/String/UTF8.hs#L691-L695) making is of `GHC.Char.eqChar`:

```haskell
#if MIN_VERSION_base(4,9,0)
{-# RULES "break (== 'c')" [3] forall c . break (eqChar c) = breakElem c #-}
#else
{-# RULES "break (== 'c')" [3] forall c . break (== c) = breakElem c #-}
#endif
```

This fix does the same and includes `GHC.Char` **if** `base` is at least version `4.9.0`.