### PR TITLE
Allow building with Win32-2.4.0.0 or later

### DIFF
--- a/Foundation/Internal/NumLiteral.hs
+++ b/Foundation/Internal/NumLiteral.hs
@@ -21,14 +21,14 @@ import           Foreign.C.Types
 import           System.Posix.Types
 
 -- | Integral Literal support
--- 
+--
 -- e.g. 123 :: Integer
 --      123 :: Word8
 class Integral a where
     fromInteger :: Integer -> a
 
 -- | Fractional Literal support
--- 
+--
 -- e.g. 1.2  :: Double
 --      0.03 :: Float
 class Fractional a where
@@ -69,6 +69,8 @@ instance Integral CSize where
 instance Integral CInt where
     fromInteger a = Prelude.fromInteger a
 instance Integral COff where
+    fromInteger a = Prelude.fromInteger a
+instance Integral CUIntPtr where
     fromInteger a = Prelude.fromInteger a
 
 instance Integral Float where


### PR DESCRIPTION
In `Win32-2.4.0.0`, the `SIZE_T` type synonym was changed from `DWORD` to `ULONG_PTR`, the latter of which is a synonym for `CUIntPtr`. Unfortunately, there's no `Integral` instance for `CUIntPtr` in `foundation`, so you get this error when trying to build:

```
Building foundation-0.0.7...
Preprocessing library foundation-0.0.7...
[122 of 124] Compiling Foundation.Foreign.MemoryMap.Windows ( Foundation\Foreign\MemoryMap\Windows.hs, dist\build\Foundation\Foreign\MemoryMap\Windows.o )

Foundation\Foreign\MemoryMap\Windows.hs:26:58: error:
    * No instance for (Integral System.Win32.Types.SIZE_T)
        arising from the literal `0'
    * In the fourth argument of `mapViewOfFile', namely `0'
      In a stmt of a 'do' block:
        ptr <- mapViewOfFile filemap fILE_MAP_READ 0 0
      In the second argument of `($)', namely
        `do ptr <- mapViewOfFile filemap fILE_MAP_READ 0 0
            return
              $ FileMapping
                  ptr (FileSize $ bhfiSize fileInfo) (unmapViewOfFile ptr)'
   |
26 |             ptr <- mapViewOfFile filemap fILE_MAP_READ 0 0
   |                                                          ^
```

This PR adds such an instance.

This is needed to build `foundation` on Windows using GHC 8.2.1, since it is bundled with `Win32-2.5.4.1`.