### PR TITLE
Collection re-arrangement + Copy + Documentation updates

### DIFF
--- a/Foundation/Array/Boxed.hs
+++ b/Foundation/Array/Boxed.hs
@@ -91,6 +91,9 @@ instance C.Foldable (Array ty) where
     foldr = aFoldr
     foldl' = aFoldl'
 
+instance C.Copy (Array ty) where
+    copy = copy
+
 instance C.Collection (Array ty) where
     null = null
     length = length

--- a/Foundation/Array/Unboxed/ByteArray.hs
+++ b/Foundation/Array/Unboxed/ByteArray.hs
@@ -11,7 +11,6 @@ import Foundation.Array.Common
 import Foundation.Array.Unboxed.Mutable
 import Foundation.Numerical
 import Control.Monad (forM_)
-import qualified Foundation.Collection as C
 
 -- | Mutable Byte Array alias
 type MutableByteArray st = MUArray Word8 st
@@ -19,7 +18,7 @@ type MutableByteArray st = MUArray Word8 st
 mutableByteArraySet :: PrimMonad prim => MUArray Word8 (PrimState prim) -> Word8 -> prim ()
 mutableByteArraySet mba val = do
     -- naive haskell way. TODO: call memset or a 32-bit/64-bit method
-    forM_ [0..(len-1)] $ \i -> C.mutUnsafeWrite mba i val
+    forM_ [0..(len-1)] $ \i -> unsafeWrite mba i val
   where
     len = mutableLength mba
 
@@ -29,7 +28,7 @@ mutableByteArraySetBetween mba val offset size
     | offset > len || offset+size > len = throw (OutOfBound OOB_MemSet (offset+size) len)
     | otherwise =
         -- TODO same as mutableByteArraySet
-        forM_ [offset..(offset+size-1)] $ \i -> C.mutUnsafeWrite mba i val
+        forM_ [offset..(offset+size-1)] $ \i -> unsafeWrite mba i val
   where
     len = mutableLength mba
 

--- a/Foundation/Boot/Builder.hs
+++ b/Foundation/Boot/Builder.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+module Foundation.Boot.Builder
+    ( Builder(..)
+    , BuildingState(..)
+    ) where
+
+import           Foundation.Internal.Base
+import           Foundation.Internal.MonadTrans
+import           Foundation.Internal.Types
+import           Foundation.Primitive.Monad
+
+newtype Builder collection mutCollection step state a = Builder
+    { runBuilder :: State (Offset step, BuildingState collection mutCollection step (PrimState state)) state a }
+    deriving (Functor, Applicative, Monad)
+
+-- | The in-progress state of a building operation.
+--
+-- The previous buffers are in reverse order, and
+-- this contains the current buffer and the state of
+-- progress packing the elements inside.
+data BuildingState collection mutCollection step state = BuildingState
+    { prevChunks     :: [collection]
+    , prevChunksSize :: !(Size step)
+    , curChunk       :: mutCollection state
+    , chunkSize      :: !(Size step)
+    }

--- a/Foundation/Boot/List.hs
+++ b/Foundation/Boot/List.hs
@@ -4,12 +4,14 @@ module Foundation.Boot.List
     ) where
 
 import Foundation.Internal.Base
-import Foundation.Numerical
+import Foundation.Numerical.Additive
 
+-- | Compute the size of the list
 length :: [a] -> Int
 length []     = 0
 length (_:xs) = succ (length xs)
 
+-- | Sum the element in a list
 sum :: Additive n => [n] -> n
 sum []     = azero
 sum (i:is) = loop i is

--- a/Foundation/Boot/List.hs
+++ b/Foundation/Boot/List.hs
@@ -1,9 +1,19 @@
 module Foundation.Boot.List
     ( length
+    , sum
     ) where
 
 import Foundation.Internal.Base
+import Foundation.Numerical
 
 length :: [a] -> Int
 length []     = 0
 length (_:xs) = succ (length xs)
+
+sum :: Additive n => [n] -> n
+sum []     = azero
+sum (i:is) = loop i is
+  where
+    loop !acc [] = acc
+    loop !acc (x:xs) = loop (acc+x) xs
+    {-# INLINE loop #-}

--- a/Foundation/Boot/List.hs
+++ b/Foundation/Boot/List.hs
@@ -1,0 +1,9 @@
+module Foundation.Boot.List
+    ( length
+    ) where
+
+import Foundation.Internal.Base
+
+length :: [a] -> Int
+length []     = 0
+length (_:xs) = succ (length xs)

--- a/Foundation/Collection.hs
+++ b/Foundation/Collection.hs
@@ -28,6 +28,7 @@ module Foundation.Collection
     , Buildable(..)
     , Builder(..)
     , BuildingState(..)
+    , Copy(..)
     ) where
 
 import           Foundation.Collection.Buildable
@@ -40,3 +41,4 @@ import           Foundation.Collection.Mutable
 import           Foundation.Collection.Collection
 import           Foundation.Collection.Sequential
 import           Foundation.Collection.Zippable
+import           Foundation.Collection.Copy

--- a/Foundation/Collection/Buildable.hs
+++ b/Foundation/Collection/Buildable.hs
@@ -15,6 +15,7 @@ module Foundation.Collection.Buildable
 
 import           Foundation.Array.Unboxed
 import           Foundation.Array.Unboxed.Mutable
+import qualified Foundation.Array.Boxed as BA
 import           Foundation.Collection.Element
 import           Foundation.Internal.Base
 import           Foundation.Primitive.Monad
@@ -53,9 +54,18 @@ class Buildable col where
           -> prim col
 
 instance PrimType ty => Buildable (UArray ty) where
-  type Mutable (UArray ty) = MUArray ty
-  type Step (UArray ty) = ty
-  append = builderAppend
-  {-# INLINE append #-}
-  build = builderBuild
-  {-# INLINE build #-}
+    type Mutable (UArray ty) = MUArray ty
+    type Step (UArray ty) = ty
+    append = builderAppend
+    {-# INLINE append #-}
+    build = builderBuild
+    {-# INLINE build #-}
+
+instance Buildable (BA.Array ty) where
+    type Mutable (BA.Array ty) = BA.MArray ty
+    type Step (BA.Array ty) = ty
+
+    append = BA.builderAppend
+    {-# INLINE append #-}
+    build = BA.builderBuild
+    {-# INLINE build #-}

--- a/Foundation/Collection/Buildable.hs
+++ b/Foundation/Collection/Buildable.hs
@@ -7,7 +7,6 @@
 --
 -- An interface for collections that can be built incrementally.
 --
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Foundation.Collection.Buildable
     ( Buildable(..)
     , Builder(..)
@@ -18,11 +17,8 @@ import           Foundation.Array.Unboxed
 import           Foundation.Array.Unboxed.Mutable
 import           Foundation.Collection.Element
 import           Foundation.Internal.Base
-import           Foundation.Internal.MonadTrans
-import           Foundation.Internal.Types
-import           Foundation.Numerical
 import           Foundation.Primitive.Monad
-import           Foundation.Primitive.Types
+import           Foundation.Boot.Builder
 
 -- $setup
 -- >>> import Control.Monad.ST
@@ -38,75 +34,28 @@ import           Foundation.Primitive.Types
 -- >>> runST $ build 32 (append 'a' >> append 'b' >> append 'c') :: UArray Char
 -- "abc"
 class Buildable col where
-  {-# MINIMAL append, build #-}
+    {-# MINIMAL append, build #-}
 
-  -- | Mutable collection type used for incrementally writing chunks.
-  type Mutable col :: * -> *
+    -- | Mutable collection type used for incrementally writing chunks.
+    type Mutable col :: * -> *
 
-  -- | Unit of the smallest step possible in an `append` operation.
-  --
-  -- A UTF-8 character can have a size between 1 and 4 bytes, so this
-  -- should be defined as 1 byte for collections of `Char`.
-  type Step col
+    -- | Unit of the smallest step possible in an `append` operation.
+    --
+    -- A UTF-8 character can have a size between 1 and 4 bytes, so this
+    -- should be defined as 1 byte for collections of `Char`.
+    type Step col
 
-  append :: (PrimMonad prim) => Element col -> Builder col prim ()
+    append :: (PrimMonad prim) => Element col -> Builder col (Mutable col) (Step col) prim ()
 
-  build :: (PrimMonad prim)
-        => Int -- ^ Size of a chunk
-        -> Builder col prim ()
-        -> prim col
-
-newtype Builder col st a = Builder
-    { runBuilder :: State (Offset (Step col), BuildingState col (PrimState st)) st a }
-    deriving (Functor, Applicative, Monad)
-
--- | The in-progress state of a building operation.
---
--- The previous buffers are in reverse order, and
--- this contains the current buffer and the state of
--- progress packing the elements inside.
-data BuildingState col st = BuildingState
-    { prevChunks     :: [col]
-    , prevChunksSize :: !(Size (Step col))
-    , curChunk       :: Mutable col st
-    , chunkSize      :: !(Size (Step col))
-    }
+    build :: (PrimMonad prim)
+          => Int -- ^ Size of a chunk
+          -> Builder col (Mutable col) (Step col) prim ()
+          -> prim col
 
 instance PrimType ty => Buildable (UArray ty) where
   type Mutable (UArray ty) = MUArray ty
   type Step (UArray ty) = ty
-
-  append v = Builder $ State $ \(i, st) ->
-      if offsetAsSize i == chunkSize st
-          then do
-              cur      <- unsafeFreeze (curChunk st)
-              newChunk <- new (chunkSize st)
-              unsafeWrite newChunk 0 v
-              return ((), (Offset 1, st { prevChunks     = cur : prevChunks st
-                                        , prevChunksSize = chunkSize st + prevChunksSize st
-                                        , curChunk       = newChunk
-                                        }))
-          else do
-              let Offset i' = i
-              unsafeWrite (curChunk st) i' v
-              return ((), (i + Offset 1, st))
+  append = builderAppend
   {-# INLINE append #-}
-
-  build sizeChunksI ab
-    | sizeChunksI <= 0 = build 64 ab
-    | otherwise        = do
-        first         <- new sizeChunks
-        ((), (i, st)) <- runState (runBuilder ab) (Offset 0, BuildingState [] (Size 0) first sizeChunks)
-        cur           <- unsafeFreezeShrink (curChunk st) (offsetAsSize i)
-        -- Build final array
-        let totalSize = prevChunksSize st + offsetAsSize i
-        new totalSize >>= fillFromEnd totalSize (cur : prevChunks st) >>= unsafeFreeze
-    where
-      sizeChunks = Size sizeChunksI
-
-      fillFromEnd _   []     mua = return mua
-      fillFromEnd !end (x:xs) mua = do
-          let sz = lengthSize x
-          unsafeCopyAtRO mua (sizeAsOffset (end - sz)) x (Offset 0) sz
-          fillFromEnd (end - sz) xs mua
+  build = builderBuild
   {-# INLINE build #-}

--- a/Foundation/Collection/Buildable.hs
+++ b/Foundation/Collection/Buildable.hs
@@ -16,6 +16,7 @@ module Foundation.Collection.Buildable
 import           Foundation.Array.Unboxed
 import           Foundation.Array.Unboxed.Mutable
 import qualified Foundation.Array.Boxed as BA
+import qualified Foundation.String.UTF8 as S
 import           Foundation.Collection.Element
 import           Foundation.Internal.Base
 import           Foundation.Primitive.Monad
@@ -68,4 +69,13 @@ instance Buildable (BA.Array ty) where
     append = BA.builderAppend
     {-# INLINE append #-}
     build = BA.builderBuild
+    {-# INLINE build #-}
+
+instance Buildable S.String where
+    type Mutable S.String = S.MutableString
+    type Step S.String = Word8
+
+    append = S.builderAppend
+    {-# INLINE append #-}
+    build = S.builderBuild
     {-# INLINE build #-}

--- a/Foundation/Collection/Collection.hs
+++ b/Foundation/Collection/Collection.hs
@@ -32,6 +32,7 @@ import           Foundation.Collection.Element
 import qualified Data.List
 import qualified Foundation.Array.Unboxed as UV
 import qualified Foundation.Array.Boxed as BA
+import qualified Foundation.String.UTF8 as S
 
 -- | NonEmpty property for any Collection
 --
@@ -119,6 +120,15 @@ instance Collection (BA.Array ty) where
     elem e = Data.List.elem e . toList
     minimum = Data.List.minimum . toList . getNonEmpty -- TODO
     maximum = Data.List.maximum . toList . getNonEmpty -- TODO
+    all p = Data.List.all p . toList
+    any p = Data.List.any p . toList
+
+instance Collection S.String where
+    null = S.null
+    length = S.length
+    elem = S.elem
+    minimum = Data.List.minimum . toList . getNonEmpty -- TODO faster implementation
+    maximum = Data.List.maximum . toList . getNonEmpty -- TODO faster implementation
     all p = Data.List.all p . toList
     any p = Data.List.any p . toList
 

--- a/Foundation/Collection/Collection.hs
+++ b/Foundation/Collection/Collection.hs
@@ -31,6 +31,7 @@ import           Foundation.Internal.Base
 import           Foundation.Collection.Element
 import qualified Data.List
 import qualified Foundation.Array.Unboxed as UV
+import qualified Foundation.Array.Boxed as BA
 
 -- | NonEmpty property for any Collection
 --
@@ -109,6 +110,15 @@ instance UV.PrimType ty => Collection (UV.UArray ty) where
     elem = UV.elem
     minimum = Data.List.minimum . toList . getNonEmpty
     maximum = Data.List.maximum . toList . getNonEmpty
+    all p = Data.List.all p . toList
+    any p = Data.List.any p . toList
+
+instance Collection (BA.Array ty) where
+    null = BA.null
+    length = BA.length
+    elem e = Data.List.elem e . toList
+    minimum = Data.List.minimum . toList . getNonEmpty -- TODO
+    maximum = Data.List.maximum . toList . getNonEmpty -- TODO
     all p = Data.List.all p . toList
     any p = Data.List.any p . toList
 

--- a/Foundation/Collection/Copy.hs
+++ b/Foundation/Collection/Copy.hs
@@ -1,0 +1,12 @@
+module Foundation.Collection.Copy
+    ( Copy(..)
+    ) where
+
+import qualified Foundation.Array.Unboxed as UA
+
+class Copy a where
+    copy :: a -> a
+instance Copy [ty] where
+    copy a = a
+instance UA.PrimType ty => Copy (UA.UArray ty) where
+    copy = UA.copy

--- a/Foundation/Collection/Copy.hs
+++ b/Foundation/Collection/Copy.hs
@@ -3,6 +3,7 @@ module Foundation.Collection.Copy
     ) where
 
 import qualified Foundation.Array.Unboxed as UA
+import qualified Foundation.Array.Boxed as BA
 
 class Copy a where
     copy :: a -> a
@@ -10,3 +11,5 @@ instance Copy [ty] where
     copy a = a
 instance UA.PrimType ty => Copy (UA.UArray ty) where
     copy = UA.copy
+instance Copy (BA.Array ty) where
+    copy = BA.copy

--- a/Foundation/Collection/Copy.hs
+++ b/Foundation/Collection/Copy.hs
@@ -4,6 +4,7 @@ module Foundation.Collection.Copy
 
 import qualified Foundation.Array.Unboxed as UA
 import qualified Foundation.Array.Boxed as BA
+import qualified Foundation.String.UTF8 as S
 
 class Copy a where
     copy :: a -> a
@@ -13,3 +14,5 @@ instance UA.PrimType ty => Copy (UA.UArray ty) where
     copy = UA.copy
 instance Copy (BA.Array ty) where
     copy = BA.copy
+instance Copy S.String where
+    copy = S.copy

--- a/Foundation/Collection/Element.hs
+++ b/Foundation/Collection/Element.hs
@@ -9,11 +9,14 @@ module Foundation.Collection.Element
     ( Element
     ) where
 
+import Foundation.Internal.Base
 import Foundation.Array.Unboxed (UArray)
 import Foundation.Array.Boxed (Array)
+import Foundation.String.UTF8 (String)
 
 -- | Element type of a collection
 type family Element container
 type instance Element [a] = a
 type instance Element (UArray ty) = ty
 type instance Element (Array ty) = ty
+type instance Element String = Char

--- a/Foundation/Collection/Element.hs
+++ b/Foundation/Collection/Element.hs
@@ -10,8 +10,10 @@ module Foundation.Collection.Element
     ) where
 
 import Foundation.Array.Unboxed (UArray)
+import Foundation.Array.Boxed (Array)
 
 -- | Element type of a collection
 type family Element container
 type instance Element [a] = a
 type instance Element (UArray ty) = ty
+type instance Element (Array ty) = ty

--- a/Foundation/Collection/Foldable.hs
+++ b/Foundation/Collection/Foldable.hs
@@ -15,6 +15,7 @@ import           Foundation.Internal.Base
 import           Foundation.Collection.Element
 import qualified Data.List
 import qualified Foundation.Array.Unboxed as UV
+import qualified Foundation.Array.Boxed as BA
 
 -- | Give the ability to fold a collection on itself
 class Foldable collection where
@@ -54,3 +55,7 @@ instance UV.PrimType ty => Foldable (UV.UArray ty) where
     foldl = UV.foldl
     foldr = UV.foldr
     foldl' = UV.foldl'
+instance Foldable (BA.Array ty) where
+    foldl = BA.foldl
+    foldr = BA.foldr
+    foldl' = BA.foldl'

--- a/Foundation/Collection/Indexed.hs
+++ b/Foundation/Collection/Indexed.hs
@@ -16,6 +16,7 @@ import           Foundation.Collection.Element
 import qualified Data.List
 import qualified Foundation.Array.Unboxed as UV
 import qualified Foundation.Array.Boxed as BA
+import qualified Foundation.String.UTF8 as S
 
 -- | Collection of elements that can indexed by int
 class IndexedCollection c where
@@ -53,3 +54,7 @@ instance IndexedCollection (BA.Array ty) where
             | i == len  = Nothing
             | otherwise =
                 if predicate (BA.unsafeIndex c i) then Just i else Nothing
+
+instance IndexedCollection S.String where
+    (!) = S.index
+    findIndex = S.findIndex

--- a/Foundation/Collection/Indexed.hs
+++ b/Foundation/Collection/Indexed.hs
@@ -15,6 +15,7 @@ import           Foundation.Internal.Base
 import           Foundation.Collection.Element
 import qualified Data.List
 import qualified Foundation.Array.Unboxed as UV
+import qualified Foundation.Array.Boxed as BA
 
 -- | Collection of elements that can indexed by int
 class IndexedCollection c where
@@ -40,3 +41,15 @@ instance UV.PrimType ty => IndexedCollection (UV.UArray ty) where
             | i == len                       = Nothing
             | predicate (UV.unsafeIndex c i) = Just i
             | otherwise                      = Nothing
+
+instance IndexedCollection (BA.Array ty) where
+    (!) l n
+        | n < 0 || n >= BA.length l = Nothing
+        | otherwise                 = Just $ BA.index l n
+    findIndex predicate c = loop 0
+      where
+        !len = BA.length c
+        loop i
+            | i == len  = Nothing
+            | otherwise =
+                if predicate (BA.unsafeIndex c i) then Just i else Nothing

--- a/Foundation/Collection/InnerFunctor.hs
+++ b/Foundation/Collection/InnerFunctor.hs
@@ -6,6 +6,7 @@ module Foundation.Collection.InnerFunctor
 import Foundation.Internal.Base
 import Foundation.Collection.Element
 import qualified Foundation.Array.Unboxed as UV
+import           Foundation.Array.Boxed (Array)
 
 -- | A monomorphic functor that maps the inner values to values of the same type
 class InnerFunctor c where
@@ -17,3 +18,5 @@ instance InnerFunctor [a]
 
 instance UV.PrimType ty => InnerFunctor (UV.UArray ty) where
     imap = UV.map
+
+instance InnerFunctor (Array ty)

--- a/Foundation/Collection/InnerFunctor.hs
+++ b/Foundation/Collection/InnerFunctor.hs
@@ -5,6 +5,7 @@ module Foundation.Collection.InnerFunctor
 
 import Foundation.Internal.Base
 import Foundation.Collection.Element
+import qualified Foundation.String.UTF8 as S
 import qualified Foundation.Array.Unboxed as UV
 import           Foundation.Array.Boxed (Array)
 
@@ -20,3 +21,6 @@ instance UV.PrimType ty => InnerFunctor (UV.UArray ty) where
     imap = UV.map
 
 instance InnerFunctor (Array ty)
+
+instance InnerFunctor S.String where
+    imap = S.charMap

--- a/Foundation/Collection/List.hs
+++ b/Foundation/Collection/List.hs
@@ -1,5 +1,5 @@
 -- |
--- Module      : Foundation.Array.List
+-- Module      : Foundation.Collection.List
 -- License     : BSD-style
 -- Maintainer  : Vincent Hanquez <vincent@snarc.org>
 -- Stability   : experimental

--- a/Foundation/Collection/Mutable.hs
+++ b/Foundation/Collection/Mutable.hs
@@ -15,6 +15,7 @@ import Foundation.Internal.Types
 
 import qualified Foundation.Array.Unboxed.Mutable as MUV
 import qualified Foundation.Array.Unboxed as UV
+import qualified Foundation.Array.Boxed as BA
 
 -- | Collection of things that can be made mutable, modified and then freezed into an MutableFreezed collection
 class MutableCollection c where
@@ -55,3 +56,19 @@ instance UV.PrimType ty => MutableCollection (MUV.MUArray ty) where
     mutUnsafeRead = MUV.unsafeRead
     mutWrite = MUV.write
     mutRead = MUV.read
+
+instance MutableCollection (BA.MArray ty) where
+    type MutableFreezed (BA.MArray ty) = BA.Array ty
+    type MutableKey (BA.MArray ty) = Int
+    type MutableValue (BA.MArray ty) = ty
+
+    thaw = BA.thaw
+    freeze = BA.freeze
+    unsafeThaw = BA.unsafeThaw
+    unsafeFreeze = BA.unsafeFreeze
+
+    mutNew n = BA.new (Size n)
+    mutUnsafeWrite = BA.unsafeWrite
+    mutUnsafeRead = BA.unsafeRead
+    mutWrite = BA.write
+    mutRead = BA.read

--- a/Foundation/Collection/Sequential.hs
+++ b/Foundation/Collection/Sequential.hs
@@ -22,6 +22,7 @@ import           Foundation.Collection.Collection
 import qualified Foundation.Collection.List as ListExtra
 import qualified Data.List
 import qualified Foundation.Array.Unboxed as UV
+import qualified Foundation.Array.Boxed as BA
 
 -- | A set of methods for ordered colection
 class (IsList c, Item c ~ Element c, Monoid c, Collection c) => Sequential c where
@@ -206,4 +207,25 @@ instance UV.PrimType ty => Sequential (UV.UArray ty) where
     cons = UV.cons
     find = UV.find
     sortBy = UV.sortBy
+    singleton = fromList . (:[])
+
+instance Sequential (BA.Array ty) where
+    take = BA.take
+    drop = BA.drop
+    splitAt = BA.splitAt
+    revTake = BA.revTake
+    revDrop = BA.revDrop
+    revSplitAt = BA.revSplitAt
+    splitOn = BA.splitOn
+    break = BA.break
+    intersperse = BA.intersperse
+    span = BA.span
+    reverse = BA.reverse
+    filter = BA.filter
+    unsnoc = BA.unsnoc
+    uncons = BA.uncons
+    snoc = BA.snoc
+    cons = BA.cons
+    find = BA.find
+    sortBy = BA.sortBy
     singleton = fromList . (:[])

--- a/Foundation/Collection/Sequential.hs
+++ b/Foundation/Collection/Sequential.hs
@@ -23,6 +23,7 @@ import qualified Foundation.Collection.List as ListExtra
 import qualified Data.List
 import qualified Foundation.Array.Unboxed as UV
 import qualified Foundation.Array.Boxed as BA
+import qualified Foundation.String.UTF8 as S
 
 -- | A set of methods for ordered colection
 class (IsList c, Item c ~ Element c, Monoid c, Collection c) => Sequential c where
@@ -229,3 +230,25 @@ instance Sequential (BA.Array ty) where
     find = BA.find
     sortBy = BA.sortBy
     singleton = fromList . (:[])
+
+instance Sequential S.String where
+    take = S.take
+    drop = S.drop
+    splitAt = S.splitAt
+    revTake = S.revTake
+    revDrop = S.revDrop
+    revSplitAt = S.revSplitAt
+    splitOn = S.splitOn
+    break = S.break
+    breakElem = S.breakElem
+    intersperse = S.intersperse
+    span = S.span
+    filter = S.filter
+    reverse = S.reverse
+    unsnoc = S.unsnoc
+    uncons = S.uncons
+    snoc = S.snoc
+    cons = S.cons
+    find = S.find
+    sortBy = S.sortBy
+    singleton = S.singleton

--- a/Foundation/Collection/Zippable.hs
+++ b/Foundation/Collection/Zippable.hs
@@ -18,6 +18,7 @@ module Foundation.Collection.Zippable
 
 import qualified Foundation.Array.Unboxed as UV
 import qualified Foundation.Array.Boxed as BA
+import qualified Foundation.String.UTF8 as S
 import           Foundation.Collection.Element
 import           Foundation.Collection.Sequential
 import           Foundation.Internal.Base
@@ -89,6 +90,12 @@ instance Zippable (BA.Array ty) where
       go _  _        []       = return ()
       go f' (a':as') (b':bs') = BA.builderAppend (f' a' b') >> go f' as' bs'
 
+instance Zippable S.String where
+  zipWith f as bs = runST $ S.builderBuild 64 $ go f (toList as) (toList bs)
+    where
+      go _  []       _        = return ()
+      go _  _        []       = return ()
+      go f' (a':as') (b':bs') = S.builderAppend (f' a' b') >> go f' as' bs'
 
 class Zippable col => BoxedZippable col where
 

--- a/Foundation/Hashing/FNV.hs
+++ b/Foundation/Hashing/FNV.hs
@@ -50,12 +50,16 @@ xor64 :: Word64 -> Word8 -> Word64
 xor64 !a !b = a `xor` Prelude.fromIntegral b
 {-# INLINE xor64 #-}
 
+-- | FNV1 32 bit state
 newtype FNV1_32 = FNV1_32 Word
 
+-- | FNV1 64 bit state
 newtype FNV1_64 = FNV1_64 Word64
 
+-- | FNV1a 32 bit state
 newtype FNV1a_32 = FNV1a_32 Word
 
+-- | FNV1a 64 bit state
 newtype FNV1a_64 = FNV1a_64 Word64
 
 fnv1_32_Mix8 :: Word8 -> FNV1_32 -> FNV1_32

--- a/Foundation/Math/Trigonometry.hs
+++ b/Foundation/Math/Trigonometry.hs
@@ -7,19 +7,33 @@ import           Foundation.Internal.Base
 import           Foundation.Numerical
 import qualified Prelude
 
+-- | Method to support basic trigonometric functions
 class Trigonometry a where
+    -- | the famous pi value
     pi    :: a
+    -- | sine
     sin   :: a -> a
+    -- | cosine
     cos   :: a -> a
+    -- | tan
     tan   :: a -> a
+    -- | sine-1
     asin  :: a -> a
+    -- | cosine-1
     acos  :: a -> a
+    -- | tangent-1
     atan  :: a -> a
+    -- | hyperbolic sine
     sinh  :: a -> a
+    -- | hyperbolic cosine
     cosh  :: a -> a
+    -- | hyperbolic tangent
     tanh  :: a -> a
+    -- | hyperbolic sine-1
     asinh :: a -> a
+    -- | hyperbolic cosine-1
     acosh :: a -> a
+    -- | hyperbolic tangent-1
     atanh :: a -> a
 
 instance Trigonometry FP32 where

--- a/Foundation/Monad/Identity.hs
+++ b/Foundation/Monad/Identity.hs
@@ -1,3 +1,8 @@
+-- |
+-- The identity monad transformer.
+--
+-- This is useful for functions parameterized by a monad transformer.
+--
 module Foundation.Monad.Identity
     ( IdentityT
     , runIdentityT
@@ -8,6 +13,7 @@ import Foundation.Monad.MonadIO
 import Foundation.Monad.Exception
 import Foundation.Monad.Transformer
 
+-- | Identity Transformer
 newtype IdentityT m a = IdentityT { runIdentityT :: m a }
 
 instance Functor m => Functor (IdentityT m) where

--- a/Foundation/Monad/Reader.hs
+++ b/Foundation/Monad/Reader.hs
@@ -1,3 +1,8 @@
+-- |
+-- The Reader monad transformer.
+--
+-- This is useful to keep a non-modifiable value
+-- in a context
 module Foundation.Monad.Reader
     ( ReaderT
     , runReaderT

--- a/Foundation/Numerical/Multiplicative.hs
+++ b/Foundation/Numerical/Multiplicative.hs
@@ -47,6 +47,9 @@ class (Additive a, Multiplicative a) => IDivisible a where
     divMod :: a -> a -> (a, a)
     divMod a b = (div a b, mod a b)
 
+-- | Support for division between same types
+--
+-- This is likely to change to represent specific mathematic divisions
 class Multiplicative a => Divisible a where
     {-# MINIMAL (/) #-}
     (/) :: a -> a -> a

--- a/Foundation/Numerical/Number.hs
+++ b/Foundation/Numerical/Number.hs
@@ -15,6 +15,7 @@ class (Enum a, Eq a, Ord a, Integral a) => IsIntegral a where
     {-# MINIMAL toInteger #-}
     toInteger :: a -> Integer
 
+-- | Non Negative Number literals, convertible through the generic Natural type
 class (Enum a, Eq a, Ord a, Integral a, IsIntegral a) => IsNatural a where
     {-# MINIMAL toNatural #-}
     toNatural :: a -> Natural

--- a/Foundation/Numerical/Primitives.hs
+++ b/Foundation/Numerical/Primitives.hs
@@ -12,12 +12,14 @@ import GHC.Word
 import GHC.Int
 import qualified Prelude
 
+-- | Convert an 'Int' into a 'Word'
 intToWord :: Int -> Word
 intToWord (I# i) = W# (int2Word# i)
 {-# INLINE intToWord #-}
 
+-- | Various conversion between integral number
 class IntegralConvert a b where
-    -- lossless integral convertion
+    -- | lossless integral convertion
     integralConvert :: a -> b
 
 instance IntegralConvert Int8 Word8 where

--- a/Foundation/String/Encoding/ASCII7.hs
+++ b/Foundation/String/Encoding/ASCII7.hs
@@ -23,7 +23,7 @@ import GHC.Word
 import GHC.Types
 import Foundation.Array.Unboxed
 import Foundation.Array.Unboxed.Mutable (MUArray)
-import Foundation.Collection.Buildable
+import Foundation.Boot.Builder
 
 import Foundation.String.Encoding.Encoding
 
@@ -81,7 +81,7 @@ write :: (PrimMonad st, Monad st)
            -- otherwise this function will throw an exception
       -> Builder (UArray Word8) (MUArray Word8) Word8 st ()
 write c
-    | c < toEnum 0x80 = append $ w8 c
+    | c < toEnum 0x80 = builderAppend $ w8 c
     | otherwise       = throw $ CharNotAscii c
   where
     w8 :: Char -> Word8

--- a/Foundation/String/Encoding/ASCII7.hs
+++ b/Foundation/String/Encoding/ASCII7.hs
@@ -22,6 +22,7 @@ import GHC.Prim
 import GHC.Word
 import GHC.Types
 import Foundation.Array.Unboxed
+import Foundation.Array.Unboxed.Mutable (MUArray)
 import Foundation.Collection.Buildable
 
 import Foundation.String.Encoding.Encoding
@@ -78,7 +79,7 @@ write :: (PrimMonad st, Monad st)
       => Char
            -- ^ expecting it to be a valid Ascii character.
            -- otherwise this function will throw an exception
-      -> Builder (UArray Word8) st ()
+      -> Builder (UArray Word8) (MUArray Word8) Word8 st ()
 write c
     | c < toEnum 0x80 = append $ w8 c
     | otherwise       = throw $ CharNotAscii c

--- a/Foundation/String/Encoding/Encoding.hs
+++ b/Foundation/String/Encoding/Encoding.hs
@@ -21,6 +21,7 @@ import Foundation.Numerical
 import qualified Foundation.Collection as C
 import           Foundation.Collection.Buildable
 import           Foundation.Array.Unboxed (UArray)
+import           Foundation.Array.Unboxed.Mutable (MUArray)
 import qualified Foundation.Array.Unboxed as Vec
 
 class Encoding encoding where
@@ -47,8 +48,7 @@ class Encoding encoding where
                 -> Offset (Unit encoding)
                       -- ^ offset of the `Unit encoding` where starts the
                       -- encoding of a given unicode
-                -> Either (Error encoding) (Char, Offset (Unit encoding))
-                      -- ^ either successfully validated the `Unit encoding`
+                -> Either (Error encoding) (Char, Offset (Unit encoding)) -- ^ either successfully validated the `Unit encoding`
                       -- and returned the next offset or fail with an
                       -- `Error encoding`
 
@@ -61,7 +61,9 @@ class Encoding encoding where
                       -- ^ only used for type deduction
                   -> Char
                       -- ^ the unicode character to encode
-                  -> Builder (UArray (Unit encoding)) st ()
+                  -> Builder (UArray (Unit encoding))
+                             (MUArray (Unit encoding))
+                             (Unit encoding) st ()
 
 -- | helper to convert a given Array in a given encoding into an array
 -- with another encoding.

--- a/Foundation/String/Encoding/Encoding.hs
+++ b/Foundation/String/Encoding/Encoding.hs
@@ -13,13 +13,12 @@ module Foundation.String.Encoding.Encoding
     , convertFromTo
     ) where
 
-import Foundation.Internal.Base
-import Foundation.Internal.Types
-import Foundation.Primitive.Monad
-import Foundation.Primitive.Types
-import Foundation.Numerical
-import qualified Foundation.Collection as C
-import           Foundation.Collection.Buildable
+import           Foundation.Internal.Base
+import           Foundation.Internal.Types
+import           Foundation.Primitive.Monad
+import           Foundation.Primitive.Types
+import           Foundation.Boot.Builder
+import           Foundation.Numerical
 import           Foundation.Array.Unboxed (UArray)
 import           Foundation.Array.Unboxed.Mutable (MUArray)
 import qualified Foundation.Array.Unboxed as Vec
@@ -92,10 +91,10 @@ convertFromTo :: ( PrimMonad st, Monad st
                 -- ^ the input raw array
               -> st (UArray (Unit output))
 convertFromTo inputEncodingTy outputEncodingTy bytes
-    | C.null bytes = return mempty
-    | otherwise    = Vec.unsafeIndexer bytes $ \t -> build 64 (loop azero t)
+    | Vec.null bytes = return mempty
+    | otherwise      = Vec.unsafeIndexer bytes $ \t -> Vec.builderBuild 64 (loop azero t)
   where
-    lastUnit = Offset $ C.length bytes
+    lastUnit = Offset $ Vec.length bytes
 
     loop off getter
       | off >= lastUnit = return ()

--- a/Foundation/String/Encoding/ISO_8859_1.hs
+++ b/Foundation/String/Encoding/ISO_8859_1.hs
@@ -22,6 +22,7 @@ import GHC.Prim
 import GHC.Word
 import GHC.Types
 import Foundation.Array.Unboxed
+import Foundation.Array.Unboxed.Mutable (MUArray)
 import Foundation.Collection.Buildable
 
 import Foundation.String.Encoding.Encoding
@@ -54,7 +55,7 @@ next getter off = Right (toChar w, off + aone)
 
 write :: (PrimMonad st, Monad st)
       => Char
-      -> Builder (UArray Word8) st ()
+      -> Builder (UArray Word8) (MUArray Word8) Word8 st ()
 write c@(C# ch)
     | c <= toEnum 0xFF = append (W8# x)
     | otherwise        = throw $ NotISO_8859_1 c

--- a/Foundation/String/Encoding/ISO_8859_1.hs
+++ b/Foundation/String/Encoding/ISO_8859_1.hs
@@ -23,7 +23,7 @@ import GHC.Word
 import GHC.Types
 import Foundation.Array.Unboxed
 import Foundation.Array.Unboxed.Mutable (MUArray)
-import Foundation.Collection.Buildable
+import Foundation.Boot.Builder
 
 import Foundation.String.Encoding.Encoding
 
@@ -57,7 +57,7 @@ write :: (PrimMonad st, Monad st)
       => Char
       -> Builder (UArray Word8) (MUArray Word8) Word8 st ()
 write c@(C# ch)
-    | c <= toEnum 0xFF = append (W8# x)
+    | c <= toEnum 0xFF = builderAppend (W8# x)
     | otherwise        = throw $ NotISO_8859_1 c
   where
     x :: Word#

--- a/Foundation/String/Encoding/UTF16.hs
+++ b/Foundation/String/Encoding/UTF16.hs
@@ -22,7 +22,7 @@ import Data.Bits
 import qualified Prelude
 import Foundation.Array.Unboxed
 import Foundation.Array.Unboxed.Mutable (MUArray)
-import Foundation.Collection.Buildable
+import Foundation.Boot.Builder
 
 import Foundation.String.Encoding.Encoding
 
@@ -79,10 +79,10 @@ write :: (PrimMonad st, Monad st)
       => Char
       -> Builder (UArray Word16) (MUArray Word16) Word16 st ()
 write c
-    | c < toEnum 0xd800   = append $ w16 c
-    | c > toEnum 0x10000  = let (w1, w2) = wHigh c in append w1 >> append w2
+    | c < toEnum 0xd800   = builderAppend $ w16 c
+    | c > toEnum 0x10000  = let (w1, w2) = wHigh c in builderAppend w1 >> builderAppend w2
     | c > toEnum 0x10ffff = throw $ InvalidUnicode c
-    | c >= toEnum 0xe000  = append $ w16 c
+    | c >= toEnum 0xe000  = builderAppend $ w16 c
     | otherwise = throw $ InvalidUnicode c
   where
     w16 :: Char -> Word16

--- a/Foundation/String/Encoding/UTF16.hs
+++ b/Foundation/String/Encoding/UTF16.hs
@@ -21,6 +21,7 @@ import Foundation.Numerical
 import Data.Bits
 import qualified Prelude
 import Foundation.Array.Unboxed
+import Foundation.Array.Unboxed.Mutable (MUArray)
 import Foundation.Collection.Buildable
 
 import Foundation.String.Encoding.Encoding
@@ -76,7 +77,7 @@ next getter off
 
 write :: (PrimMonad st, Monad st)
       => Char
-      -> Builder (UArray Word16) st ()
+      -> Builder (UArray Word16) (MUArray Word16) Word16 st ()
 write c
     | c < toEnum 0xd800   = append $ w16 c
     | c > toEnum 0x10000  = let (w1, w2) = wHigh c in append w1 >> append w2

--- a/Foundation/String/Encoding/UTF32.hs
+++ b/Foundation/String/Encoding/UTF32.hs
@@ -19,6 +19,7 @@ import GHC.Word
 import GHC.Types
 import Foundation.Numerical
 import Foundation.Array.Unboxed
+import Foundation.Array.Unboxed.Mutable (MUArray)
 import Foundation.Collection.Buildable
 
 import Foundation.String.Encoding.Encoding
@@ -46,7 +47,7 @@ next getter off = Right (char, off + Offset 1)
 
 write :: (PrimMonad st, Monad st)
       => Char
-      -> Builder (UArray Word32) st ()
+      -> Builder (UArray Word32) (MUArray Word32) Word32 st ()
 write c = append w32
   where
     !(C# ch) = c

--- a/Foundation/String/Encoding/UTF32.hs
+++ b/Foundation/String/Encoding/UTF32.hs
@@ -20,7 +20,7 @@ import GHC.Types
 import Foundation.Numerical
 import Foundation.Array.Unboxed
 import Foundation.Array.Unboxed.Mutable (MUArray)
-import Foundation.Collection.Buildable
+import Foundation.Boot.Builder
 
 import Foundation.String.Encoding.Encoding
 
@@ -48,7 +48,7 @@ next getter off = Right (char, off + Offset 1)
 write :: (PrimMonad st, Monad st)
       => Char
       -> Builder (UArray Word32) (MUArray Word32) Word32 st ()
-write c = append w32
+write c = builderAppend w32
   where
     !(C# ch) = c
     w32 :: Word32

--- a/Foundation/String/ModifiedUTF8.hs
+++ b/Foundation/String/ModifiedUTF8.hs
@@ -28,7 +28,6 @@ import           Foundation.Internal.Base
 import           Foundation.Internal.Types
 import qualified Foundation.Array.Unboxed as Vec
 import           Foundation.Array.Unboxed (UArray)
-import           Foundation.Collection.Buildable
 import           Foundation.Numerical
 import           Foundation.Primitive.FinalPtr
 import           Foundation.String.UTF8Table
@@ -62,13 +61,13 @@ fromModified addr = runST $ do
     ba <- buildByteArray addr
     Vec.unsafeIndexer ba buildWithBytes
   where
-    buildWithBytes getAt = build 64 $ loopBuilder getAt (Offset 0)
+    buildWithBytes getAt = Vec.builderBuild 64 $ loopBuilder getAt (Offset 0)
     loopBuilder getAt offset =
         case bs of
             [] -> internalError "ModifiedUTF8.fromModified"
             [0x00] -> return ()
-            [b1,b2] | b1 == 0xC0 && b2 == 0x80 -> append 0x00 >> loopBuilder getAt noffset
-            _ -> mapM_ append bs >> loopBuilder getAt noffset
+            [b1,b2] | b1 == 0xC0 && b2 == 0x80 -> Vec.builderAppend 0x00 >> loopBuilder getAt noffset
+            _ -> mapM_ Vec.builderAppend bs >> loopBuilder getAt noffset
       where
         (bs, noffset) = accessBytes offset getAt
 

--- a/Foundation/String/UTF8.hs
+++ b/Foundation/String/UTF8.hs
@@ -148,6 +148,9 @@ instance C.Zippable String where
       go _  _        []       = return ()
       go f' (a':as') (b':bs') = append (f' a' b') >> go f' as' bs'
 
+instance C.Copy String where
+    copy = copy
+
 instance Buildable String where
   type Mutable String = MutableString
   type Step String = Word8

--- a/Foundation/String/UTF8.hs
+++ b/Foundation/String/UTF8.hs
@@ -493,6 +493,9 @@ unsafeFreezeShrink (MutableString mba) s = String <$> Vec.unsafeFreezeShrink mba
 ------------------------------------------------------------------------
 -- real functions
 
+-- | Convert a String to a list of characters
+--
+-- The list is lazily created as evaluation needed
 sToList :: String -> [Char]
 sToList s = loop azero
   where
@@ -512,6 +515,11 @@ sToList s = loop azero
   sFromList (unpackCStringUtf8# s) = String $ fromModified s
   #-}
 
+-- | Create a new String from a list of characters
+--
+-- The list is strictly and fully evaluated before
+-- creating the new String, as the size need to be
+-- computed before filling.
 sFromList :: [Char] -> String
 sFromList l = runST (new bytes >>= startCopy)
   where

--- a/foundation.cabal
+++ b/foundation.cabal
@@ -80,6 +80,7 @@ Library
                      Foundation.Random
                      Foundation.System.Entropy
   Other-modules:     Foundation.Boot.Builder
+                     Foundation.Boot.List
                      Foundation.String.Internal
                      Foundation.String.UTF8
                      Foundation.String.Encoding.Encoding

--- a/foundation.cabal
+++ b/foundation.cabal
@@ -98,6 +98,7 @@ Library
                      Foundation.Collection.Element
                      Foundation.Collection.InnerFunctor
                      Foundation.Collection.Collection
+                     Foundation.Collection.Copy
                      Foundation.Collection.Sequential
                      Foundation.Collection.Keyed
                      Foundation.Collection.Indexed

--- a/foundation.cabal
+++ b/foundation.cabal
@@ -79,7 +79,8 @@ Library
                      Foundation.Parser
                      Foundation.Random
                      Foundation.System.Entropy
-  Other-modules:     Foundation.String.Internal
+  Other-modules:     Foundation.Boot.Builder
+                     Foundation.String.Internal
                      Foundation.String.UTF8
                      Foundation.String.Encoding.Encoding
                      Foundation.String.Encoding.UTF16


### PR DESCRIPTION
* Expose Copy (fix #166)
* Make collection depends on the basic types (string, uarray, array) instead of the other way around
* Add random documentation all over the places

Potentially allow simple primitive types which foundation build upon to be split in their own thing, but also make a significant improvement in term of organisation.