### PR TITLE
add MonadReader and MonadState

### DIFF
--- a/Foundation/Monad/Reader.hs
+++ b/Foundation/Monad/Reader.hs
@@ -17,7 +17,7 @@ module Foundation.Monad.Reader
     , runReaderT
     ) where
 
-import Foundation.Internal.Base (($), (.), const, id, (<$>))
+import Foundation.Internal.Base (($), (.), const, id)
 import Foundation.Monad.Base
 
 class Monad m => MonadReader r m where
@@ -35,7 +35,7 @@ class Monad m => MonadReader r m where
     -- | Retrieves a function of the current environment.
     reader :: (r -> a) -- ^ The selector function to apply to the environment.
            -> m a
-    reader f = f <$> ask
+    reader f = ask >>= return . f
 
 -- | Retrieves a function of the current environment.
 asks :: MonadReader r m

--- a/Foundation/Monad/Reader.hs
+++ b/Foundation/Monad/Reader.hs
@@ -3,13 +3,45 @@
 --
 -- This is useful to keep a non-modifiable value
 -- in a context
+
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleInstances #-}
+
 module Foundation.Monad.Reader
-    ( ReaderT
+    ( -- * MonadReader
+      MonadReader(..)
+    , asks
+
+    , -- * ReaderT
+      ReaderT
     , runReaderT
     ) where
 
-import Foundation.Internal.Base (($), (.), const)
+import Foundation.Internal.Base (($), (.), const, id, (<$>))
 import Foundation.Monad.Base
+
+class Monad m => MonadReader r m where
+    {-# MINIMAL (ask | reader), local #-}
+
+    -- | Retrieves the monad environment.
+    ask   :: m r
+    ask = reader id
+
+    -- | Executes a computation in a modified environment.
+    local :: (r -> r) -- ^ The function to modify the environment.
+          -> m a      -- ^ @Reader@ to run in the modified environment.
+          -> m a
+
+    -- | Retrieves a function of the current environment.
+    reader :: (r -> a) -- ^ The selector function to apply to the environment.
+           -> m a
+    reader f = f <$> ask
+
+-- | Retrieves a function of the current environment.
+asks :: MonadReader r m
+     => (r -> a) -- ^ The selector function to apply to the environment.
+     -> m a
+asks = reader
 
 -- | Reader Transformer
 newtype ReaderT r m a = ReaderT { runReaderT :: r -> m a }
@@ -47,3 +79,7 @@ instance MonadThrow m => MonadThrow (ReaderT r m) where
 
 instance MonadCatch m => MonadCatch (ReaderT r m) where
     catch (ReaderT m) c = ReaderT $ \r -> m r `catch` (\e -> runReaderT (c e) r)
+
+instance Monad m => MonadReader r (ReaderT r m) where
+    ask = ReaderT return
+    local f m = ReaderT $ runReaderT m . f

--- a/Foundation/Monad/State.hs
+++ b/Foundation/Monad/State.hs
@@ -1,11 +1,65 @@
 {-# LANGUAGE TupleSections #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
 module Foundation.Monad.State
-    ( StateT
+    ( -- * MonadState
+      MonadState(..)
+    , modify
+    , modify'
+    , gets
+
+    , -- * StateT
+      StateT
     , runStateT
     ) where
 
-import Foundation.Internal.Base (($), (.))
+import Foundation.Internal.Base (($), (.), seq)
 import Foundation.Monad.Base
+
+class Monad m => MonadState s m | m -> s where
+    {-# MINIMAL state | get, put #-}
+    -- | Return the state from the internals of the monad.
+    get :: m s
+    get = state (\s -> (s, s))
+
+    -- | Replace the state inside the monad.
+    put :: s -> m ()
+    put s = state (\_ -> ((), s))
+
+    -- | Embed a simple state action into the monad.
+    state :: (s -> (a, s)) -> m a
+    state f = do
+        s <- get
+        let ~(a, s') = f s
+        put s'
+        return a
+
+-- | Monadic state transformer.
+--
+--      Maps an old state to a new state inside a state monad.
+--      The old state is thrown away.
+--
+-- >      Main> :t modify ((+1) :: Int -> Int)
+-- >      modify (...) :: (MonadState Int a) => a ()
+--
+--    This says that @modify (+1)@ acts over any
+--    Monad that is a member of the @MonadState@ class,
+--    with an @Int@ state.
+modify :: MonadState s m => (s -> s) -> m ()
+modify f = state (\s -> ((), f s))
+
+-- | A variant of 'modify' in which the computation is strict in the
+-- new state.
+modify' :: MonadState s m => (s -> s) -> m ()
+modify' f = state (\s -> let s' = f s in s' `seq` ((), s'))
+
+-- | Gets specific component of the state, using a projection function
+-- supplied.
+gets :: MonadState s m => (s -> a) -> m a
+gets f = do
+    s <- get
+    return (f s)
 
 -- | State Transformer
 newtype StateT s m a = StateT { runStateT :: s -> m (a, s) }
@@ -46,3 +100,8 @@ instance (Functor m, MonadThrow m) => MonadThrow (StateT s m) where
 
 instance (Functor m, MonadCatch m) => MonadCatch (StateT s m) where
     catch (StateT m) c = StateT $ \s1 -> m s1 `catch` (\e -> runStateT (c e) s1)
+
+instance Monad m => MonadState s (StateT s m) where
+  get = state $ \ s -> (s, s)
+  state f = StateT (return . f)
+  put s = state $ \ _ -> ((), s)


### PR DESCRIPTION
add the missing classes and functions to make use of `ReaderT` and `StateT`.

fix #246 