### PR TITLE
add Big Endian and Little Endian types

### DIFF
--- a/Foundation/Bits.hs
+++ b/Foundation/Bits.hs
@@ -5,16 +5,11 @@ module Foundation.Bits
     , Bits(..)
     , alignRoundUp
     , alignRoundDown
-    , htonl, htons
-    , ntohl, ntohs
     ) where
 
 import Foundation.Internal.Base
-import Foundation.Internal.ByteSwap
 import Foundation.Numerical
-import Foundation.System.Info (Endianness(..), endianness)
 import Data.Bits
-import Data.Word (Word16, Word32)
 
 -- | Unsafe Shift Left Operator
 (.<<.) :: Bits a => a -> Int -> a
@@ -45,27 +40,3 @@ alignRoundDown :: Int -- ^ Number to Align
                -> Int -- ^ Alignment (power of 2)
                -> Int
 alignRoundDown m alignment = m .&. complement (alignment-1)
-
--- | perform conversion from Host to Network endianness
-htons :: Word16 -> Word16
-htons w = case endianness of
-    LittleEndian -> byteSwap16 w
-    BigEndian    -> w
-
--- | perform conversion from Network to Host endianness
-ntohs :: Word16 -> Word16
-ntohs w = case endianness of
-    LittleEndian -> byteSwap16 w
-    BigEndian    -> w
-
--- | perform conversion from Host to Network endianness
-htonl :: Word32 -> Word32
-htonl w = case endianness of
-    LittleEndian -> byteSwap32 w
-    BigEndian    -> w
-
--- | perform conversion from Network to Host endianness
-ntohl :: Word32 -> Word32
-ntohl w = case endianness of
-    LittleEndian -> byteSwap32 w
-    BigEndian    -> w

--- a/Foundation/Class/Storable.hs
+++ b/Foundation/Class/Storable.hs
@@ -24,6 +24,7 @@ import GHC.Types (Double, Float)
 import Foreign.Ptr (castPtr)
 import qualified Foreign.Ptr
 import qualified Foreign.Storable (peek, poke, sizeOf, alignment)
+import           Foreign.C.Types (CChar, CUChar)
 
 import Foundation.Internal.Base
 import Foundation.Internal.Types
@@ -61,6 +62,12 @@ peekOff ptr off = peek (ptr `plusPtr` offsetAsSize off)
 pokeOff :: StorableFixed a => Ptr a -> Offset a -> a -> IO ()
 pokeOff ptr off = poke (ptr `plusPtr` offsetAsSize off)
 
+instance Storable CChar where
+    peek (Ptr addr) = primAddrRead addr (Offset 0)
+    poke (Ptr addr) = primAddrWrite addr (Offset 0)
+instance Storable CUChar where
+    peek (Ptr addr) = primAddrRead addr (Offset 0)
+    poke (Ptr addr) = primAddrWrite addr (Offset 0)
 instance Storable Char where
     peek (Ptr addr) = primAddrRead addr (Offset 0)
     poke (Ptr addr) = primAddrWrite addr (Offset 0)
@@ -116,6 +123,12 @@ instance Storable (Ptr a) where
     peek = Foreign.Storable.peek
     poke = Foreign.Storable.poke
 
+instance StorableFixed CChar where
+    size      = primSizeInBytes . toProxy
+    alignment = primSizeInBytes . toProxy
+instance StorableFixed CUChar where
+    size      = primSizeInBytes . toProxy
+    alignment = primSizeInBytes . toProxy
 instance StorableFixed Char where
     size      = primSizeInBytes . toProxy
     alignment = primSizeInBytes . toProxy

--- a/Foundation/Class/Storable.hs
+++ b/Foundation/Class/Storable.hs
@@ -9,6 +9,8 @@
 --
 --
 
+{-# LANGUAGE FlexibleInstances #-}
+
 module Foundation.Class.Storable
     ( Storable(..)
     , StorableFixed(..)
@@ -27,6 +29,7 @@ import Foundation.Internal.Base
 import Foundation.Internal.Types
 import Foundation.Internal.Proxy
 import Foundation.Primitive.Types
+import Foundation.Primitive.Endianness
 import Foundation.Numerical
 
 toProxy :: proxy ty -> Proxy ty
@@ -85,12 +88,30 @@ instance Storable Word8 where
 instance Storable Word16 where
     peek (Ptr addr) = primAddrRead addr (Offset 0)
     poke (Ptr addr) = primAddrWrite addr (Offset 0)
+instance Storable (BE Word16) where
+    peek (Ptr addr) = BE <$> primAddrRead addr (Offset 0)
+    poke (Ptr addr) = primAddrWrite addr (Offset 0) . unBE
+instance Storable (LE Word16) where
+    peek (Ptr addr) = LE <$> primAddrRead addr (Offset 0)
+    poke (Ptr addr) = primAddrWrite addr (Offset 0) . unLE
 instance Storable Word32 where
     peek (Ptr addr) = primAddrRead addr (Offset 0)
     poke (Ptr addr) = primAddrWrite addr (Offset 0)
+instance Storable (BE Word32) where
+    peek (Ptr addr) = BE <$> primAddrRead addr (Offset 0)
+    poke (Ptr addr) = primAddrWrite addr (Offset 0) . unBE
+instance Storable (LE Word32) where
+    peek (Ptr addr) = LE <$> primAddrRead addr (Offset 0)
+    poke (Ptr addr) = primAddrWrite addr (Offset 0) . unLE
 instance Storable Word64 where
     peek (Ptr addr) = primAddrRead addr (Offset 0)
     poke (Ptr addr) = primAddrWrite addr (Offset 0)
+instance Storable (BE Word64) where
+    peek (Ptr addr) = BE <$> primAddrRead addr (Offset 0)
+    poke (Ptr addr) = primAddrWrite addr (Offset 0) . unBE
+instance Storable (LE Word64) where
+    peek (Ptr addr) = LE <$> primAddrRead addr (Offset 0)
+    poke (Ptr addr) = primAddrWrite addr (Offset 0) . unLE
 instance Storable (Ptr a) where
     peek = Foreign.Storable.peek
     poke = Foreign.Storable.poke
@@ -122,10 +143,28 @@ instance StorableFixed Word8 where
 instance StorableFixed Word16 where
     size      = primSizeInBytes . toProxy
     alignment = primSizeInBytes . toProxy
+instance StorableFixed (BE Word16) where
+    size      = primSizeInBytes . toProxy
+    alignment = primSizeInBytes . toProxy
+instance StorableFixed (LE Word16) where
+    size      = primSizeInBytes . toProxy
+    alignment = primSizeInBytes . toProxy
 instance StorableFixed Word32 where
     size      = primSizeInBytes . toProxy
     alignment = primSizeInBytes . toProxy
+instance StorableFixed (BE Word32) where
+    size      = primSizeInBytes . toProxy
+    alignment = primSizeInBytes . toProxy
+instance StorableFixed (LE Word32) where
+    size      = primSizeInBytes . toProxy
+    alignment = primSizeInBytes . toProxy
 instance StorableFixed Word64 where
+    size      = primSizeInBytes . toProxy
+    alignment = primSizeInBytes . toProxy
+instance StorableFixed (BE Word64) where
+    size      = primSizeInBytes . toProxy
+    alignment = primSizeInBytes . toProxy
+instance StorableFixed (LE Word64) where
     size      = primSizeInBytes . toProxy
     alignment = primSizeInBytes . toProxy
 instance StorableFixed (Ptr a) where

--- a/Foundation/Internal/ByteSwap.hs
+++ b/Foundation/Internal/ByteSwap.hs
@@ -12,7 +12,11 @@ module Foundation.Internal.ByteSwap
     ( byteSwap16
     , byteSwap32
     , byteSwap64
+    , ByteSwap
+    , byteSwap
     ) where
+
+import Foundation.Internal.Base (Word16, Word32, Word64)
 
 #if MIN_VERSION_base(4,7,0)
 
@@ -64,3 +68,15 @@ byteSwap64 w = w1 .|. w2 .|. w3 .|. w4 .|. w5 .|. w6 .|. w7 .|. w8
     w7 = (w `unsafeShiftL`  8) .&. 0x000000FF00000000
     w8 = (w `unsafeShiftR`  8) .&. 0x00000000FF000000
 #endif
+
+-- | Class of types that can be byte-swapped.
+--
+-- e.g. Word16, Word32, Word64
+class ByteSwap a where
+    byteSwap :: a -> a
+instance ByteSwap Word16 where
+    byteSwap = byteSwap16
+instance ByteSwap Word32 where
+    byteSwap = byteSwap32
+instance ByteSwap Word64 where
+    byteSwap = byteSwap64

--- a/Foundation/Network/IPv4.hs
+++ b/Foundation/Network/IPv4.hs
@@ -18,6 +18,7 @@ import Foundation.Hashing.Hashable
 import Foundation.Internal.Base
 import Foundation.Internal.Proxy
 import Foundation.String (String)
+import Foundation.Primitive
 import Foundation.Bits
 
 -- | IPv4 data type
@@ -28,8 +29,8 @@ instance Show IPv4 where
 instance IsString IPv4 where
     fromString = fromLString
 instance Storable IPv4 where
-    peek ptr = IPv4 . ntohl <$> peek (castPtr ptr)
-    poke ptr (IPv4 w) = poke (castPtr ptr) (htonl w)
+    peek ptr = IPv4 . fromBE <$> peek (castPtr ptr)
+    poke ptr (IPv4 w) = poke (castPtr ptr) (toBE w)
 instance StorableFixed IPv4 where
     size      _ = size      (Proxy :: Proxy Word32)
     alignment _ = alignment (Proxy :: Proxy Word32)
@@ -39,7 +40,7 @@ toString = fromList . toLString
 
 fromLString :: [Char] -> IPv4
 fromLString str = unsafePerformIO $ withCString str $ \cstr ->
-    IPv4 . ntohl <$> c_inet_addr cstr
+    IPv4 . fromBE <$> c_inet_addr cstr
 
 toLString :: IPv4 -> [Char]
 toLString ipv4 =
@@ -73,4 +74,4 @@ toTuple (IPv4 w) =
 
 
 foreign import ccall unsafe "inet_addr"
-    c_inet_addr :: CString -> IO Word32
+    c_inet_addr :: CString -> IO (BE Word32)

--- a/Foundation/Primitive.hs
+++ b/Foundation/Primitive.hs
@@ -13,7 +13,13 @@
 module Foundation.Primitive
     ( PrimType(..)
     , PrimMonad(..)
+
+    -- * endianess
+    , ByteSwap
+    , LE(..), toLE, fromLE
+    , BE(..), toBE, fromBE
     ) where
 
 import Foundation.Primitive.Types
 import Foundation.Primitive.Monad
+import Foundation.Primitive.Endianness

--- a/Foundation/Primitive/Endianness.hs
+++ b/Foundation/Primitive/Endianness.hs
@@ -29,11 +29,15 @@ import Foundation.System.Info (endianness, Endianness(..))
 
 -- | Little Endian value
 newtype LE a = LE { unLE :: a }
-  deriving (Show, Eq, Ord, Typeable)
+  deriving (Show, Eq, Typeable)
+instance (ByteSwap a, Ord a) => Ord (LE a) where
+    compare e1 e2 = compare (fromLE e1) (fromLE e2)
 
 -- | Big Endian value
 newtype BE a = BE { unBE :: a }
-  deriving (Show, Eq, Ord, Typeable)
+  deriving (Show, Eq, Typeable)
+instance (ByteSwap a, Ord a) => Ord (BE a) where
+    compare e1 e2 = compare (fromBE e1) (fromBE e2)
 
 -- | Convert a value in cpu endianess to big endian
 toBE :: ByteSwap a => a -> BE a

--- a/Foundation/Primitive/Endianness.hs
+++ b/Foundation/Primitive/Endianness.hs
@@ -1,0 +1,80 @@
+-- |
+-- Module      : Foundation.Primitive.Endianness
+-- License     : BSD-style
+-- Maintainer  : Haskell Foundation
+-- Stability   : experimental
+-- Portability : portable
+--
+-- Set endianness tag to a given primitive. This will help for serialising
+-- data for protocols (such as the network protocols).
+--
+
+{-# LANGUAGE CPP #-}
+
+module Foundation.Primitive.Endianness
+    (
+      ByteSwap
+      -- * Big Endian
+    , BE(..), toBE, fromBE
+      -- * Little Endian
+    , LE(..), toLE, fromLE
+    ) where
+
+import Foundation.Internal.Base
+import Foundation.Internal.ByteSwap
+
+#if !defined(ARCH_IS_LITTLE_ENDIAN) && !defined(ARCH_IS_BIG_ENDIAN)
+import Foundation.System.Info (endianness, Endianness(..))
+#endif
+
+-- | Little Endian value
+newtype LE a = LE { unLE :: a }
+  deriving (Show, Eq, Ord, Typeable)
+
+-- | Big Endian value
+newtype BE a = BE { unBE :: a }
+  deriving (Show, Eq, Ord, Typeable)
+
+-- | Convert a value in cpu endianess to big endian
+toBE :: ByteSwap a => a -> BE a
+#ifdef ARCH_IS_LITTLE_ENDIAN
+toBE = BE . byteSwap
+#elif ARCH_IS_BIG_ENDIAN
+toBE = BE
+#else
+toBE = BE . (if endianness == LittleEndian then byteSwap else id)
+#endif
+{-# INLINE toBE #-}
+
+-- | Convert from a big endian value to the cpu endianness
+fromBE :: ByteSwap a => BE a -> a
+#ifdef ARCH_IS_LITTLE_ENDIAN
+fromBE (BE a) = byteSwap a
+#elif ARCH_IS_BIG_ENDIAN
+fromBE (BE a) = a
+#else
+fromBE (BE a) = if endianness == LittleEndian then byteSwap a else a
+#endif
+{-# INLINE fromBE #-}
+
+-- | Convert a value in cpu endianess to little endian
+toLE :: ByteSwap a => a -> LE a
+#ifdef ARCH_IS_LITTLE_ENDIAN
+toLE = LE
+#elif ARCH_IS_BIG_ENDIAN
+toLE = LE . byteSwap
+#else
+toLE = LE . (if endianness == LittleEndian then id else byteSwap)
+#endif
+{-# INLINE toLE #-}
+
+-- | Convert from a little endian value to the cpu endianness
+fromLE :: ByteSwap a => LE a -> a
+#ifdef ARCH_IS_LITTLE_ENDIAN
+fromLE (LE a) = a
+#elif ARCH_IS_BIG_ENDIAN
+fromLE (LE a) = byteSwap a
+#else
+fromLE (LE a) = if endianness == LittleEndian then a else byteSwap a
+#endif
+{-# INLINE fromLE #-}

--- a/Foundation/Primitive/Types.hs
+++ b/Foundation/Primitive/Types.hs
@@ -7,6 +7,7 @@
 --
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE CPP #-}
 module Foundation.Primitive.Types
     ( PrimType(..)
@@ -31,6 +32,7 @@ import           Foreign.C.Types
 import           Foundation.Internal.Proxy
 import           Foundation.Internal.Base
 import           Foundation.Internal.Types
+import           Foundation.Primitive.Endianness
 import           Foundation.Primitive.Monad
 import qualified Prelude (quot)
 
@@ -219,6 +221,36 @@ instance PrimType Word16 where
     {-# INLINE primAddrRead #-}
     primAddrWrite addr (Offset (I# n)) (W16# w) = primitive $ \s1 -> (# writeWord16OffAddr# addr n w s1, () #)
     {-# INLINE primAddrWrite #-}
+instance PrimType (BE Word16) where
+    primSizeInBytes _ = Size 2
+    {-# INLINE primSizeInBytes #-}
+    primBaUIndex ba (Offset a) = BE $ primBaUIndex ba (Offset a)
+    {-# INLINE primBaUIndex #-}
+    primMbaURead ba (Offset a) = BE <$> primMbaURead ba (Offset a)
+    {-# INLINE primMbaURead #-}
+    primMbaUWrite mba (Offset a) (BE w) = primMbaUWrite mba (Offset a) w
+    {-# INLINE primMbaUWrite #-}
+    primAddrIndex addr (Offset a) = BE $ primAddrIndex addr (Offset a)
+    {-# INLINE primAddrIndex #-}
+    primAddrRead addr (Offset a) = BE <$> primAddrRead addr (Offset a)
+    {-# INLINE primAddrRead #-}
+    primAddrWrite addr (Offset a) (BE w) = primAddrWrite addr (Offset a) w
+    {-# INLINE primAddrWrite #-}
+instance PrimType (LE Word16) where
+    primSizeInBytes _ = Size 2
+    {-# INLINE primSizeInBytes #-}
+    primBaUIndex ba (Offset a) = LE $ primBaUIndex ba (Offset a)
+    {-# INLINE primBaUIndex #-}
+    primMbaURead ba (Offset a) = LE <$> primMbaURead ba (Offset a)
+    {-# INLINE primMbaURead #-}
+    primMbaUWrite mba (Offset a) (LE w) = primMbaUWrite mba (Offset a) w
+    {-# INLINE primMbaUWrite #-}
+    primAddrIndex addr (Offset a) = LE $ primAddrIndex addr (Offset a)
+    {-# INLINE primAddrIndex #-}
+    primAddrRead addr (Offset a) = LE <$> primAddrRead addr (Offset a)
+    {-# INLINE primAddrRead #-}
+    primAddrWrite addr (Offset a) (LE w) = primAddrWrite addr (Offset a) w
+    {-# INLINE primAddrWrite #-}
 instance PrimType Word32 where
     primSizeInBytes _ = Size 4
     {-# INLINE primSizeInBytes #-}
@@ -234,6 +266,36 @@ instance PrimType Word32 where
     {-# INLINE primAddrRead #-}
     primAddrWrite addr (Offset (I# n)) (W32# w) = primitive $ \s1 -> (# writeWord32OffAddr# addr n w s1, () #)
     {-# INLINE primAddrWrite #-}
+instance PrimType (BE Word32) where
+    primSizeInBytes _ = Size 4
+    {-# INLINE primSizeInBytes #-}
+    primBaUIndex ba (Offset a) = BE $ primBaUIndex ba (Offset a)
+    {-# INLINE primBaUIndex #-}
+    primMbaURead ba (Offset a) = BE <$> primMbaURead ba (Offset a)
+    {-# INLINE primMbaURead #-}
+    primMbaUWrite mba (Offset a) (BE w) = primMbaUWrite mba (Offset a) w
+    {-# INLINE primMbaUWrite #-}
+    primAddrIndex addr (Offset a) = BE $ primAddrIndex addr (Offset a)
+    {-# INLINE primAddrIndex #-}
+    primAddrRead addr (Offset a) = BE <$> primAddrRead addr (Offset a)
+    {-# INLINE primAddrRead #-}
+    primAddrWrite addr (Offset a) (BE w) = primAddrWrite addr (Offset a) w
+    {-# INLINE primAddrWrite #-}
+instance PrimType (LE Word32) where
+    primSizeInBytes _ = Size 4
+    {-# INLINE primSizeInBytes #-}
+    primBaUIndex ba (Offset a) = LE $ primBaUIndex ba (Offset a)
+    {-# INLINE primBaUIndex #-}
+    primMbaURead ba (Offset a) = LE <$> primMbaURead ba (Offset a)
+    {-# INLINE primMbaURead #-}
+    primMbaUWrite mba (Offset a) (LE w) = primMbaUWrite mba (Offset a) w
+    {-# INLINE primMbaUWrite #-}
+    primAddrIndex addr (Offset a) = LE $ primAddrIndex addr (Offset a)
+    {-# INLINE primAddrIndex #-}
+    primAddrRead addr (Offset a) = LE <$> primAddrRead addr (Offset a)
+    {-# INLINE primAddrRead #-}
+    primAddrWrite addr (Offset a) (LE w) = primAddrWrite addr (Offset a) w
+    {-# INLINE primAddrWrite #-}
 instance PrimType Word64 where
     primSizeInBytes _ = Size 8
     {-# INLINE primSizeInBytes #-}
@@ -248,6 +310,36 @@ instance PrimType Word64 where
     primAddrRead addr (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readWord64OffAddr# addr n s1 in (# s2, W64# r #)
     {-# INLINE primAddrRead #-}
     primAddrWrite addr (Offset (I# n)) (W64# w) = primitive $ \s1 -> (# writeWord64OffAddr# addr n w s1, () #)
+    {-# INLINE primAddrWrite #-}
+instance PrimType (BE Word64) where
+    primSizeInBytes _ = Size 8
+    {-# INLINE primSizeInBytes #-}
+    primBaUIndex ba (Offset a) = BE $ primBaUIndex ba (Offset a)
+    {-# INLINE primBaUIndex #-}
+    primMbaURead ba (Offset a) = BE <$> primMbaURead ba (Offset a)
+    {-# INLINE primMbaURead #-}
+    primMbaUWrite mba (Offset a) (BE w) = primMbaUWrite mba (Offset a) w
+    {-# INLINE primMbaUWrite #-}
+    primAddrIndex addr (Offset a) = BE $ primAddrIndex addr (Offset a)
+    {-# INLINE primAddrIndex #-}
+    primAddrRead addr (Offset a) = BE <$> primAddrRead addr (Offset a)
+    {-# INLINE primAddrRead #-}
+    primAddrWrite addr (Offset a) (BE w) = primAddrWrite addr (Offset a) w
+    {-# INLINE primAddrWrite #-}
+instance PrimType (LE Word64) where
+    primSizeInBytes _ = Size 8
+    {-# INLINE primSizeInBytes #-}
+    primBaUIndex ba (Offset a) = LE $ primBaUIndex ba (Offset a)
+    {-# INLINE primBaUIndex #-}
+    primMbaURead ba (Offset a) = LE <$> primMbaURead ba (Offset a)
+    {-# INLINE primMbaURead #-}
+    primMbaUWrite mba (Offset a) (LE w) = primMbaUWrite mba (Offset a) w
+    {-# INLINE primMbaUWrite #-}
+    primAddrIndex addr (Offset a) = LE $ primAddrIndex addr (Offset a)
+    {-# INLINE primAddrIndex #-}
+    primAddrRead addr (Offset a) = LE <$> primAddrRead addr (Offset a)
+    {-# INLINE primAddrRead #-}
+    primAddrWrite addr (Offset a) (LE w) = primAddrWrite addr (Offset a) w
     {-# INLINE primAddrWrite #-}
 instance PrimType Int8 where
     primSizeInBytes _ = Size 1

--- a/foundation.cabal
+++ b/foundation.cabal
@@ -132,6 +132,7 @@ Library
                      Foundation.IO.File
                      Foundation.IO.Terminal
                      Foundation.Primitive.Base16
+                     Foundation.Primitive.Endianness
                      Foundation.Primitive.Types
                      Foundation.Primitive.Monad
                      Foundation.Primitive.Utils

--- a/tests/Test/Foundation/Array.hs
+++ b/tests/Test/Foundation/Array.hs
@@ -11,6 +11,7 @@ import Control.Monad
 import Foundation
 import Foundation.Collection
 import Foundation.Foreign
+import Foundation.Class.Storable
 
 import Test.Tasty
 import Test.Tasty.QuickCheck
@@ -66,10 +67,16 @@ testArrayRefs = testGroup "Array"
         , testCollection "Array(Integer)" (Proxy :: Proxy (Array Integer)) arbitrary
         , testCollection "Array(CChar)"   (Proxy :: Proxy (Array CChar))  (CChar <$> arbitrary)
         , testCollection "Array(CUChar)"  (Proxy :: Proxy (Array CUChar)) (CUChar <$> arbitrary)
+        , testCollection "Array(BE W16)"  (Proxy :: Proxy (Array (BE Word16))) (toBE <$> arbitrary)
+        , testCollection "Array(BE W32)"  (Proxy :: Proxy (Array (BE Word32))) (toBE <$> arbitrary)
+        , testCollection "Array(BE W64)"  (Proxy :: Proxy (Array (BE Word64))) (toBE <$> arbitrary)
+        , testCollection "Array(LE W16)"  (Proxy :: Proxy (Array (LE Word16))) (toLE <$> arbitrary)
+        , testCollection "Array(LE W32)"  (Proxy :: Proxy (Array (LE Word32))) (toLE <$> arbitrary)
+        , testCollection "Array(LE W64)"  (Proxy :: Proxy (Array (LE Word64))) (toLE <$> arbitrary)
         ]
     ]
 
-testUnboxedForeign :: (PrimType e, Show e, Element a ~ e, Storable e)
+testUnboxedForeign :: (PrimType e, Show e, Element a ~ e, StorableFixed e)
                    => Proxy a -> Gen e -> [TestTree]
 testUnboxedForeign proxy genElement =
     [ testProperty "equal" $ withElementsM $ \fptr l ->

--- a/tests/Test/Foundation/Array.hs
+++ b/tests/Test/Foundation/Array.hs
@@ -11,6 +11,7 @@ import Control.Monad
 import Foundation
 import Foundation.Collection
 import Foundation.Foreign
+import Foundation.Primitive
 import Foundation.Class.Storable
 
 import Test.Tasty
@@ -36,6 +37,12 @@ testArrayRefs = testGroup "Array"
         , testCollection "UArray(F64)" (Proxy :: Proxy (UArray Double)) arbitrary
         , testCollection "UArray(CChar)"  (Proxy :: Proxy (UArray CChar))  (CChar <$> arbitrary)
         , testCollection "UArray(CUChar)" (Proxy :: Proxy (UArray CUChar)) (CUChar <$> arbitrary)
+        , testCollection "UArray(BE W16)" (Proxy :: Proxy (UArray (BE Word16))) (toBE <$> arbitrary)
+        , testCollection "UArray(BE W32)" (Proxy :: Proxy (UArray (BE Word32))) (toBE <$> arbitrary)
+        , testCollection "UArray(BE W64)" (Proxy :: Proxy (UArray (BE Word64))) (toBE <$> arbitrary)
+        , testCollection "UArray(LE W16)" (Proxy :: Proxy (UArray (LE Word16))) (toLE <$> arbitrary)
+        , testCollection "UArray(LE W32)" (Proxy :: Proxy (UArray (LE Word32))) (toLE <$> arbitrary)
+        , testCollection "UArray(LE W64)" (Proxy :: Proxy (UArray (LE Word64))) (toLE <$> arbitrary)
         ]
     , testGroup "Unboxed-Foreign"
         [ testGroup "UArray(W8)"  (testUnboxedForeign (Proxy :: Proxy (UArray Word8))  arbitrary)
@@ -50,6 +57,12 @@ testArrayRefs = testGroup "Array"
         , testGroup "UArray(F64)" (testUnboxedForeign (Proxy :: Proxy (UArray Double)) arbitrary)
         , testGroup "UArray(CChar)"  (testUnboxedForeign (Proxy :: Proxy (UArray CChar))  (CChar <$> arbitrary))
         , testGroup "UArray(CUChar)" (testUnboxedForeign (Proxy :: Proxy (UArray CUChar)) (CUChar <$> arbitrary))
+        , testGroup "UArray(BE W16)" (testUnboxedForeign (Proxy :: Proxy (UArray (BE Word16))) (toBE <$> arbitrary))
+        , testGroup "UArray(BE W32)" (testUnboxedForeign (Proxy :: Proxy (UArray (BE Word32))) (toBE <$> arbitrary))
+        , testGroup "UArray(BE W64)" (testUnboxedForeign (Proxy :: Proxy (UArray (BE Word64))) (toBE <$> arbitrary))
+        , testGroup "UArray(LE W16)" (testUnboxedForeign (Proxy :: Proxy (UArray (LE Word16))) (toLE <$> arbitrary))
+        , testGroup "UArray(LE W32)" (testUnboxedForeign (Proxy :: Proxy (UArray (LE Word32))) (toLE <$> arbitrary))
+        , testGroup "UArray(LE W64)" (testUnboxedForeign (Proxy :: Proxy (UArray (LE Word64))) (toLE <$> arbitrary))
         ]
     , testGroup "Boxed"
         [ testCollection "Array(W8)"  (Proxy :: Proxy (Array Word8))  arbitrary

--- a/tests/Test/Foundation/Bits.hs
+++ b/tests/Test/Foundation/Bits.hs
@@ -6,7 +6,6 @@ module Test.Foundation.Bits
 import Foundation.Bits
 import Imports
 import Foundation
-import Foundation.Numerical
 
 tests = testGroup "Bits"
     [ testProperty "round-up" $ \(Positive m) n' -> n' >= 1 ==>

--- a/tests/Test/Foundation/ChunkedUArray.hs
+++ b/tests/Test/Foundation/ChunkedUArray.hs
@@ -13,6 +13,7 @@ import Foundation.Collection
 import Foundation.Array
 import Foundation.Foreign
 import Foundation.Class.Storable
+import Foundation.Primitive
 
 import Test.Tasty
 import Test.Tasty.QuickCheck
@@ -35,6 +36,12 @@ testChunkedUArrayRefs = testGroup "ChunkedArray"
         , testCollection "ChunkedUArray(I64)" (Proxy :: Proxy (ChunkedUArray Int64))  arbitrary
         , testCollection "ChunkedUArray(F32)" (Proxy :: Proxy (ChunkedUArray Float))  arbitrary
         , testCollection "ChunkedUArray(F64)" (Proxy :: Proxy (ChunkedUArray Double)) arbitrary
+        , testCollection "ChunkedUArray(BE W16)" (Proxy :: Proxy (ChunkedUArray (BE Word16))) (toBE <$> arbitrary)
+        , testCollection "ChunkedUArray(BE W32)" (Proxy :: Proxy (ChunkedUArray (BE Word32))) (toBE <$> arbitrary)
+        , testCollection "ChunkedUArray(BE W64)" (Proxy :: Proxy (ChunkedUArray (BE Word64))) (toBE <$> arbitrary)
+        , testCollection "ChunkedUArray(LE W16)" (Proxy :: Proxy (ChunkedUArray (LE Word16))) (toLE <$> arbitrary)
+        , testCollection "ChunkedUArray(LE W32)" (Proxy :: Proxy (ChunkedUArray (LE Word32))) (toLE <$> arbitrary)
+        , testCollection "ChunkedUArray(LE W64)" (Proxy :: Proxy (ChunkedUArray (LE Word64))) (toLE <$> arbitrary)
         ]
     , testGroup "Unboxed-Foreign"
         [ testGroup "UArray(W8)"  (testUnboxedForeign (Proxy :: Proxy (ChunkedUArray Word8))  arbitrary)
@@ -47,6 +54,12 @@ testChunkedUArrayRefs = testGroup "ChunkedArray"
         , testGroup "UArray(I64)" (testUnboxedForeign (Proxy :: Proxy (ChunkedUArray Int64))  arbitrary)
         , testGroup "UArray(F32)" (testUnboxedForeign (Proxy :: Proxy (ChunkedUArray Float))  arbitrary)
         , testGroup "UArray(F64)" (testUnboxedForeign (Proxy :: Proxy (ChunkedUArray Double)) arbitrary)
+        , testGroup "UArray(BE W16)" (testUnboxedForeign (Proxy :: Proxy (ChunkedUArray (BE Word16))) (toBE <$> arbitrary))
+        , testGroup "UArray(BE W32)" (testUnboxedForeign (Proxy :: Proxy (ChunkedUArray (BE Word32))) (toBE <$> arbitrary))
+        , testGroup "UArray(BE W64)" (testUnboxedForeign (Proxy :: Proxy (ChunkedUArray (BE Word64))) (toBE <$> arbitrary))
+        , testGroup "UArray(LE W16)" (testUnboxedForeign (Proxy :: Proxy (ChunkedUArray (LE Word16))) (toLE <$> arbitrary))
+        , testGroup "UArray(LE W32)" (testUnboxedForeign (Proxy :: Proxy (ChunkedUArray (LE Word32))) (toLE <$> arbitrary))
+        , testGroup "UArray(LE W64)" (testUnboxedForeign (Proxy :: Proxy (ChunkedUArray (LE Word64))) (toLE <$> arbitrary))
         ]
     , testGroup "Boxed"
         [ testCollection "Array(W8)"  (Proxy :: Proxy (Array Word8))  arbitrary
@@ -62,6 +75,12 @@ testChunkedUArrayRefs = testGroup "ChunkedArray"
         , testCollection "Array(Int)" (Proxy :: Proxy (Array Int))  arbitrary
         , testCollection "Array(Int,Int)" (Proxy :: Proxy (Array (Int,Int)))  arbitrary
         , testCollection "Array(Integer)" (Proxy :: Proxy (Array Integer)) arbitrary
+        , testCollection "Array(BE W16)" (Proxy :: Proxy (Array (BE Word16))) (toBE <$> arbitrary)
+        , testCollection "Array(BE W32)" (Proxy :: Proxy (Array (BE Word32))) (toBE <$> arbitrary)
+        , testCollection "Array(BE W64)" (Proxy :: Proxy (Array (BE Word64))) (toBE <$> arbitrary)
+        , testCollection "Array(LE W16)" (Proxy :: Proxy (Array (LE Word16))) (toLE <$> arbitrary)
+        , testCollection "Array(LE W32)" (Proxy :: Proxy (Array (LE Word32))) (toLE <$> arbitrary)
+        , testCollection "Array(LE W64)" (Proxy :: Proxy (Array (LE Word64))) (toLE <$> arbitrary)
         ]
     ]
 

--- a/tests/Test/Foundation/ChunkedUArray.hs
+++ b/tests/Test/Foundation/ChunkedUArray.hs
@@ -12,6 +12,7 @@ import Foundation
 import Foundation.Collection
 import Foundation.Array
 import Foundation.Foreign
+import Foundation.Class.Storable
 
 import Test.Tasty
 import Test.Tasty.QuickCheck
@@ -64,7 +65,7 @@ testChunkedUArrayRefs = testGroup "ChunkedArray"
         ]
     ]
 
-testUnboxedForeign :: (PrimType e, Show e, Element a ~ e, Storable e)
+testUnboxedForeign :: (PrimType e, Show e, Element a ~ e, StorableFixed e)
                    => Proxy a -> Gen e -> [TestTree]
 testUnboxedForeign proxy genElement =
     [ testProperty "equal" $ withElementsM $ \fptr l ->

--- a/tests/Test/Foundation/Storable.hs
+++ b/tests/Test/Foundation/Storable.hs
@@ -10,6 +10,7 @@ module Test.Foundation.Storable
 
 import Foundation
 import Foundation.Class.Storable
+import Foundation.Primitive
 
 import qualified Foreign.Storable
 import qualified Foreign.Marshal.Alloc
@@ -47,7 +48,27 @@ testForeignStorableRefs = testGroup "Storable"
         , testPropertyStorableFixed "Double" (Proxy :: Proxy Double)
         , testPropertyStorableFixed "Float" (Proxy :: Proxy Float)
         ]
+    , testGroup "Endianness"
+        [ testPropertyBE "Word16" (Proxy :: Proxy Word16)
+        , testPropertyBE "Word32" (Proxy :: Proxy Word32)
+        , testPropertyBE "Word64" (Proxy :: Proxy Word64)
+        ]
     ]
+
+testPropertyBE :: (ByteSwap a, StorableFixed a, Arbitrary a, Eq a, Show a)
+               => LString
+               -> Proxy a
+               -> TestTree
+testPropertyBE name p = testGroup name
+    [ testProperty "fromBE . toBE == id" $ withProxy p $ \a ->
+        fromBE (toBE a) === a
+    , testProperty "fromLE . toLE == id" $ withProxy p $ \a ->
+        fromLE (toLE a) === a
+    ]
+  where
+    withProxy :: (ByteSwap a, StorableFixed a, Arbitrary a, Show a, Eq a)
+              => Proxy a -> (a -> Property) -> (a -> Property)
+    withProxy _ f = f
 
 testPropertyStorable :: (Storable a, Foreign.Storable.Storable a, Arbitrary a, Eq a, Show a)
                      => LString

--- a/tests/Test/Utils/Foreign.hs
+++ b/tests/Test/Utils/Foreign.hs
@@ -10,19 +10,19 @@ module Test.Utils.Foreign
 import           Foreign.Marshal.Alloc
 
 import           Foreign.Ptr
-import           Foreign.Storable
 import           Foundation
 import           Prelude (zip)
 import           Control.Monad (forM_)
 
 import           Foundation.Foreign
+import           Foundation.Class.Storable
 
-createPtr :: forall e . Storable e => [e] -> IO (FinalPtr e)
+createPtr :: forall e . StorableFixed e => [e] -> IO (FinalPtr e)
 createPtr l
     | null l    = toFinalPtr nullPtr (\_ -> return ())
     | otherwise = do
-        let szElem = sizeOf (undefined :: e)
+        let (Size szElem) = size (Proxy :: Proxy e)
             nbBytes = szElem * length l
         ptr <- mallocBytes nbBytes
-        forM_ (zip [0..] l) $ \(o, e) -> pokeElemOff ptr o e
+        forM_ (zip [0..] l) $ \(o, e) -> pokeOff ptr o e
         toFinalPtr ptr (\p -> free p)


### PR DESCRIPTION
This concept is imported from vincenthz/hs-memory. The idea is to be able to add information about the byte ordering on the type. This will replace the `htonl` and co from `Foundation.Bits`.