### PR TITLE
Make Float and Double as the instance of Signed.

### DIFF
--- a/Foundation/Numerical.hs
+++ b/Foundation/Numerical.hs
@@ -72,6 +72,12 @@ instance Signed Int32 where
 instance Signed Int64 where
     abs = Prelude.abs
     signum = orderingToSign . compare 0
+instance Signed Float where
+    abs = Prelude.abs
+    signum = orderingToSign . compare 0
+instance Signed Double where
+    abs = Prelude.abs
+    signum = orderingToSign . compare 0
 
 class IntegralRounding a where
     -- | Round up, to the next integral.


### PR DESCRIPTION
The `abs` method is necessary for Float and Double type.