### PR TITLE
support for GHC-7.4

### DIFF
--- a/Foundation/Internal/Environment.hs
+++ b/Foundation/Internal/Environment.hs
@@ -6,15 +6,50 @@
 -- Portability : portable
 --
 -- Global configuration environment
+
+{-# LANGUAGE CPP #-}
+
 module Foundation.Internal.Environment
     ( unsafeUArrayUnpinnedMaxSize
     ) where
 
 import           Foundation.Internal.Base
 import           Foundation.Internal.Types
-import           System.Environment
 import           System.IO.Unsafe          (unsafePerformIO)
-import           Text.Read
+
+#if MIN_VERSION_base(4,6,0)
+import           System.Environment (lookupEnv)
+import           Text.Read (readMaybe)
+#else
+import           System.Environment (getEnvironment)
+import           Data.List (lookup)
+import           Text.Read (Read, minPrec, readPrec, lift)
+import           Text.ParserCombinators.ReadP as P
+import           Text.ParserCombinators.ReadPrec (readPrec_to_S)
+#endif
+
+#if !MIN_VERSION_base(4,6,0)
+lookupEnv :: [Char] -> IO (Maybe [Char])
+lookupEnv envName = lookup envName <$> getEnvironment
+
+readEither :: Read a => [Char] -> Either [Char] a
+readEither s =
+  case [ x | (x,"") <- readPrec_to_S read' minPrec s ] of
+    [x] -> Right x
+    []  -> Left "Prelude.read: no parse"
+    _   -> Left "Prelude.read: ambiguous parse"
+ where
+  read' =
+    do x <- readPrec
+       lift P.skipSpaces
+       return x
+
+readMaybe :: Read a => [Char] -> Maybe a
+readMaybe s = case readEither s of
+    Left _  -> Nothing
+    Right a -> Just a
+
+#endif
 
 -- | Defines the maximum size in bytes of unpinned arrays.
 --


### PR DESCRIPTION
`lookupEnv` and `readMaybe` were not yet in `base` (prior **base-4.6.0.0**). provide support for them so we can use it in **Foundation**.