### PR TITLE
mark hostname as very unstable and compile it only when actually asked to

### DIFF
--- a/foundation.cabal
+++ b/foundation.cabal
@@ -38,6 +38,11 @@ source-repository head
   type: git
   location: https://github.com/haskell-foundation/foundation
 
+Flag experimental
+  Description:       Enable building experimental features, known as highly unstable or without good support cross-platform
+  Default:           False
+  Manual:            False
+
 Flag bench-all
   Description:       Add some comparaison benchmarks against other haskell libraries
   Default:           False
@@ -77,7 +82,6 @@ Library
                      Foundation.Monad.State
                      Foundation.Network.IPv4
                      Foundation.Network.IPv6
-                     Foundation.Network.HostName
                      Foundation.System.Info
                      Foundation.Strict
                      Foundation.Parser
@@ -170,6 +174,8 @@ Library
   C-sources:         cbits/foundation_random.c
                      cbits/foundation_network.c
 
+  if flag(experimental)
+    Exposed-modules: Foundation.Network.HostName
   if os(windows)
     Exposed-modules: Foundation.System.Bindings.Windows
     Other-modules:   Foundation.Foreign.MemoryMap.Windows


### PR DESCRIPTION
fix #238 

One could argue that this could be compiled only for non windows platform but I think this module might be removed by the end of the month and replaced with another API.

