### PR TITLE
Fix GHC 7.10.1 build

### DIFF
--- a/Foundation/Internal/CallStack.hs
+++ b/Foundation/Internal/CallStack.hs
@@ -9,7 +9,7 @@ module Foundation.Internal.CallStack
 
 import GHC.Stack (HasCallStack)
 
-#elif MIN_VERSION_base(4,8,0)
+#elif MIN_VERSION_base(4,8,1)
 
 import qualified GHC.Stack
 


### PR DESCRIPTION
Currently, `foundation` [fails to build](https://travis-ci.org/rrnewton/hgdata/jobs/188161967#L429) with GHC 7.10.1. Here's the error:

```
[ 3 of 89] Compiling Foundation.Internal.CallStack ( Foundation/Internal/CallStack.hs, dist/build/Foundation/Internal/CallStack.o )

Foundation/Internal/CallStack.hs:16:36:
    Not in scope: type constructor or class ‘GHC.Stack.CallStack’
```

That's because `CallStack` wasn't introduced until `base-4.8.1.0` (which is bundled with GHC 7.10.2). This fixes the error by correcting the use of `MIN_VERSION_base`.