### PR TITLE
Add ResourceT for conduit usage

### DIFF
--- a/Foundation/IO/File.hs
+++ b/Foundation/IO/File.hs
@@ -6,7 +6,8 @@
 -- Portability : portable
 --
 module Foundation.IO.File
-    ( openFile
+    ( FilePath
+    , openFile
     , closeFile
     , IOMode(..)
     , withFile

--- a/Foundation/Monad.hs
+++ b/Foundation/Monad.hs
@@ -6,6 +6,7 @@ module Foundation.Monad
     , MonadFailure(..)
     , MonadThrow(..)
     , MonadCatch(..)
+    , MonadBracket(..)
     , MonadTrans(..)
     , Identity(..)
     ) where

--- a/Foundation/Monad/Exception.hs
+++ b/Foundation/Monad/Exception.hs
@@ -1,12 +1,13 @@
-
+{-# LANGUAGE ScopedTypeVariables #-}
 module Foundation.Monad.Exception
     ( MonadFailure(..)
     , MonadThrow(..)
     , MonadCatch(..)
+    , MonadBracket(..)
     ) where
 
 import           Foundation.Internal.Base
-import qualified Control.Exception (throwIO, catch)
+import qualified Control.Exception as E
 
 -- | Monad that can represent failure
 --
@@ -29,6 +30,23 @@ class Monad m => MonadThrow m where
 class MonadThrow m => MonadCatch m where
     catch :: Exception e => m a -> (e -> m a) -> m a
 
+-- | Monad that can ensure cleanup actions are performed even in the
+-- case of exceptions, both synchronous and asynchronous. This usually
+-- excludes continuation-based monads.
+class MonadCatch m => MonadBracket m where
+    -- | A generalized version of the standard bracket function which
+    -- allows distinguishing different exit cases.
+    generalBracket
+        :: m a
+        -- ^ acquire some resource
+        -> (a -> b -> m ignored1)
+        -- ^ cleanup, no exception thrown
+        -> (a -> E.SomeException -> m ignored2)
+        -- ^ cleanup, some exception thrown. The exception will be rethrown
+        -> (a -> m b)
+        -- ^ inner action to perform with the resource
+        -> m b
+
 instance MonadFailure Maybe where
     type Failure Maybe = ()
     mFail _ = Nothing
@@ -37,6 +55,21 @@ instance MonadFailure (Either a) where
     mFail a = Left a
 
 instance MonadThrow IO where
-    throw = Control.Exception.throwIO
+    throw = E.throwIO
 instance MonadCatch IO where
-    catch = Control.Exception.catch
+    catch = E.catch
+instance MonadBracket IO where
+    generalBracket acquire onSuccess onException inner = E.mask $ \restore -> do
+        x <- acquire
+        res1 <- E.try $ restore $ inner x
+        case res1 of
+            Left (e1 :: E.SomeException) -> do
+                -- explicitly ignore exceptions from the cleanup
+                -- action so we keep the original exception
+                E.uninterruptibleMask_ $ fmap (const ()) (onException x e1) `E.catch`
+                    (\(_ :: E.SomeException) -> return ())
+                E.throwIO e1
+            Right y -> do
+                -- Allow exceptions from the onSuccess function to propagate
+                _ <- onSuccess x y
+                return y

--- a/tests/Test/Foundation/Conduit.hs
+++ b/tests/Test/Foundation/Conduit.hs
@@ -15,6 +15,7 @@ testConduit :: TestTree
 testConduit = testGroup "Conduit"
     [ testCase "sourceHandle gives same data as readFile" testSourceFile
     , testCase "sourceHandle/sinkHandle copies data" testCopyFile
+    , testCase "sourceFile/sinkFile copies data" testCopyFileRes
     ]
   where
     testSourceFile :: Assertion
@@ -31,6 +32,15 @@ testConduit = testGroup "Conduit"
             dst = "temp-file" -- FIXME some temp file API?
         withFile src ReadMode $ \hin -> withFile dst WriteMode $ \hout ->
             runConduit $ sourceHandle hin .| sinkHandle hout
+        orig <- readFile src
+        new <- readFile dst
+        assertEqual "copied foundation.cabal contents" orig new
+
+    testCopyFileRes :: Assertion
+    testCopyFileRes = do
+        let src = "foundation.cabal"
+            dst = "temp-file" -- FIXME some temp file API?
+        runConduitRes $ sourceFile src .| sinkFile dst
         orig <- readFile src
         new <- readFile dst
         assertEqual "copied foundation.cabal contents" orig new


### PR DESCRIPTION
This pulled in a few more features

* MonadBracket, to allow for a generalized way to install cleanups
* ResourceT/MonadResource
* runConduitRes and bracketConduit
* The sourceFile and sinkFile functions, demonstrating usage