### PR TITLE
Add Network's type: IPv4

### DIFF
--- a/Foundation/Bits.hs
+++ b/Foundation/Bits.hs
@@ -5,11 +5,16 @@ module Foundation.Bits
     , Bits(..)
     , alignRoundUp
     , alignRoundDown
+    , htonl, htons
+    , ntohl, ntohs
     ) where
 
 import Foundation.Internal.Base
+import Foundation.Internal.ByteSwap
 import Foundation.Numerical
+import Foundation.System.Info (Endianness(..), endianness)
 import Data.Bits
+import Data.Word (Word16, Word32)
 
 -- | Unsafe Shift Left Operator
 (.<<.) :: Bits a => a -> Int -> a
@@ -40,3 +45,27 @@ alignRoundDown :: Int -- ^ Number to Align
                -> Int -- ^ Alignment (power of 2)
                -> Int
 alignRoundDown m alignment = m .&. complement (alignment-1)
+
+-- | perform conversion from Host to Network endianness
+htons :: Word16 -> Word16
+htons w = case endianness of
+    LittleEndian -> byteSwap16 w
+    BigEndian    -> w
+
+-- | perform conversion from Network to Host endianness
+ntohs :: Word16 -> Word16
+ntohs w = case endianness of
+    LittleEndian -> byteSwap16 w
+    BigEndian    -> w
+
+-- | perform conversion from Host to Network endianness
+htonl :: Word32 -> Word32
+htonl w = case endianness of
+    LittleEndian -> byteSwap32 w
+    BigEndian    -> w
+
+-- | perform conversion from Network to Host endianness
+ntohl :: Word32 -> Word32
+ntohl w = case endianness of
+    LittleEndian -> byteSwap32 w
+    BigEndian    -> w

--- a/Foundation/Bits.hs
+++ b/Foundation/Bits.hs
@@ -2,6 +2,7 @@
 module Foundation.Bits
     ( (.<<.)
     , (.>>.)
+    , Bits(..)
     , alignRoundUp
     , alignRoundDown
     ) where

--- a/Foundation/Internal/ByteSwap.hs
+++ b/Foundation/Internal/ByteSwap.hs
@@ -1,0 +1,66 @@
+-- |
+-- Module      : Foundation.Internal.ByteSwap
+-- License     : BSD-style
+-- Maintainer  : Foundation
+-- Stability   : experimental
+-- Portability : portable
+--
+
+{-# LANGUAGE CPP #-}
+
+module Foundation.Internal.ByteSwap
+    ( byteSwap16
+    , byteSwap32
+    , byteSwap64
+    ) where
+
+#if MIN_VERSION_base(4,7,0)
+
+import Data.Word (byteSwap16, byteSwap32, byteSwap64)
+
+#else
+
+import Foundation.Internal.Base (fromInteger)
+
+import Data.Bits ((.|.), (.&.), unsafeShiftL, unsafeShiftR)
+
+import Data.Word (Word16, Word32, Word64)
+
+-- | compatibility implementation (i.e. may be slow)
+--
+-- Swap the bytes position (inverting order) as would be done in GHC >= 7.8
+byteSwap16 :: Word16 -> Word16
+byteSwap16 w = w1 .|. w2
+  where
+    w1,w2 :: Word16
+    w1 = (w `unsafeShiftL` 8) .&. 0xFF00
+    w2 = (w `unsafeShiftR` 8) .&. 0x00FF
+
+-- | compatibility implementation (i.e. may be slow)
+--
+-- Swap the bytes position (inverting order) as would be done in GHC >= 7.8
+byteSwap32 :: Word32 -> Word32
+byteSwap32 w = w1 .|. w2 .|. w3 .|. w4
+  where
+    w1,w2,w3,w4 :: Word32
+    w1 = (w `unsafeShiftL` 24) .&. 0xFF000000
+    w2 = (w `unsafeShiftR` 24) .&. 0x000000FF
+    w3 = (w `unsafeShiftL` 8)  .&. 0x00FF0000
+    w4 = (w `unsafeShiftR` 8)  .&. 0x0000FF00
+
+-- | compatibility implementation (i.e. may be slow)
+--
+-- Swap the bytes position (inverting order) as would be done in GHC >= 7.8
+byteSwap64 :: Word64 -> Word64
+byteSwap64 w = w1 .|. w2 .|. w3 .|. w4 .|. w5 .|. w6 .|. w7 .|. w8
+  where
+    w1,w2,w3,w4,w5,w6,w7,w8 :: Word64
+    w1 = (w `unsafeShiftL` 56) .&. 0xFF00000000000000
+    w2 = (w `unsafeShiftR` 56) .&. 0x00000000000000FF
+    w3 = (w `unsafeShiftL` 40) .&. 0x00FF000000000000
+    w4 = (w `unsafeShiftR` 40) .&. 0x000000000000FF00
+    w5 = (w `unsafeShiftL` 24) .&. 0x0000FF0000000000
+    w6 = (w `unsafeShiftR` 24) .&. 0x0000000000FF0000
+    w7 = (w `unsafeShiftL`  8) .&. 0x000000FF00000000
+    w8 = (w `unsafeShiftR`  8) .&. 0x00000000FF000000
+#endif

--- a/Foundation/Network/IPv4.hs
+++ b/Foundation/Network/IPv4.hs
@@ -1,0 +1,76 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Foundation.Network.IPv4
+    ( IPv4
+    , fromString, toString
+    , fromTuple, toTuple
+    ) where
+
+import Prelude (fromIntegral)
+
+import System.IO.Unsafe (unsafePerformIO)
+import Foreign.C.String (withCString, CString)
+
+import Foundation.Class.Storable
+import Foundation.Hashing.Hashable
+import Foundation.Internal.Base
+import Foundation.Internal.Proxy
+import Foundation.String (String)
+import Foundation.Bits
+
+-- | IPv4 data type
+newtype IPv4 = IPv4 Word32
+  deriving (Eq, Ord, Typeable, Hashable)
+instance Show IPv4 where
+    show = toLString
+instance IsString IPv4 where
+    fromString = fromLString
+instance Storable IPv4 where
+    peek ptr = IPv4 . ntohl <$> peek (castPtr ptr)
+    poke ptr (IPv4 w) = poke (castPtr ptr) (htonl w)
+instance StorableFixed IPv4 where
+    size      _ = size      (Proxy :: Proxy Word32)
+    alignment _ = alignment (Proxy :: Proxy Word32)
+
+toString :: IPv4 -> String
+toString = fromList . toLString
+
+fromLString :: [Char] -> IPv4
+fromLString str = unsafePerformIO $ withCString str $ \cstr ->
+    IPv4 . ntohl <$> c_inet_addr cstr
+
+toLString :: IPv4 -> [Char]
+toLString ipv4 =
+    let (i1, i2, i3, i4) = toTuple ipv4
+     in show i1 <> "." <> show i2 <> "." <> show i3 <> "." <> show i4
+
+fromTuple :: (Word8, Word8, Word8, Word8) -> IPv4
+fromTuple (i1, i2, i3, i4) =
+     IPv4 $     (w1 .<<. 24) .&. 0xFF000000
+            .|. (w2 .<<. 16) .&. 0x00FF0000
+            .|. (w3 .<<.  8) .&. 0x0000FF00
+            .|.  w4          .&. 0x000000FF
+  where
+    f = fromIntegral
+    w1, w2, w3, w4 :: Word32
+    w1 = f i1
+    w2 = f i2
+    w3 = f i3
+    w4 = f i4
+
+toTuple :: IPv4 -> (Word8, Word8, Word8, Word8)
+toTuple (IPv4 w) =
+    (f w1, f w2, f w3, f w4)
+  where
+    f = fromIntegral
+    w1, w2, w3, w4 :: Word32
+    w1 = w .>>. 24 .&. 0x000000FF
+    w2 = w .>>. 16 .&. 0x000000FF
+    w3 = w .>>.  8 .&. 0x000000FF
+    w4 = w         .&. 0x000000FF
+
+
+foreign import ccall unsafe "inet_addr"
+    c_inet_addr :: CString -> IO Word32

--- a/foundation.cabal
+++ b/foundation.cabal
@@ -106,6 +106,7 @@ Library
                      Foundation.Collection.Zippable
                      Foundation.Conduit.Internal
                      Foundation.Internal.Base
+                     Foundation.Internal.ByteSwap
                      Foundation.Internal.CallStack
                      Foundation.Internal.Environment
                      Foundation.Internal.Error

--- a/foundation.cabal
+++ b/foundation.cabal
@@ -74,6 +74,7 @@ Library
                      Foundation.Monad
                      Foundation.Monad.Reader
                      Foundation.Monad.State
+                     Foundation.Network.IPv4
                      Foundation.System.Info
                      Foundation.Strict
                      Foundation.Parser
@@ -191,12 +192,14 @@ Test-Suite test-foundation
   Main-is:           Tests.hs
   Other-modules:     Test.Utils.Foreign
                      Test.Data.List
+                     Test.Data.Network
                      Test.Data.Unicode
                      Test.Data.ASCII
                      Test.Foundation.Collection
                      Test.Foundation.Conduit
                      Test.Foundation.Bits
                      Test.Foundation.ChunkedUArray
+                     Test.Foundation.Network.IPv4
                      Test.Foundation.Number
                      Test.Foundation.Encoding
                      Test.Foundation.Parser

--- a/tests/Test/Data/Network.hs
+++ b/tests/Test/Data/Network.hs
@@ -1,0 +1,46 @@
+-- |
+-- Module:
+-- Author: Nicolas Di Prima <nicolas>
+-- Date:   2017-01-18T17:34:06+00:00
+-- Email:  nicolasdiprima@gmail.com
+--
+
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE FlexibleInstances #-}
+
+module Test.Data.Network
+    ( genIPv4
+    , genIPv4Tuple
+    , genIPv4String
+    ) where
+
+import Foundation
+import Foundation.Network.IPv4
+import Foundation.Class.Storable as F
+import Test.Tasty.QuickCheck
+import qualified Foreign.Storable as Foreign
+
+instance Arbitrary IPv4 where
+    arbitrary = genIPv4
+instance Foreign.Storable IPv4 where
+    sizeOf a = let Size b = F.size (Just a) in b
+    alignment a = let Size b = F.alignment (Just a) in b
+    peek = F.peek
+    poke = F.poke
+
+genIPv4Tuple :: Gen (Word8, Word8, Word8, Word8)
+genIPv4Tuple =
+    (,,,) <$> choose (0, 255)
+          <*> choose (0, 255)
+          <*> choose (0, 255)
+          <*> choose (0, 255)
+
+genIPv4String :: Gen String
+genIPv4String = do
+    (w1, w2, w3, w4) <- genIPv4Tuple
+    return $ show w1 <> "." <> show w2 <> "." <> show w3 <> "." <> show w4
+
+-- | a better generator for unicode Character
+genIPv4 :: Gen IPv4
+genIPv4 = fromTuple <$> genIPv4Tuple

--- a/tests/Test/Foundation/Network/IPv4.hs
+++ b/tests/Test/Foundation/Network/IPv4.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Test.Foundation.Network.IPv4
+    ( testNetworkIPv4
+    ) where
+
+import Foundation
+import Foundation.Network.IPv4
+
+import Test.Tasty
+import Test.Tasty.QuickCheck
+
+import Test.Data.Network
+import Test.Foundation.Storable
+
+-- | test property equality for the given Collection
+testEquality :: Gen IPv4 -> TestTree
+testEquality genElement = testGroup "equality"
+    [ testProperty "x == x" $ forAll genElement (\x -> x == x)
+    , testProperty "x == y" $ forAll ((,) <$> genElement <*> genElement) $
+        \(x,y) -> (toTuple x == toTuple y) == (x == y)
+    ]
+
+-- | test ordering
+testOrdering :: Gen IPv4 -> TestTree
+testOrdering genElement = testProperty "ordering" $
+    forAll ((,) <$> genElement <*> genElement) $ \(x, y) ->
+        (toTuple x `compare` toTuple y) == x `compare` y
+
+testNetworkIPv4 :: TestTree
+testNetworkIPv4 = testGroup "IPv4"
+    [ testProperty "toTuple . fromTuple == id" $
+        forAll genIPv4Tuple $ \x -> x == toTuple (fromTuple x)
+    , testProperty "toString . fromString == id" $
+        forAll genIPv4String $ \x -> x == toString (fromString $ toList x)
+    , testEquality genIPv4
+    , testOrdering genIPv4
+    , testPropertyStorable      "Storable" (Proxy :: Proxy IPv4)
+    , testPropertyStorableFixed "StorableFixed" (Proxy :: Proxy IPv4)
+    ]

--- a/tests/Test/Foundation/Network/IPv4.hs
+++ b/tests/Test/Foundation/Network/IPv4.hs
@@ -16,23 +16,23 @@ import Test.Foundation.Storable
 -- | test property equality for the given Collection
 testEquality :: Gen IPv4 -> TestTree
 testEquality genElement = testGroup "equality"
-    [ testProperty "x == x" $ forAll genElement (\x -> x == x)
+    [ testProperty "x == x" $ forAll genElement (\x -> x === x)
     , testProperty "x == y" $ forAll ((,) <$> genElement <*> genElement) $
-        \(x,y) -> (toTuple x == toTuple y) == (x == y)
+        \(x,y) -> (toTuple x == toTuple y) === (x == y)
     ]
 
 -- | test ordering
 testOrdering :: Gen IPv4 -> TestTree
 testOrdering genElement = testProperty "ordering" $
     forAll ((,) <$> genElement <*> genElement) $ \(x, y) ->
-        (toTuple x `compare` toTuple y) == x `compare` y
+        (toTuple x `compare` toTuple y) === x `compare` y
 
 testNetworkIPv4 :: TestTree
 testNetworkIPv4 = testGroup "IPv4"
     [ testProperty "toTuple . fromTuple == id" $
-        forAll genIPv4Tuple $ \x -> x == toTuple (fromTuple x)
+        forAll genIPv4Tuple $ \x -> x === toTuple (fromTuple x)
     , testProperty "toString . fromString == id" $
-        forAll genIPv4String $ \x -> x == toString (fromString $ toList x)
+        forAll genIPv4String $ \x -> x === toString (fromString $ toList x)
     , testEquality genIPv4
     , testOrdering genIPv4
     , testPropertyStorable      "Storable" (Proxy :: Proxy IPv4)

--- a/tests/Test/Foundation/Storable.hs
+++ b/tests/Test/Foundation/Storable.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE TypeFamilies        #-}
 module Test.Foundation.Storable
     ( testForeignStorableRefs
+    , testPropertyStorable, testPropertyStorableFixed
     ) where
 
 import Foundation

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -28,6 +28,7 @@ import Test.Foundation.String
 import Test.Foundation.Parser
 import Test.Foundation.Storable
 import Test.Foundation.Random
+import Test.Foundation.Network.IPv4
 import qualified Test.Foundation.Bits as Bits
 
 data CharMap = CharMap LUString Prelude.Int
@@ -319,6 +320,7 @@ tests =
     , testForeignStorableRefs
     , testRandom
     , testConduit
+    , testNetworkIPv4
     ]
 
 testCaseModifiedUTF8 :: [Char] -> String -> Assertion


### PR DESCRIPTION
This PR is part of the work of splitting #174 into smaller PRs.

## IPv4

Simply add the type, the tests and provide the basic interfaces.

## Convenient other changes

* re-export the class `Bits` (from `base`) from `Foundation.Bits`;
* add some compatibility function (`byteSwapXX`) as not implemented before `base` **4.7.0**;