### PR TITLE
Block & MutableBlock

### DIFF
--- a/Foundation/Array.hs
+++ b/Foundation/Array.hs
@@ -24,7 +24,7 @@ module Foundation.Array
     , OutOfBound
     ) where
 
-import           Foundation.Array.Common
+import           Foundation.Primitive.Exception
 import           Foundation.Array.Boxed
 import           Foundation.Array.Unboxed
 import           Foundation.Array.Unboxed.Mutable

--- a/Foundation/Array/Bitmap.hs
+++ b/Foundation/Array/Bitmap.hs
@@ -32,7 +32,7 @@ module Foundation.Array.Bitmap
 import           Foundation.Array.Unboxed (UArray)
 import qualified Foundation.Array.Unboxed as A
 import           Foundation.Array.Unboxed.Mutable (MUArray)
-import           Foundation.Array.Common
+import           Foundation.Primitive.Exception
 import           Foundation.Internal.Base
 import           Foundation.Primitive.Types.OffsetSize
 import           Foundation.Primitive.Monad

--- a/Foundation/Array/Boxed.hs
+++ b/Foundation/Array/Boxed.hs
@@ -74,7 +74,7 @@ import           Foundation.Primitive.Types
 import           Foundation.Primitive.NormalForm
 import           Foundation.Primitive.IntegralConv
 import           Foundation.Primitive.Monad
-import           Foundation.Array.Common
+import           Foundation.Primitive.Exception
 import           Foundation.Boot.Builder
 import qualified Foundation.Boot.List as List
 import qualified Prelude

--- a/Foundation/Array/Chunked/Unboxed.hs
+++ b/Foundation/Array/Chunked/Unboxed.hs
@@ -21,7 +21,7 @@ import           Data.Typeable
 import           Control.Arrow ((***))
 import           Foundation.Array.Boxed (Array)
 import qualified Foundation.Array.Boxed as A
-import           Foundation.Array.Common
+import           Foundation.Primitive.Exception
 import           Foundation.Array.Unboxed (UArray)
 import qualified Foundation.Array.Unboxed as U
 import           Foundation.Class.Bifunctor

--- a/Foundation/Array/Internal.hs
+++ b/Foundation/Array/Internal.hs
@@ -15,6 +15,7 @@ module Foundation.Array.Internal
     ( UArray(..)
     , fromForeignPtr
     , withPtr
+    , copyToPtr
     , recast
     , toHexadecimal
     -- * Mutable facilities

--- a/Foundation/Array/Unboxed.hs
+++ b/Foundation/Array/Unboxed.hs
@@ -513,13 +513,13 @@ copyToPtr :: forall ty prim . (PrimType ty, PrimMonad prim)
 copyToPtr (UVecBA start sz _ ba) (Ptr p) = primitive $ \s1 ->
     (# copyByteArrayToAddr# ba offset p szBytes s1, () #)
   where
-    !(Offset (I# offset)) = offsetOfE (primSizeInBytes (Proxy :: Proxy ty)) start
+    !(Offset (I# offset)) = primOffsetOfE start
     !(Size (I# szBytes)) = sizeInBytes sz
 copyToPtr (UVecAddr start sz fptr) dst =
     unsafePrimFromIO $ withFinalPtr fptr $ \ptr -> copyBytes dst (ptr `plusPtr` os) szBytes
   where
-    !(Offset os)   = offsetOfE (primSizeInBytes (Proxy :: Proxy ty)) start
-    (Size szBytes) = sizeInBytes sz
+    !(Offset os)    = primOffsetOfE start
+    !(Size szBytes) = sizeInBytes sz
 
 withPtr :: (PrimMonad prim, PrimType ty)
         => UArray ty

--- a/Foundation/Array/Unboxed.hs
+++ b/Foundation/Array/Unboxed.hs
@@ -511,7 +511,7 @@ copyToPtr :: forall ty prim . (PrimType ty, PrimMonad prim)
           -> Ptr ty    -- ^ The destination address where the copy is going to start
           -> prim ()
 copyToPtr (UVecBA start sz _ ba) (Ptr p) = primitive $ \s1 ->
-    (# copyByteArrayToAddr# ba offset p szBytes s1, () #)
+    (# compatCopyByteArrayToAddr# ba offset p szBytes s1, () #)
   where
     !(Offset (I# offset)) = primOffsetOfE start
     !(Size (I# szBytes)) = sizeInBytes sz
@@ -520,6 +520,7 @@ copyToPtr (UVecAddr start sz fptr) dst =
   where
     !(Offset os)    = primOffsetOfE start
     !(Size szBytes) = sizeInBytes sz
+
 data TmpBA = TmpBA ByteArray#
 
 withPtr :: (PrimMonad prim, PrimType ty)

--- a/Foundation/Array/Unboxed.hs
+++ b/Foundation/Array/Unboxed.hs
@@ -108,7 +108,7 @@ import           Foundation.Primitive.NormalForm
 import           Foundation.Primitive.IntegralConv
 import           Foundation.Primitive.FinalPtr
 import           Foundation.Primitive.Utils
-import           Foundation.Array.Common
+import           Foundation.Primitive.Exception
 import           Foundation.Array.Unboxed.Mutable hiding (sub)
 import           Foundation.Numerical
 import           Foundation.Boot.Builder

--- a/Foundation/Array/Unboxed.hs
+++ b/Foundation/Array/Unboxed.hs
@@ -547,6 +547,7 @@ withPtr vec@(UVecBA start _ pstatus a) f
   where
     sz           = primSizeInBytes (vectorProxyTy vec)
     !(Offset os) = offsetOfE sz start
+{-# INLINE withPtr #-}
 
 recast :: (PrimType a, PrimType b) => UArray a -> UArray b
 recast = recast_ Proxy Proxy

--- a/Foundation/Array/Unboxed/Mutable.hs
+++ b/Foundation/Array/Unboxed/Mutable.hs
@@ -47,7 +47,7 @@ import           Foundation.Primitive.Types.OffsetSize
 import           Foundation.Primitive.Monad
 import           Foundation.Primitive.Types
 import           Foundation.Primitive.FinalPtr
-import           Foundation.Array.Common
+import           Foundation.Primitive.Exception
 import           Foundation.Numerical
 -- import           Foreign.Marshal.Utils (copyBytes)
 

--- a/Foundation/Collection/Collection.hs
+++ b/Foundation/Collection/Collection.hs
@@ -31,6 +31,7 @@ module Foundation.Collection.Collection
 import           Foundation.Internal.Base
 import           Foundation.Collection.Element
 import qualified Data.List
+import qualified Foundation.Primitive.Block as BLK
 import qualified Foundation.Array.Unboxed as UV
 import qualified Foundation.Array.Boxed as BA
 import qualified Foundation.String.UTF8 as S
@@ -108,6 +109,15 @@ instance Collection [a] where
 
     any = Data.List.any
     all = Data.List.all
+
+instance UV.PrimType ty => Collection (BLK.Block ty) where
+    null = (==) 0 . BLK.length
+    length = BLK.length
+    elem = BLK.elem
+    minimum = Data.List.minimum . toList . getNonEmpty
+    maximum = Data.List.maximum . toList . getNonEmpty
+    all = BLK.all
+    any = BLK.any
 
 instance UV.PrimType ty => Collection (UV.UArray ty) where
     null = UV.null

--- a/Foundation/Collection/Copy.hs
+++ b/Foundation/Collection/Copy.hs
@@ -2,6 +2,9 @@ module Foundation.Collection.Copy
     ( Copy(..)
     ) where
 
+import           GHC.ST (runST)
+import           Foundation.Internal.Base ((>>=))
+import qualified Foundation.Primitive.Block as BLK
 import qualified Foundation.Array.Unboxed as UA
 import qualified Foundation.Array.Boxed as BA
 import qualified Foundation.String.UTF8 as S
@@ -10,6 +13,8 @@ class Copy a where
     copy :: a -> a
 instance Copy [ty] where
     copy a = a
+instance UA.PrimType ty => Copy (BLK.Block ty) where
+    copy blk = runST (BLK.thaw blk >>= BLK.unsafeFreeze)
 instance UA.PrimType ty => Copy (UA.UArray ty) where
     copy = UA.copy
 instance Copy (BA.Array ty) where

--- a/Foundation/Collection/Element.hs
+++ b/Foundation/Collection/Element.hs
@@ -10,6 +10,7 @@ module Foundation.Collection.Element
     ) where
 
 import Foundation.Internal.Base
+import Foundation.Primitive.Block (Block)
 import Foundation.Array.Unboxed (UArray)
 import Foundation.Array.Boxed (Array)
 import Foundation.String.UTF8 (String)
@@ -17,6 +18,7 @@ import Foundation.String.UTF8 (String)
 -- | Element type of a collection
 type family Element container
 type instance Element [a] = a
+type instance Element (Block ty) = ty
 type instance Element (UArray ty) = ty
 type instance Element (Array ty) = ty
 type instance Element String = Char

--- a/Foundation/Collection/Foldable.hs
+++ b/Foundation/Collection/Foldable.hs
@@ -15,6 +15,7 @@ import           Foundation.Internal.Base
 import           Foundation.Collection.Element
 import qualified Data.List
 import qualified Foundation.Array.Unboxed as UV
+import qualified Foundation.Primitive.Block as BLK
 import qualified Foundation.Array.Boxed as BA
 
 -- | Give the ability to fold a collection on itself
@@ -59,3 +60,7 @@ instance Foldable (BA.Array ty) where
     foldl = BA.foldl
     foldr = BA.foldr
     foldl' = BA.foldl'
+instance UV.PrimType ty => Foldable (BLK.Block ty) where
+    foldl = BLK.foldl
+    foldr = BLK.foldr
+    foldl' = BLK.foldl'

--- a/Foundation/Collection/Indexed.hs
+++ b/Foundation/Collection/Indexed.hs
@@ -17,7 +17,7 @@ import           Foundation.Collection.Element
 import qualified Data.List
 import qualified Foundation.Array.Unboxed as UV
 import qualified Foundation.Array.Boxed as BA
-import qualified Foundation.Array.Common as A
+import qualified Foundation.Primitive.Exception as A
 import qualified Foundation.String.UTF8 as S
 
 -- | Collection of elements that can indexed by int

--- a/Foundation/Collection/Indexed.hs
+++ b/Foundation/Collection/Indexed.hs
@@ -15,6 +15,7 @@ import           Foundation.Internal.Base
 import           Foundation.Primitive.Types.OffsetSize
 import           Foundation.Collection.Element
 import qualified Data.List
+import qualified Foundation.Primitive.Block as BLK
 import qualified Foundation.Array.Unboxed as UV
 import qualified Foundation.Array.Boxed as BA
 import qualified Foundation.Primitive.Exception as A
@@ -32,6 +33,18 @@ instance IndexedCollection [a] where
                         []  -> Nothing
                         x:_ -> Just x
     findIndex predicate = fmap Offset . Data.List.findIndex predicate
+
+instance UV.PrimType ty => IndexedCollection (BLK.Block ty) where
+    (!) l n
+        | A.isOutOfBound n (BLK.lengthSize l) = Nothing
+        | otherwise                           = Just $ BLK.index l n
+    findIndex predicate c = loop 0
+      where
+        !len = BLK.lengthSize c
+        loop i
+            | i .==# len                      = Nothing
+            | predicate (BLK.unsafeIndex c i) = Just i
+            | otherwise                       = Nothing
 
 instance UV.PrimType ty => IndexedCollection (UV.UArray ty) where
     (!) l n

--- a/Foundation/Collection/Mutable.hs
+++ b/Foundation/Collection/Mutable.hs
@@ -9,9 +9,11 @@ module Foundation.Collection.Mutable
     ( MutableCollection(..)
     ) where
 
-import Foundation.Primitive.Monad
-import Foundation.Primitive.Types.OffsetSize
-import Foundation.Internal.Base
+import           Foundation.Primitive.Monad
+import           Foundation.Primitive.Types.OffsetSize
+import qualified Foundation.Primitive.Block         as BLK
+import qualified Foundation.Primitive.Block.Mutable as BLK
+import           Foundation.Internal.Base
 
 import qualified Foundation.Array.Unboxed.Mutable as MUV
 import qualified Foundation.Array.Unboxed as UV
@@ -56,6 +58,23 @@ instance UV.PrimType ty => MutableCollection (MUV.MUArray ty) where
     mutUnsafeRead = MUV.unsafeRead
     mutWrite = MUV.write
     mutRead = MUV.read
+
+instance UV.PrimType ty => MutableCollection (BLK.MutableBlock ty) where
+    type MutableFreezed (BLK.MutableBlock ty) = BLK.Block ty
+    type MutableKey (BLK.MutableBlock ty) = Offset ty
+    type MutableValue (BLK.MutableBlock ty) = ty
+
+    thaw = BLK.thaw
+    freeze = BLK.freeze
+    unsafeThaw = BLK.unsafeThaw
+    unsafeFreeze = BLK.unsafeFreeze
+
+    mutNew i = BLK.new (Size i)
+
+    mutUnsafeWrite = BLK.unsafeWrite
+    mutUnsafeRead = BLK.unsafeRead
+    mutWrite = BLK.write
+    mutRead = BLK.read
 
 instance MutableCollection (BA.MArray ty) where
     type MutableFreezed (BA.MArray ty) = BA.Array ty

--- a/Foundation/Collection/Sequential.hs
+++ b/Foundation/Collection/Sequential.hs
@@ -18,11 +18,13 @@ module Foundation.Collection.Sequential
 
 import           Foundation.Internal.Base
 import           Foundation.Primitive.IntegralConv
+import           Foundation.Primitive.Types.OffsetSize
 import           Foundation.Collection.Element
 import           Foundation.Collection.Collection
 import qualified Foundation.Collection.List as ListExtra
 import qualified Data.List
 import qualified Foundation.Array.Unboxed as UV
+import qualified Foundation.Primitive.Block as BLK
 import qualified Foundation.Array.Boxed as BA
 import qualified Foundation.String.UTF8 as S
 
@@ -194,6 +196,24 @@ instance Sequential [a] where
     isPrefixOf = Data.List.isPrefixOf
     isSuffixOf = Data.List.isSuffixOf
 
+instance UV.PrimType ty => Sequential (BLK.Block ty) where
+    splitAt n = BLK.splitAt (Size n)
+    revSplitAt n = BLK.revSplitAt (Size n)
+    splitOn = BLK.splitOn
+    break = BLK.break
+    intersperse = BLK.intersperse
+    span = BLK.span
+    filter = BLK.filter
+    reverse = BLK.reverse
+    uncons = BLK.uncons
+    unsnoc = BLK.unsnoc
+    snoc = BLK.snoc
+    cons = BLK.cons
+    find = BLK.find
+    sortBy = BLK.sortBy
+    singleton = BLK.singleton
+    replicate = BLK.replicate
+
 instance UV.PrimType ty => Sequential (UV.UArray ty) where
     take = UV.take
     revTake = UV.revTake
@@ -236,7 +256,7 @@ instance Sequential (BA.Array ty) where
     cons = BA.cons
     find = BA.find
     sortBy = BA.sortBy
-    singleton = fromList . (:[])
+    singleton = BA.singleton
     replicate = BA.replicate
 
 instance Sequential S.String where

--- a/Foundation/Internal/Primitive.hs
+++ b/Foundation/Internal/Primitive.hs
@@ -14,6 +14,7 @@ module Foundation.Internal.Primitive
     , compatAndI#
     , compatQuotRemInt#
     , compatCopyAddrToByteArray#
+    , compatCopyByteArrayToAddr#
     , compatMkWeak#
     , compatGetSizeofMutableByteArray#
     , compatShrinkMutableByteArray#
@@ -94,6 +95,24 @@ compatCopyAddrToByteArray# addr ba ofs sz stini =
                 (# st2, w #) -> loop (o +# 1#) (i +# 1#) (writeWord8Array# ba o w st2)
 #endif
 {-# INLINE compatCopyAddrToByteArray# #-}
+
+-- | A version friendly fo copyByteArrayToAddr#
+--
+-- only available from GHC 7.8
+compatCopyByteArrayToAddr# :: ByteArray# -> Int# -> Addr# -> Int# -> State# s -> State# s
+#if MIN_VERSION_base(4,7,0)
+compatCopyByteArrayToAddr# = copyByteArrayToAddr#
+#else
+compatCopyByteArrayToAddr# ba ofs addrIni sz stini =
+    loop ofs 0# stini
+  where
+    loop o i st
+        | bool# (i ==# sz)  = st
+        | Prelude.otherwise =
+            case readWord8Array# ba o st of
+                (# st2, w #) -> loop (o +# 1#) (i +# 1#) (writeWord8OffAddr# ba i w st2)
+#endif
+{-# INLINE compatCopyByteArrayToAddr# #-}
 
 -- | A mkWeak# version that keep working on 8.0
 --

--- a/Foundation/Internal/Primitive.hs
+++ b/Foundation/Internal/Primitive.hs
@@ -103,14 +103,13 @@ compatCopyByteArrayToAddr# :: ByteArray# -> Int# -> Addr# -> Int# -> State# s ->
 #if MIN_VERSION_base(4,7,0)
 compatCopyByteArrayToAddr# = copyByteArrayToAddr#
 #else
-compatCopyByteArrayToAddr# ba ofs addrIni sz stini =
+compatCopyByteArrayToAddr# ba ofs addr sz stini =
     loop ofs 0# stini
   where
     loop o i st
         | bool# (i ==# sz)  = st
         | Prelude.otherwise =
-            case readWord8Array# ba o st of
-                (# st2, w #) -> loop (o +# 1#) (i +# 1#) (writeWord8OffAddr# ba i w st2)
+            loop (o +# 1#) (i +# 1#) (writeWord8OffAddr# addr i (indexWord8Array# ba o) st)
 #endif
 {-# INLINE compatCopyByteArrayToAddr# #-}
 

--- a/Foundation/Primitive.hs
+++ b/Foundation/Primitive.hs
@@ -31,6 +31,10 @@ module Foundation.Primitive
 
     -- * These
     , These(..)
+
+    -- * Block of memory
+    , Block
+    , MutableBlock
     ) where
 
 import Foundation.Primitive.Types
@@ -39,3 +43,4 @@ import Foundation.Primitive.Endianness
 import Foundation.Primitive.IntegralConv
 import Foundation.Primitive.NormalForm
 import Foundation.Primitive.These
+import Foundation.Primitive.Block

--- a/Foundation/Primitive/Block.hs
+++ b/Foundation/Primitive/Block.hs
@@ -1,0 +1,333 @@
+--
+-- A block of memory that contains elements of a type,
+-- very similar to an unboxed array but with the key difference:
+--
+-- * It doesn't have slicing capability (no cheap take or drop)
+-- * It consume less memory: 1 Offset, 1 Size, 1 Pinning status trimmed
+-- * It's unpackable in any constructor
+-- * It uses unpinned memory by default
+--
+{-# LANGUAGE MagicHash           #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE UnboxedTuples       #-}
+module Foundation.Primitive.Block
+    ( Block(..)
+    , MutableBlock(..)
+    -- * Properties
+    , length
+    , lengthSize
+    -- * Lowlevel functions
+    , unsafeThaw
+    , unsafeFreeze
+    , unsafeIndex
+    , thaw
+    , copy
+    -- * safer api
+    , empty
+    , create
+    , singleton
+    , replicate
+    , fromList
+    , toList
+    , equal
+    , bcompare
+    , append
+    , concat
+    , index
+    , map
+    , foldl
+    , foldl'
+    , foldr
+    , cons
+    , snoc
+    , uncons
+    , unsnoc
+    , sub
+    , splitAt
+    , break
+    , span
+    ) where
+
+import           GHC.Prim
+import           GHC.Types
+--import           GHC.Ptr
+import           GHC.ST
+import qualified Data.List
+import           Foundation.Internal.Base hiding (fromList, toList)
+import           Foundation.Internal.Proxy
+import           Foundation.Primitive.Types.OffsetSize
+import           Foundation.Primitive.Monad
+import           Foundation.Primitive.Exception
+import           Foundation.Primitive.IntegralConv
+import           Foundation.Primitive.Types
+import qualified Foundation.Primitive.Block.Mutable as M
+import           Foundation.Primitive.Block.Mutable (Block(..), MutableBlock(..), new, unsafeThaw, unsafeFreeze)
+import           Foundation.Numerical
+
+-- | Create an empty block of memory
+empty :: Block ty
+empty = Block ba where !(Block ba) = empty_
+
+empty_ :: Block ()
+empty_ = runST $ primitive $ \s1 ->
+    case newByteArray# 0# s1           of { (# s2, mba #) ->
+    case unsafeFreezeByteArray# mba s2 of { (# s3, ba  #) ->
+        (# s3, Block ba #) }}
+
+-- | return the number of elements of the array.
+length :: PrimType ty => Block ty -> Int
+length a = let (Size len) = lengthSize a in len
+{-# INLINE[1] length #-}
+
+lengthSize :: forall ty . PrimType ty => Block ty -> Size ty
+lengthSize (Block ba) =
+    let !(Size (I# szBits)) = primSizeInBytes (Proxy :: Proxy ty)
+        !elems              = quotInt# (sizeofByteArray# ba) szBits
+     in Size (I# elems)
+{-# INLINE[1] lengthSize #-}
+
+lengthBytes :: Block ty -> Size Word8
+lengthBytes (Block ba) = Size (I# (sizeofByteArray# ba))
+{-# INLINE[1] lengthBytes #-}
+
+-- | Return the element at a specific index from an array without bounds checking.
+--
+-- Reading from invalid memory can return unpredictable and invalid values.
+-- use 'index' if unsure.
+unsafeIndex :: forall ty . PrimType ty => Block ty -> Offset ty -> ty
+unsafeIndex (Block ba) n = primBaIndex ba n
+{-# INLINE unsafeIndex #-}
+
+-- | Create a new array of size @n by settings each cells through the
+-- function @f.
+create :: forall ty . PrimType ty
+       => Size ty           -- ^ the size of the block (in element of ty)
+       -> (Offset ty -> ty) -- ^ the function that set the value at the index
+       -> Block ty          -- ^ the array created
+create n initializer
+    | n == 0    = empty
+    | otherwise = runST $ do
+        mb <- new n
+        M.iterSet initializer mb
+        unsafeFreeze mb
+
+singleton :: PrimType ty => ty -> Block ty
+singleton ty = create 1 (const ty)
+
+replicate :: PrimType ty => Word -> ty -> Block ty
+replicate sz ty = create (Size (integralCast sz)) (const ty)
+
+-- | make a block from a list of elements.
+fromList :: PrimType ty => [ty] -> Block ty
+fromList l = runST $ do
+    ma <- new (Size len)
+    iter 0 l $ \i x -> M.unsafeWrite ma i x
+    unsafeFreeze ma
+  where len = Data.List.length l
+        iter _  []     _ = return ()
+        iter !i (x:xs) z = z i x >> iter (i+1) xs z
+
+-- | transform a block to a list.
+toList :: forall ty . PrimType ty => Block ty -> [ty]
+toList blk@(Block ba)
+    | len == 0  = []
+    | otherwise = loop 0
+  where
+    !len = lengthSize blk
+    loop !i | i .==# len = []
+            | otherwise  = primBaIndex ba i : loop (i+1)
+
+-- | Check if two vectors are identical
+equal :: (PrimType ty, Eq ty) => Block ty -> Block ty -> Bool
+equal a b
+    | la /= lb  = False
+    | otherwise = loop 0
+  where
+    !la = lengthSize a
+    !lb = lengthSize b
+    loop n | n .==# la = True
+           | otherwise = (unsafeIndex a n == unsafeIndex b n) && loop (n+1)
+
+-- | Compare 2 vectors
+bcompare :: (Ord ty, PrimType ty) => Block ty -> Block ty -> Ordering
+bcompare a b = loop 0
+  where
+    !la = lengthSize a
+    !lb = lengthSize b
+    loop n
+        | n .==# la = if la == lb then EQ else LT
+        | n .==# lb = GT
+        | otherwise =
+            case unsafeIndex a n `compare` unsafeIndex b n of
+                EQ -> loop (n+1)
+                r  -> r
+
+-- | Append 2 arrays together by creating a new bigger array
+append :: Block ty -> Block ty -> Block ty
+append a b
+    | la == 0 = b
+    | lb == 0 = a
+    | otherwise = runST $ do
+        r  <- M.unsafeNew (la+lb)
+        M.unsafeCopyBytesRO r 0                 a 0 la
+        M.unsafeCopyBytesRO r (sizeAsOffset la) b 0 lb
+        unsafeFreeze r
+  where
+    !la = lengthBytes a
+    !lb = lengthBytes b
+
+concat :: [Block ty] -> Block ty
+concat [] = empty
+concat l  =
+    case filterAndSum 0 [] l of
+        (_,[])            -> empty
+        (_,[x])           -> x
+        (totalLen,chunks) -> runST $ do
+            r <- M.unsafeNew totalLen
+            doCopy r 0 chunks
+            unsafeFreeze r
+  where
+    -- TODO would go faster not to reverse but pack from the end instead
+    filterAndSum !totalLen acc []     = (totalLen, Data.List.reverse acc)
+    filterAndSum !totalLen acc (x:xs)
+        | len == 0  = filterAndSum totalLen acc xs
+        | otherwise = filterAndSum (len+totalLen) (x:acc) xs
+      where len = lengthBytes x
+
+    doCopy _ _ []     = return ()
+    doCopy r i (x:xs) = do
+        M.unsafeCopyBytesRO r i x 0 lx
+        doCopy r (i `offsetPlusE` lx) xs
+      where !lx = lengthBytes x
+
+-- | Thaw a Block into a MutableBlock
+--
+-- the Block is not modified, instead a new Mutable Block is created
+-- and its content is copied to the mutable block
+thaw :: (PrimMonad prim, PrimType ty) => Block ty -> prim (MutableBlock ty (PrimState prim))
+thaw array = do
+    ma <- M.unsafeNew (lengthBytes array)
+    M.unsafeCopyBytesRO ma 0 array 0 (lengthBytes array)
+    return ma
+{-# INLINE thaw #-}
+
+-- | Copy every cells of an existing Block to a new Block
+copy :: PrimType ty => Block ty -> Block ty
+copy array = runST (thaw array >>= unsafeFreeze)
+
+-- | Return the element at a specific index from an array.
+--
+-- If the index @n is out of bounds, an error is raised.
+index :: PrimType ty => Block ty -> Offset ty -> ty
+index array n
+    | isOutOfBound n len = outOfBound OOB_Index n len
+    | otherwise          = unsafeIndex array n
+  where
+    !len = lengthSize array
+{-# INLINE index #-}
+
+-- | Map all element 'a' from a block to a new block of 'b'
+map :: (PrimType a, PrimType b) => (a -> b) -> Block a -> Block b
+map f a = create lenB (\i -> f $ unsafeIndex a (offsetCast Proxy i))
+  where !lenB = sizeCast (Proxy :: Proxy (a -> b)) (lengthSize a)
+
+foldl :: PrimType ty => (a -> ty -> a) -> a -> Block ty -> a
+foldl f initialAcc vec = loop 0 initialAcc
+  where
+    !len = lengthSize vec
+    loop i acc
+        | i .==# len = acc
+        | otherwise  = loop (i+1) (f acc (unsafeIndex vec i))
+
+foldr :: PrimType ty => (ty -> a -> a) -> a -> Block ty -> a
+foldr f initialAcc vec = loop 0
+  where
+    !len = lengthSize vec
+    loop i
+        | i .==# len = initialAcc
+        | otherwise  = unsafeIndex vec i `f` loop (i+1)
+
+foldl' :: PrimType ty => (a -> ty -> a) -> a -> Block ty -> a
+foldl' f initialAcc vec = loop 0 initialAcc
+  where
+    !len = lengthSize vec
+    loop i !acc
+        | i .==# len = acc
+        | otherwise  = loop (i+1) (f acc (unsafeIndex vec i))
+
+cons :: PrimType ty => ty -> Block ty -> Block ty
+cons e vec
+    | len == 0  = singleton e
+    | otherwise = runST $ do
+        muv <- new (len + 1)
+        M.unsafeCopyElementsRO muv 1 vec 0 len
+        M.unsafeWrite muv 0 e
+        unsafeFreeze muv
+  where
+    !len = lengthSize vec
+
+snoc :: PrimType ty => Block ty -> ty -> Block ty
+snoc vec e
+    | len == Size 0 = singleton e
+    | otherwise     = runST $ do
+        muv <- new (len + 1)
+        M.unsafeCopyElementsRO muv 0 vec 0 len
+        M.unsafeWrite muv (0 `offsetPlusE` lengthSize vec) e
+        unsafeFreeze muv
+  where
+     !len = lengthSize vec
+
+sub :: PrimType ty => Block ty -> Offset ty -> Offset ty -> Block ty
+sub vec start end
+    | start >= end = empty
+    | otherwise    = runST $ do
+        dst <- new len
+        M.unsafeCopyElementsRO dst 0 vec start newLen
+        unsafeFreeze dst
+  where
+    newLen = end' - start
+    end' = min end (start `offsetPlusE` (end - start))
+    !len = lengthSize vec
+
+uncons :: PrimType ty => Block ty -> Maybe (ty, Block ty)
+uncons vec
+    | nbElems == 0 = Nothing
+    | otherwise    = Just (unsafeIndex vec 0, sub vec 1 (0 `offsetPlusE` nbElems))
+  where
+    !nbElems = lengthSize vec
+
+unsnoc :: PrimType ty => Block ty -> Maybe (Block ty, ty)
+unsnoc vec
+    | nbElems == 0 = Nothing
+    | otherwise    = Just (sub vec 0 lastElem, unsafeIndex vec lastElem)
+  where
+    !lastElem = 0 `offsetPlusE` (nbElems - 1)
+    !nbElems = lengthSize vec
+
+splitAt :: PrimType ty => Size ty -> Block ty -> (Block ty, Block ty)
+splitAt nbElems v
+    | nbElems <= 0 = (empty, v)
+    | n == vlen    = (v, empty)
+    | otherwise    = runST $ do
+        left  <- new nbElems
+        right <- new (vlen - nbElems)
+        M.unsafeCopyElementsRO left  0 v 0                      nbElems
+        M.unsafeCopyElementsRO right 0 v (sizeAsOffset nbElems) (vlen - nbElems)
+
+        (,) <$> unsafeFreeze left <*> unsafeFreeze right
+  where
+    n    = min nbElems vlen
+    vlen = lengthSize v
+
+break :: PrimType ty => (ty -> Bool) -> Block ty -> (Block ty, Block ty)
+break predicate blk = findBreak 0
+  where
+    !len = lengthSize blk
+    findBreak !i
+        | i .==# len                    = (blk, empty)
+        | predicate (unsafeIndex blk i) = splitAt (offsetAsSize i) blk
+        | otherwise                     = findBreak (i + 1)
+    {-# INLINE findBreak #-}
+
+span :: PrimType ty => (ty -> Bool) -> Block ty -> (Block ty, Block ty)
+span p = break (not . p)

--- a/Foundation/Primitive/Block.hs
+++ b/Foundation/Primitive/Block.hs
@@ -27,16 +27,9 @@ module Foundation.Primitive.Block
     , thaw
     , copy
     -- * safer api
-    , empty
     , create
     , singleton
     , replicate
-    , fromList
-    , toList
-    , equal
-    , bcompare
-    , append
-    , concat
     , index
     , map
     , foldl
@@ -50,15 +43,16 @@ module Foundation.Primitive.Block
     , splitAt
     , break
     , span
+    , elem
+    , all
+    , any
     -- * Foreign interfaces
     , unsafeCopyToPtr
     ) where
 
 import           GHC.Prim
 import           GHC.Types
---import           GHC.Ptr
 import           GHC.ST
-import qualified Data.List
 import           Foundation.Internal.Base hiding (fromList, toList)
 import           Foundation.Internal.Proxy
 import           Foundation.Internal.Primitive
@@ -69,41 +63,13 @@ import           Foundation.Primitive.IntegralConv
 import           Foundation.Primitive.Types
 import qualified Foundation.Primitive.Block.Mutable as M
 import           Foundation.Primitive.Block.Mutable (Block(..), MutableBlock(..), new, unsafeThaw, unsafeFreeze)
+import           Foundation.Primitive.Block.Base
 import           Foundation.Numerical
-
--- | Create an empty block of memory
-empty :: Block ty
-empty = Block ba where !(Block ba) = empty_
-
-empty_ :: Block ()
-empty_ = runST $ primitive $ \s1 ->
-    case newByteArray# 0# s1           of { (# s2, mba #) ->
-    case unsafeFreezeByteArray# mba s2 of { (# s3, ba  #) ->
-        (# s3, Block ba #) }}
 
 -- | return the number of elements of the array.
 length :: PrimType ty => Block ty -> Int
 length a = let (Size len) = lengthSize a in len
 {-# INLINE[1] length #-}
-
-lengthSize :: forall ty . PrimType ty => Block ty -> Size ty
-lengthSize (Block ba) =
-    let !(Size (I# szBits)) = primSizeInBytes (Proxy :: Proxy ty)
-        !elems              = quotInt# (sizeofByteArray# ba) szBits
-     in Size (I# elems)
-{-# INLINE[1] lengthSize #-}
-
-lengthBytes :: Block ty -> Size Word8
-lengthBytes (Block ba) = Size (I# (sizeofByteArray# ba))
-{-# INLINE[1] lengthBytes #-}
-
--- | Return the element at a specific index from an array without bounds checking.
---
--- Reading from invalid memory can return unpredictable and invalid values.
--- use 'index' if unsure.
-unsafeIndex :: forall ty . PrimType ty => Block ty -> Offset ty -> ty
-unsafeIndex (Block ba) n = primBaIndex ba n
-{-# INLINE unsafeIndex #-}
 
 -- | Copy all the block content to the memory starting at the destination address
 unsafeCopyToPtr :: forall ty prim . PrimMonad prim
@@ -120,7 +86,7 @@ create :: forall ty . PrimType ty
        -> (Offset ty -> ty) -- ^ the function that set the value at the index
        -> Block ty          -- ^ the array created
 create n initializer
-    | n == 0    = empty
+    | n == 0    = mempty
     | otherwise = runST $ do
         mb <- new n
         M.iterSet initializer mb
@@ -131,89 +97,6 @@ singleton ty = create 1 (const ty)
 
 replicate :: PrimType ty => Word -> ty -> Block ty
 replicate sz ty = create (Size (integralCast sz)) (const ty)
-
--- | make a block from a list of elements.
-fromList :: PrimType ty => [ty] -> Block ty
-fromList l = runST $ do
-    ma <- new (Size len)
-    iter 0 l $ \i x -> M.unsafeWrite ma i x
-    unsafeFreeze ma
-  where len = Data.List.length l
-        iter _  []     _ = return ()
-        iter !i (x:xs) z = z i x >> iter (i+1) xs z
-
--- | transform a block to a list.
-toList :: forall ty . PrimType ty => Block ty -> [ty]
-toList blk@(Block ba)
-    | len == 0  = []
-    | otherwise = loop 0
-  where
-    !len = lengthSize blk
-    loop !i | i .==# len = []
-            | otherwise  = primBaIndex ba i : loop (i+1)
-
--- | Check if two vectors are identical
-equal :: (PrimType ty, Eq ty) => Block ty -> Block ty -> Bool
-equal a b
-    | la /= lb  = False
-    | otherwise = loop 0
-  where
-    !la = lengthSize a
-    !lb = lengthSize b
-    loop n | n .==# la = True
-           | otherwise = (unsafeIndex a n == unsafeIndex b n) && loop (n+1)
-
--- | Compare 2 vectors
-bcompare :: (Ord ty, PrimType ty) => Block ty -> Block ty -> Ordering
-bcompare a b = loop 0
-  where
-    !la = lengthSize a
-    !lb = lengthSize b
-    loop n
-        | n .==# la = if la == lb then EQ else LT
-        | n .==# lb = GT
-        | otherwise =
-            case unsafeIndex a n `compare` unsafeIndex b n of
-                EQ -> loop (n+1)
-                r  -> r
-
--- | Append 2 arrays together by creating a new bigger array
-append :: Block ty -> Block ty -> Block ty
-append a b
-    | la == 0 = b
-    | lb == 0 = a
-    | otherwise = runST $ do
-        r  <- M.unsafeNew (la+lb)
-        M.unsafeCopyBytesRO r 0                 a 0 la
-        M.unsafeCopyBytesRO r (sizeAsOffset la) b 0 lb
-        unsafeFreeze r
-  where
-    !la = lengthBytes a
-    !lb = lengthBytes b
-
-concat :: [Block ty] -> Block ty
-concat [] = empty
-concat l  =
-    case filterAndSum 0 [] l of
-        (_,[])            -> empty
-        (_,[x])           -> x
-        (totalLen,chunks) -> runST $ do
-            r <- M.unsafeNew totalLen
-            doCopy r 0 chunks
-            unsafeFreeze r
-  where
-    -- TODO would go faster not to reverse but pack from the end instead
-    filterAndSum !totalLen acc []     = (totalLen, Data.List.reverse acc)
-    filterAndSum !totalLen acc (x:xs)
-        | len == 0  = filterAndSum totalLen acc xs
-        | otherwise = filterAndSum (len+totalLen) (x:acc) xs
-      where len = lengthBytes x
-
-    doCopy _ _ []     = return ()
-    doCopy r i (x:xs) = do
-        M.unsafeCopyBytesRO r i x 0 lx
-        doCopy r (i `offsetPlusE` lx) xs
-      where !lx = lengthBytes x
 
 -- | Thaw a Block into a MutableBlock
 --
@@ -294,7 +177,7 @@ snoc vec e
 
 sub :: PrimType ty => Block ty -> Offset ty -> Offset ty -> Block ty
 sub vec start end
-    | start >= end = empty
+    | start >= end = mempty
     | otherwise    = runST $ do
         dst <- new len
         M.unsafeCopyElementsRO dst 0 vec start newLen
@@ -321,8 +204,8 @@ unsnoc vec
 
 splitAt :: PrimType ty => Size ty -> Block ty -> (Block ty, Block ty)
 splitAt nbElems v
-    | nbElems <= 0 = (empty, v)
-    | n == vlen    = (v, empty)
+    | nbElems <= 0 = (mempty, v)
+    | n == vlen    = (v, mempty)
     | otherwise    = runST $ do
         left  <- new nbElems
         right <- new (vlen - nbElems)
@@ -339,10 +222,37 @@ break predicate blk = findBreak 0
   where
     !len = lengthSize blk
     findBreak !i
-        | i .==# len                    = (blk, empty)
+        | i .==# len                    = (blk, mempty)
         | predicate (unsafeIndex blk i) = splitAt (offsetAsSize i) blk
         | otherwise                     = findBreak (i + 1)
     {-# INLINE findBreak #-}
 
 span :: PrimType ty => (ty -> Bool) -> Block ty -> (Block ty, Block ty)
 span p = break (not . p)
+
+elem :: PrimType ty => ty -> Block ty -> Bool
+elem v blk = loop 0
+  where
+    !len = lengthSize blk
+    loop i
+        | i .==# len             = False
+        | unsafeIndex blk i == v = True
+        | otherwise              = loop (i+1)
+
+all :: PrimType ty => (ty -> Bool) -> Block ty -> Bool
+all p blk = loop 0
+  where
+    !len = lengthSize blk
+    loop i
+        | i .==# len            = True
+        | p (unsafeIndex blk i) = loop (i+1)
+        | otherwise             = False
+
+any :: PrimType ty => (ty -> Bool) -> Block ty -> Bool
+any p blk = loop 0
+  where
+    !len = lengthSize blk
+    loop i
+        | i .==# len            = False
+        | p (unsafeIndex blk i) = True
+        | otherwise             = loop (i+1)

--- a/Foundation/Primitive/Block.hs
+++ b/Foundation/Primitive/Block.hs
@@ -1,3 +1,7 @@
+-- |
+-- Module      : Foundation.Primitive.Block
+-- License     : BSD-style
+-- Maintainer  : Haskell Foundation
 --
 -- A block of memory that contains elements of a type,
 -- very similar to an unboxed array but with the key difference:

--- a/Foundation/Primitive/Block.hs
+++ b/Foundation/Primitive/Block.hs
@@ -50,6 +50,8 @@ module Foundation.Primitive.Block
     , splitAt
     , break
     , span
+    -- * Foreign interfaces
+    , unsafeCopyToPtr
     ) where
 
 import           GHC.Prim
@@ -101,6 +103,14 @@ lengthBytes (Block ba) = Size (I# (sizeofByteArray# ba))
 unsafeIndex :: forall ty . PrimType ty => Block ty -> Offset ty -> ty
 unsafeIndex (Block ba) n = primBaIndex ba n
 {-# INLINE unsafeIndex #-}
+
+-- | Copy all the block content to the memory starting at the destination address
+unsafeCopyToPtr :: forall ty prim . PrimMonad prim
+                => Block ty -- ^ the source block to copy
+                -> Ptr ty   -- ^ The destination address where the copy is going to start
+                -> prim ()
+unsafeCopyToPtr (Block blk) (Ptr p) = primitive $ \s1 ->
+    (# copyByteArrayToAddr# blk 0# p (sizeofByteArray# blk) s1, () #)
 
 -- | Create a new array of size @n by settings each cells through the
 -- function @f.

--- a/Foundation/Primitive/Block.hs
+++ b/Foundation/Primitive/Block.hs
@@ -61,6 +61,7 @@ import           GHC.ST
 import qualified Data.List
 import           Foundation.Internal.Base hiding (fromList, toList)
 import           Foundation.Internal.Proxy
+import           Foundation.Internal.Primitive
 import           Foundation.Primitive.Types.OffsetSize
 import           Foundation.Primitive.Monad
 import           Foundation.Primitive.Exception
@@ -110,7 +111,7 @@ unsafeCopyToPtr :: forall ty prim . PrimMonad prim
                 -> Ptr ty   -- ^ The destination address where the copy is going to start
                 -> prim ()
 unsafeCopyToPtr (Block blk) (Ptr p) = primitive $ \s1 ->
-    (# copyByteArrayToAddr# blk 0# p (sizeofByteArray# blk) s1, () #)
+    (# compatCopyByteArrayToAddr# blk 0# p (sizeofByteArray# blk) s1, () #)
 
 -- | Create a new array of size @n by settings each cells through the
 -- function @f.

--- a/Foundation/Primitive/Block/Base.hs
+++ b/Foundation/Primitive/Block/Base.hs
@@ -1,0 +1,281 @@
+{-# LANGUAGE MagicHash           #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE UnboxedTuples       #-}
+module Foundation.Primitive.Block.Base
+    ( Block(..)
+    , MutableBlock(..)
+    -- * Basic accessor
+    , unsafeNew
+    , unsafeThaw
+    , unsafeFreeze
+    , unsafeCopyElements
+    , unsafeCopyElementsRO
+    , unsafeCopyBytes
+    , unsafeCopyBytesRO
+    , unsafeRead
+    , unsafeWrite
+    , unsafeIndex
+    -- * Properties
+    , lengthSize
+    , lengthBytes
+    -- * Other methods
+    , new
+    ) where
+
+import           GHC.Prim
+import           GHC.Types
+import           GHC.ST
+import qualified Data.List
+import           Foundation.Internal.Base
+import           Foundation.Internal.Proxy
+import           Foundation.Primitive.Types.OffsetSize
+import           Foundation.Primitive.Monad
+import           Foundation.Primitive.NormalForm
+import           Foundation.Numerical
+import           Foundation.Primitive.Types
+
+-- | A block of memory containing unpacked bytes representing values of type 'ty'
+data Block ty = Block ByteArray#
+
+instance Data ty => Data (Block ty) where
+    dataTypeOf _ = blockType
+    toConstr _   = error "toConstr"
+    gunfold _ _  = error "gunfold"
+
+blockType :: DataType
+blockType = mkNoRepType "Foundation.Block"
+
+instance NormalForm (Block ty) where
+    toNormalForm (Block !_) = ()
+instance (PrimType ty, Show ty) => Show (Block ty) where
+    show v = show (toList v)
+instance (PrimType ty, Eq ty) => Eq (Block ty) where
+    (==) = equal
+instance (PrimType ty, Ord ty) => Ord (Block ty) where
+    compare = internalCompare
+
+instance PrimType ty => Monoid (Block ty) where
+    mempty  = empty
+    mappend = append
+    mconcat = concat
+
+instance PrimType ty => IsList (Block ty) where
+    type Item (Block ty) = ty
+    fromList = internalFromList
+    toList = internalToList
+
+lengthSize :: forall ty . PrimType ty => Block ty -> Size ty
+lengthSize (Block ba) =
+    let !(Size (I# szBits)) = primSizeInBytes (Proxy :: Proxy ty)
+        !elems              = quotInt# (sizeofByteArray# ba) szBits
+     in Size (I# elems)
+{-# INLINE[1] lengthSize #-}
+
+lengthBytes :: Block ty -> Size Word8
+lengthBytes (Block ba) = Size (I# (sizeofByteArray# ba))
+{-# INLINE[1] lengthBytes #-}
+
+-- | Create an empty block of memory
+empty :: Block ty
+empty = Block ba where !(Block ba) = empty_
+
+empty_ :: Block ()
+empty_ = runST $ primitive $ \s1 ->
+    case newByteArray# 0# s1           of { (# s2, mba #) ->
+    case unsafeFreezeByteArray# mba s2 of { (# s3, ba  #) ->
+        (# s3, Block ba #) }}
+
+-- | Return the element at a specific index from an array without bounds checking.
+--
+-- Reading from invalid memory can return unpredictable and invalid values.
+-- use 'index' if unsure.
+unsafeIndex :: forall ty . PrimType ty => Block ty -> Offset ty -> ty
+unsafeIndex (Block ba) n = primBaIndex ba n
+{-# INLINE unsafeIndex #-}
+
+-- | make a block from a list of elements.
+internalFromList :: PrimType ty => [ty] -> Block ty
+internalFromList l = runST $ do
+    ma <- new (Size len)
+    iter 0 l $ \i x -> unsafeWrite ma i x
+    unsafeFreeze ma
+  where len = Data.List.length l
+        iter _  []     _ = return ()
+        iter !i (x:xs) z = z i x >> iter (i+1) xs z
+
+-- | transform a block to a list.
+internalToList :: forall ty . PrimType ty => Block ty -> [ty]
+internalToList blk@(Block ba)
+    | len == 0  = []
+    | otherwise = loop 0
+  where
+    !len = lengthSize blk
+    loop !i | i .==# len = []
+            | otherwise  = primBaIndex ba i : loop (i+1)
+
+-- | Check if two vectors are identical
+equal :: (PrimType ty, Eq ty) => Block ty -> Block ty -> Bool
+equal a b
+    | la /= lb  = False
+    | otherwise = loop 0
+  where
+    !la = lengthSize a
+    !lb = lengthSize b
+    loop n | n .==# la = True
+           | otherwise = (unsafeIndex a n == unsafeIndex b n) && loop (n+1)
+
+-- | Compare 2 vectors
+internalCompare :: (Ord ty, PrimType ty) => Block ty -> Block ty -> Ordering
+internalCompare a b = loop 0
+  where
+    !la = lengthSize a
+    !lb = lengthSize b
+    loop n
+        | n .==# la = if la == lb then EQ else LT
+        | n .==# lb = GT
+        | otherwise =
+            case unsafeIndex a n `compare` unsafeIndex b n of
+                EQ -> loop (n+1)
+                r  -> r
+
+-- | Append 2 arrays together by creating a new bigger array
+append :: Block ty -> Block ty -> Block ty
+append a b
+    | la == 0 = b
+    | lb == 0 = a
+    | otherwise = runST $ do
+        r  <- unsafeNew (la+lb)
+        unsafeCopyBytesRO r 0                 a 0 la
+        unsafeCopyBytesRO r (sizeAsOffset la) b 0 lb
+        unsafeFreeze r
+  where
+    !la = lengthBytes a
+    !lb = lengthBytes b
+
+concat :: [Block ty] -> Block ty
+concat [] = empty
+concat l  =
+    case filterAndSum 0 [] l of
+        (_,[])            -> empty
+        (_,[x])           -> x
+        (totalLen,chunks) -> runST $ do
+            r <- unsafeNew totalLen
+            doCopy r 0 chunks
+            unsafeFreeze r
+  where
+    -- TODO would go faster not to reverse but pack from the end instead
+    filterAndSum !totalLen acc []     = (totalLen, Data.List.reverse acc)
+    filterAndSum !totalLen acc (x:xs)
+        | len == 0  = filterAndSum totalLen acc xs
+        | otherwise = filterAndSum (len+totalLen) (x:acc) xs
+      where len = lengthBytes x
+
+    doCopy _ _ []     = return ()
+    doCopy r i (x:xs) = do
+        unsafeCopyBytesRO r i x 0 lx
+        doCopy r (i `offsetPlusE` lx) xs
+      where !lx = lengthBytes x
+
+-- | A Mutable block of memory containing unpacked bytes representing values of type 'ty'
+data MutableBlock ty st = MutableBlock (MutableByteArray# st)
+
+-- | Freeze a mutable block into a block.
+--
+-- If the mutable block is still use after freeze,
+-- then the modification will be reflected in an unexpected
+-- way in the Block.
+unsafeFreeze :: PrimMonad prim => MutableBlock ty (PrimState prim) -> prim (Block ty)
+unsafeFreeze (MutableBlock mba) = primitive $ \s1 ->
+    case unsafeFreezeByteArray# mba s1 of
+        (# s2, ba #) -> (# s2, Block ba #)
+{-# INLINE unsafeFreeze #-}
+
+-- | Thaw an immutable block.
+--
+-- If the immutable block is modified, then the original immutable block will
+-- be modified too, but lead to unexpected results when querying
+unsafeThaw :: (PrimType ty, PrimMonad prim) => Block ty -> prim (MutableBlock ty (PrimState prim))
+unsafeThaw (Block ba) = primitive $ \st -> (# st, MutableBlock (unsafeCoerce# ba) #)
+
+-- | Create a new mutable block of a specific size in bytes.
+--
+-- Note that no checks are made to see if the size in bytes is compatible with the size
+-- of the underlaying element 'ty' in the block.
+--
+-- use 'new' if unsure
+unsafeNew :: PrimMonad prim => Size Word8 -> prim (MutableBlock ty (PrimState prim))
+unsafeNew (Size (I# bytes)) =
+    primitive $ \s1 -> case newByteArray# bytes s1 of { (# s2, mba #) -> (# s2, MutableBlock mba #) }
+
+-- | Create a new mutable block of a specific N size of 'ty' elements
+new :: forall prim ty . (PrimMonad prim, PrimType ty) => Size ty -> prim (MutableBlock ty (PrimState prim))
+new n = unsafeNew (sizeOfE (primSizeInBytes (Proxy :: Proxy ty)) n)
+
+-- | Copy a number of elements from an array to another array with offsets
+unsafeCopyElements :: forall prim ty . (PrimMonad prim, PrimType ty)
+                   => MutableBlock ty (PrimState prim) -- ^ destination mutable block
+                   -> Offset ty                        -- ^ offset at destination
+                   -> MutableBlock ty (PrimState prim) -- ^ source mutable block
+                   -> Offset ty                        -- ^ offset at source
+                   -> Size ty                          -- ^ number of elements to copy
+                   -> prim ()
+unsafeCopyElements dstMb destOffset srcMb srcOffset n = -- (MutableBlock dstMba) ed (MutableBlock srcBa) es n =
+    unsafeCopyBytes dstMb (offsetOfE sz destOffset)
+                    srcMb (offsetOfE sz srcOffset)
+                    (sizeOfE sz n)
+  where
+    !sz = primSizeInBytes (Proxy :: Proxy ty)
+
+unsafeCopyElementsRO :: forall prim ty . (PrimMonad prim, PrimType ty)
+                     => MutableBlock ty (PrimState prim) -- ^ destination mutable block
+                     -> Offset ty                        -- ^ offset at destination
+                     -> Block ty                         -- ^ source block
+                     -> Offset ty                        -- ^ offset at source
+                     -> Size ty                          -- ^ number of elements to copy
+                     -> prim ()
+unsafeCopyElementsRO dstMb destOffset srcMb srcOffset n =
+    unsafeCopyBytesRO dstMb (offsetOfE sz destOffset)
+                      srcMb (offsetOfE sz srcOffset)
+                      (sizeOfE sz n)
+  where
+    !sz = primSizeInBytes (Proxy :: Proxy ty)
+
+-- | Copy a number of bytes from a MutableBlock to another MutableBlock with specific byte offsets
+unsafeCopyBytes :: forall prim ty . PrimMonad prim
+                => MutableBlock ty (PrimState prim) -- ^ destination mutable block
+                -> Offset Word8                     -- ^ offset at destination
+                -> MutableBlock ty (PrimState prim) -- ^ source mutable block
+                -> Offset Word8                     -- ^ offset at source
+                -> Size Word8                       -- ^ number of elements to copy
+                -> prim ()
+unsafeCopyBytes (MutableBlock dstMba) (Offset (I# d)) (MutableBlock srcBa) (Offset (I# s)) (Size (I# n)) =
+    primitive $ \st -> (# copyMutableByteArray# srcBa s dstMba d n st, () #)
+{-# INLINE unsafeCopyBytes #-}
+
+-- | Copy a number of bytes from a Block to a MutableBlock with specific byte offsets
+unsafeCopyBytesRO :: forall prim ty . PrimMonad prim
+                  => MutableBlock ty (PrimState prim) -- ^ destination mutable block
+                  -> Offset Word8                     -- ^ offset at destination
+                  -> Block ty                         -- ^ source block
+                  -> Offset Word8                     -- ^ offset at source
+                  -> Size Word8                       -- ^ number of elements to copy
+                  -> prim ()
+unsafeCopyBytesRO (MutableBlock dstMba) (Offset (I# d)) (Block srcBa) (Offset (I# s)) (Size (I# n)) =
+    primitive $ \st -> (# copyByteArray# srcBa s dstMba d n st, () #)
+{-# INLINE unsafeCopyBytesRO #-}
+
+-- | read from a cell in a mutable block without bounds checking.
+--
+-- Reading from invalid memory can return unpredictable and invalid values.
+-- use 'read' if unsure.
+unsafeRead :: (PrimMonad prim, PrimType ty) => MutableBlock ty (PrimState prim) -> Offset ty -> prim ty
+unsafeRead (MutableBlock mba) i = primMbaRead mba i
+{-# INLINE unsafeRead #-}
+
+-- | write to a cell in a mutable block without bounds checking.
+--
+-- Writing with invalid bounds will corrupt memory and your program will
+-- become unreliable. use 'write' if unsure.
+unsafeWrite :: (PrimMonad prim, PrimType ty) => MutableBlock ty (PrimState prim) -> Offset ty -> ty -> prim ()
+unsafeWrite (MutableBlock mba) i v = primMbaWrite mba i v
+{-# INLINE unsafeWrite #-}

--- a/Foundation/Primitive/Block/Base.hs
+++ b/Foundation/Primitive/Block/Base.hs
@@ -36,6 +36,7 @@ import           Foundation.Primitive.Types
 
 -- | A block of memory containing unpacked bytes representing values of type 'ty'
 data Block ty = Block ByteArray#
+    deriving (Typeable)
 
 instance Data ty => Data (Block ty) where
     dataTypeOf _ = blockType

--- a/Foundation/Primitive/Block/Mutable.hs
+++ b/Foundation/Primitive/Block/Mutable.hs
@@ -52,19 +52,13 @@ module Foundation.Primitive.Block.Mutable
 
 import           GHC.Prim
 import           GHC.Types
-import           GHC.Ptr
 import           Foundation.Internal.Base
 import           Foundation.Internal.Proxy
 import           Foundation.Primitive.Types.OffsetSize
 import           Foundation.Primitive.Monad
 import           Foundation.Numerical
 import           Foundation.Primitive.Types
-
--- | A block of memory containing unpacked bytes representing values of type 'ty'
-data Block ty = Block ByteArray#
-
--- | A Mutable block of memory containing unpacked bytes representing values of type 'ty'
-data MutableBlock ty st = MutableBlock (MutableByteArray# st)
+import           Foundation.Primitive.Block.Base
 
 -- | Return the length of a Mutable Block
 --
@@ -83,38 +77,6 @@ isPinned (MutableBlock mba) =
     -- in 8.2, there's a primitive to know if an array in pinned
     I# (sizeofMutableByteArray# mba) > 3000
 
--- | Freeze a mutable block into a block.
---
--- If the mutable block is still use after freeze,
--- then the modification will be reflected in an unexpected
--- way in the Block.
-unsafeFreeze :: PrimMonad prim => MutableBlock ty (PrimState prim) -> prim (Block ty)
-unsafeFreeze (MutableBlock mba) = primitive $ \s1 ->
-    case unsafeFreezeByteArray# mba s1 of
-        (# s2, ba #) -> (# s2, Block ba #)
-{-# INLINE unsafeFreeze #-}
-
--- | Thaw an immutable block.
---
--- If the immutable block is modified, then the original immutable block will
--- be modified too, but lead to unexpected results when querying
-unsafeThaw :: (PrimType ty, PrimMonad prim) => Block ty -> prim (MutableBlock ty (PrimState prim))
-unsafeThaw (Block ba) = primitive $ \st -> (# st, MutableBlock (unsafeCoerce# ba) #)
-
--- | Create a new mutable block of a specific size in bytes.
---
--- Note that no checks are made to see if the size in bytes is compatible with the size
--- of the underlaying element 'ty' in the block.
---
--- use 'new' if unsure
-unsafeNew :: PrimMonad prim => Size Word8 -> prim (MutableBlock ty (PrimState prim))
-unsafeNew (Size (I# bytes)) =
-    primitive $ \s1 -> case newByteArray# bytes s1 of { (# s2, mba #) -> (# s2, MutableBlock mba #) }
-
-
--- | Create a new mutable block of a specific N size of 'ty' elements
-new :: forall prim ty . (PrimMonad prim, PrimType ty) => Size ty -> prim (MutableBlock ty (PrimState prim))
-new n = unsafeNew (sizeOfE (primSizeInBytes (Proxy :: Proxy ty)) n)
 
 -- | Set all mutable block element to a value
 iterSet :: (PrimType ty, PrimMonad prim)
@@ -128,72 +90,3 @@ iterSet f ma = loop 0
         | i .==# sz = pure ()
         | otherwise = unsafeWrite ma i (f i) >> loop (i+1)
     {-# INLINE loop #-}
-
--- | read from a cell in a mutable block without bounds checking.
---
--- Reading from invalid memory can return unpredictable and invalid values.
--- use 'read' if unsure.
-unsafeRead :: (PrimMonad prim, PrimType ty) => MutableBlock ty (PrimState prim) -> Offset ty -> prim ty
-unsafeRead (MutableBlock mba) i = primMbaRead mba i
-{-# INLINE unsafeRead #-}
-
--- | write to a cell in a mutable block without bounds checking.
---
--- Writing with invalid bounds will corrupt memory and your program will
--- become unreliable. use 'write' if unsure.
-unsafeWrite :: (PrimMonad prim, PrimType ty) => MutableBlock ty (PrimState prim) -> Offset ty -> ty -> prim ()
-unsafeWrite (MutableBlock mba) i v = primMbaWrite mba i v
-{-# INLINE unsafeWrite #-}
-
--- | Copy a number of elements from an array to another array with offsets
-unsafeCopyElements :: forall prim ty . (PrimMonad prim, PrimType ty)
-                   => MutableBlock ty (PrimState prim) -- ^ destination mutable block
-                   -> Offset ty                        -- ^ offset at destination
-                   -> MutableBlock ty (PrimState prim) -- ^ source mutable block
-                   -> Offset ty                        -- ^ offset at source
-                   -> Size ty                          -- ^ number of elements to copy
-                   -> prim ()
-unsafeCopyElements dstMb destOffset srcMb srcOffset n = -- (MutableBlock dstMba) ed (MutableBlock srcBa) es n =
-    unsafeCopyBytes dstMb (offsetOfE sz destOffset)
-                    srcMb (offsetOfE sz srcOffset)
-                    (sizeOfE sz n)
-  where
-    !sz = primSizeInBytes (Proxy :: Proxy ty)
-
-unsafeCopyElementsRO :: forall prim ty . (PrimMonad prim, PrimType ty)
-                     => MutableBlock ty (PrimState prim) -- ^ destination mutable block
-                     -> Offset ty                        -- ^ offset at destination
-                     -> Block ty                         -- ^ source block
-                     -> Offset ty                        -- ^ offset at source
-                     -> Size ty                          -- ^ number of elements to copy
-                     -> prim ()
-unsafeCopyElementsRO dstMb destOffset srcMb srcOffset n =
-    unsafeCopyBytesRO dstMb (offsetOfE sz destOffset)
-                      srcMb (offsetOfE sz srcOffset)
-                      (sizeOfE sz n)
-  where
-    !sz = primSizeInBytes (Proxy :: Proxy ty)
-
--- | Copy a number of bytes from a MutableBlock to another MutableBlock with specific byte offsets
-unsafeCopyBytes :: forall prim ty . PrimMonad prim
-                => MutableBlock ty (PrimState prim) -- ^ destination mutable block
-                -> Offset Word8                     -- ^ offset at destination
-                -> MutableBlock ty (PrimState prim) -- ^ source mutable block
-                -> Offset Word8                     -- ^ offset at source
-                -> Size Word8                       -- ^ number of elements to copy
-                -> prim ()
-unsafeCopyBytes (MutableBlock dstMba) (Offset (I# d)) (MutableBlock srcBa) (Offset (I# s)) (Size (I# n)) =
-    primitive $ \st -> (# copyMutableByteArray# srcBa s dstMba d n st, () #)
-{-# INLINE unsafeCopyBytes #-}
-
--- | Copy a number of bytes from a Block to a MutableBlock with specific byte offsets
-unsafeCopyBytesRO :: forall prim ty . PrimMonad prim
-                  => MutableBlock ty (PrimState prim) -- ^ destination mutable block
-                  -> Offset Word8                     -- ^ offset at destination
-                  -> Block ty                         -- ^ source block
-                  -> Offset Word8                     -- ^ offset at source
-                  -> Size Word8                       -- ^ number of elements to copy
-                  -> prim ()
-unsafeCopyBytesRO (MutableBlock dstMba) (Offset (I# d)) (Block srcBa) (Offset (I# s)) (Size (I# n)) =
-    primitive $ \st -> (# copyByteArray# srcBa s dstMba d n st, () #)
-{-# INLINE unsafeCopyBytesRO #-}

--- a/Foundation/Primitive/Block/Mutable.hs
+++ b/Foundation/Primitive/Block/Mutable.hs
@@ -1,0 +1,199 @@
+-- |
+-- Module      : Foundation.Primitive.Block.Mutable
+-- License     : BSD-style
+-- Maintainer  : Haskell Foundation
+--
+-- A block of memory that contains elements of a type,
+-- very similar to an unboxed array but with the key difference:
+--
+-- * It doesn't have slicing capability (no cheap take or drop)
+-- * It consume less memory: 1 Offset, 1 Size, 1 Pinning status trimmed
+-- * It's unpackable in any constructor
+-- * It uses unpinned memory by default
+--
+-- It should be rarely needed in high level API, but
+-- in lowlevel API or some data structure containing lots
+-- of unboxed array that will benefit from optimisation.
+--
+-- Because it's unpinned, the blocks are compactable / movable,
+-- at the expense of making them less friendly to C layer / address.
+--
+-- Note that sadly the bytearray primitive type automatically create
+-- a pinned bytearray if the size is bigger than a certain threshold
+--
+-- GHC Documentation associated:
+--
+-- includes/rts/storage/Block.h
+--   * LARGE_OBJECT_THRESHOLD ((uint32_t)(BLOCK_SIZE * 8 / 10))
+--   * BLOCK_SIZE   (1<<BLOCK_SHIFT)
+--
+-- includes/rts/Constant.h
+--   * BLOCK_SHIFT  12
+--
+{-# LANGUAGE MagicHash           #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE UnboxedTuples       #-}
+module Foundation.Primitive.Block.Mutable
+    ( Block(..)
+    , MutableBlock(..)
+    , new
+    , isPinned
+    , iterSet
+    , unsafeNew
+    , unsafeWrite
+    , unsafeRead
+    , unsafeFreeze
+    , unsafeThaw
+    , unsafeCopyElements
+    , unsafeCopyElementsRO
+    , unsafeCopyBytes
+    , unsafeCopyBytesRO
+    ) where
+
+import           GHC.Prim
+import           GHC.Types
+import           GHC.Ptr
+import           Foundation.Internal.Base
+import           Foundation.Internal.Proxy
+import           Foundation.Primitive.Types.OffsetSize
+import           Foundation.Primitive.Monad
+import           Foundation.Numerical
+import           Foundation.Primitive.Types
+
+-- | A block of memory containing unpacked bytes representing values of type 'ty'
+data Block ty = Block ByteArray#
+
+-- | A Mutable block of memory containing unpacked bytes representing values of type 'ty'
+data MutableBlock ty st = MutableBlock (MutableByteArray# st)
+
+-- | Return the length of a Mutable Block
+--
+-- note: we don't allow resizing yet, so this can remain a pure function
+mutableLengthSize :: forall ty st . PrimType ty => MutableBlock ty st -> Size ty
+mutableLengthSize (MutableBlock mba) =
+    let !(Size (I# szBits)) = primSizeInBytes (Proxy :: Proxy ty)
+        !elems              = quotInt# (sizeofMutableByteArray# mba) szBits
+     in Size (I# elems)
+{-# INLINE[1] mutableLengthSize #-}
+
+-- | Return if a Mutable Block is pinned or not
+isPinned :: MutableBlock ty st -> Bool
+isPinned (MutableBlock mba) =
+    -- TODO use the exact value where the array become pinned (LARGE_OBJECT_THRESHOLD)
+    -- in 8.2, there's a primitive to know if an array in pinned
+    I# (sizeofMutableByteArray# mba) > 3000
+
+-- | Freeze a mutable block into a block.
+--
+-- If the mutable block is still use after freeze,
+-- then the modification will be reflected in an unexpected
+-- way in the Block.
+unsafeFreeze :: PrimMonad prim => MutableBlock ty (PrimState prim) -> prim (Block ty)
+unsafeFreeze (MutableBlock mba) = primitive $ \s1 ->
+    case unsafeFreezeByteArray# mba s1 of
+        (# s2, ba #) -> (# s2, Block ba #)
+{-# INLINE unsafeFreeze #-}
+
+-- | Thaw an immutable block.
+--
+-- If the immutable block is modified, then the original immutable block will
+-- be modified too, but lead to unexpected results when querying
+unsafeThaw :: (PrimType ty, PrimMonad prim) => Block ty -> prim (MutableBlock ty (PrimState prim))
+unsafeThaw (Block ba) = primitive $ \st -> (# st, MutableBlock (unsafeCoerce# ba) #)
+
+-- | Create a new mutable block of a specific size in bytes.
+--
+-- Note that no checks are made to see if the size in bytes is compatible with the size
+-- of the underlaying element 'ty' in the block.
+--
+-- use 'new' if unsure
+unsafeNew :: PrimMonad prim => Size Word8 -> prim (MutableBlock ty (PrimState prim))
+unsafeNew (Size (I# bytes)) =
+    primitive $ \s1 -> case newByteArray# bytes s1 of { (# s2, mba #) -> (# s2, MutableBlock mba #) }
+
+
+-- | Create a new mutable block of a specific N size of 'ty' elements
+new :: forall prim ty . (PrimMonad prim, PrimType ty) => Size ty -> prim (MutableBlock ty (PrimState prim))
+new n = unsafeNew (sizeOfE (primSizeInBytes (Proxy :: Proxy ty)) n)
+
+-- | Set all mutable block element to a value
+iterSet :: (PrimType ty, PrimMonad prim)
+        => (Offset ty -> ty)
+        -> MutableBlock ty (PrimState prim)
+        -> prim ()
+iterSet f ma = loop 0
+  where
+    !sz = mutableLengthSize ma
+    loop i
+        | i .==# sz = pure ()
+        | otherwise = unsafeWrite ma i (f i) >> loop (i+1)
+    {-# INLINE loop #-}
+
+-- | read from a cell in a mutable block without bounds checking.
+--
+-- Reading from invalid memory can return unpredictable and invalid values.
+-- use 'read' if unsure.
+unsafeRead :: (PrimMonad prim, PrimType ty) => MutableBlock ty (PrimState prim) -> Offset ty -> prim ty
+unsafeRead (MutableBlock mba) i = primMbaRead mba i
+{-# INLINE unsafeRead #-}
+
+-- | write to a cell in a mutable block without bounds checking.
+--
+-- Writing with invalid bounds will corrupt memory and your program will
+-- become unreliable. use 'write' if unsure.
+unsafeWrite :: (PrimMonad prim, PrimType ty) => MutableBlock ty (PrimState prim) -> Offset ty -> ty -> prim ()
+unsafeWrite (MutableBlock mba) i v = primMbaWrite mba i v
+{-# INLINE unsafeWrite #-}
+
+-- | Copy a number of elements from an array to another array with offsets
+unsafeCopyElements :: forall prim ty . (PrimMonad prim, PrimType ty)
+                   => MutableBlock ty (PrimState prim) -- ^ destination mutable block
+                   -> Offset ty                        -- ^ offset at destination
+                   -> MutableBlock ty (PrimState prim) -- ^ source mutable block
+                   -> Offset ty                        -- ^ offset at source
+                   -> Size ty                          -- ^ number of elements to copy
+                   -> prim ()
+unsafeCopyElements dstMb destOffset srcMb srcOffset n = -- (MutableBlock dstMba) ed (MutableBlock srcBa) es n =
+    unsafeCopyBytes dstMb (offsetOfE sz destOffset)
+                    srcMb (offsetOfE sz srcOffset)
+                    (sizeOfE sz n)
+  where
+    !sz = primSizeInBytes (Proxy :: Proxy ty)
+
+unsafeCopyElementsRO :: forall prim ty . (PrimMonad prim, PrimType ty)
+                     => MutableBlock ty (PrimState prim) -- ^ destination mutable block
+                     -> Offset ty                        -- ^ offset at destination
+                     -> Block ty                         -- ^ source block
+                     -> Offset ty                        -- ^ offset at source
+                     -> Size ty                          -- ^ number of elements to copy
+                     -> prim ()
+unsafeCopyElementsRO dstMb destOffset srcMb srcOffset n =
+    unsafeCopyBytesRO dstMb (offsetOfE sz destOffset)
+                      srcMb (offsetOfE sz srcOffset)
+                      (sizeOfE sz n)
+  where
+    !sz = primSizeInBytes (Proxy :: Proxy ty)
+
+-- | Copy a number of bytes from a MutableBlock to another MutableBlock with specific byte offsets
+unsafeCopyBytes :: forall prim ty . PrimMonad prim
+                => MutableBlock ty (PrimState prim) -- ^ destination mutable block
+                -> Offset Word8                     -- ^ offset at destination
+                -> MutableBlock ty (PrimState prim) -- ^ source mutable block
+                -> Offset Word8                     -- ^ offset at source
+                -> Size Word8                       -- ^ number of elements to copy
+                -> prim ()
+unsafeCopyBytes (MutableBlock dstMba) (Offset (I# d)) (MutableBlock srcBa) (Offset (I# s)) (Size (I# n)) =
+    primitive $ \st -> (# copyMutableByteArray# srcBa s dstMba d n st, () #)
+{-# INLINE unsafeCopyBytes #-}
+
+-- | Copy a number of bytes from a Block to a MutableBlock with specific byte offsets
+unsafeCopyBytesRO :: forall prim ty . PrimMonad prim
+                  => MutableBlock ty (PrimState prim) -- ^ destination mutable block
+                  -> Offset Word8                     -- ^ offset at destination
+                  -> Block ty                         -- ^ source block
+                  -> Offset Word8                     -- ^ offset at source
+                  -> Size Word8                       -- ^ number of elements to copy
+                  -> prim ()
+unsafeCopyBytesRO (MutableBlock dstMba) (Offset (I# d)) (Block srcBa) (Offset (I# s)) (Size (I# n)) =
+    primitive $ \st -> (# copyByteArray# srcBa s dstMba d n st, () #)
+{-# INLINE unsafeCopyBytesRO #-}

--- a/Foundation/Primitive/Exception.hs
+++ b/Foundation/Primitive/Exception.hs
@@ -1,5 +1,5 @@
 -- |
--- Module      : Foundation.Array.Common
+-- Module      : Foundation.Primitive.Exception
 -- License     : BSD-style
 -- Maintainer  : Vincent Hanquez <vincent@snarc.org>
 -- Stability   : experimental
@@ -8,7 +8,7 @@
 -- Common part for vectors
 --
 {-# LANGUAGE DeriveDataTypeable #-}
-module Foundation.Array.Common
+module Foundation.Primitive.Exception
     ( OutOfBound(..)
     , OutOfBoundOperation(..)
     , isOutOfBound

--- a/Foundation/Primitive/Types.hs
+++ b/Foundation/Primitive/Types.hs
@@ -496,14 +496,6 @@ primOffsetOfE = getOffset Proxy
   where getOffset :: PrimType a => Proxy a -> Offset a -> Offset8
         getOffset proxy = offsetOfE (primSizeInBytes proxy)
 
-sizeAsOffset :: Size a -> Offset a
-sizeAsOffset (Size a) = Offset a
-{-# INLINE sizeAsOffset #-}
-
-offsetAsSize :: Offset a -> Size a
-offsetAsSize (Offset a) = Size a
-{-# INLINE offsetAsSize #-}
-
 primWordGetByteAndShift :: Word# -> (# Word#, Word# #)
 primWordGetByteAndShift w = (# and# w 0xff##, uncheckedShiftRL# w 8# #)
 {-# INLINE primWordGetByteAndShift #-}

--- a/Foundation/Primitive/Types.hs
+++ b/Foundation/Primitive/Types.hs
@@ -22,6 +22,7 @@ module Foundation.Primitive.Types
     , sizeRecast
     , offsetAsSize
     , sizeAsOffset
+    , sizeInBytes
     , primWordGetByteAndShift
     , primWord64GetByteAndShift
     , primWord64GetHiLo
@@ -481,6 +482,9 @@ sizeRecast = doRecast Proxy Proxy
                 (Size szB)   = primSizeInBytes pb
                 (Size bytes) = sizeOfE szA sz
              in Size (bytes `Prelude.quot` szB)
+
+sizeInBytes :: forall a . PrimType a => Size a -> Size Word8
+sizeInBytes sz = sizeOfE (primSizeInBytes (Proxy :: Proxy a)) sz
 
 primOffsetRecast :: (PrimType a, PrimType b) => Offset a -> Offset b
 primOffsetRecast = doRecast Proxy Proxy

--- a/Foundation/Primitive/Types/OffsetSize.hs
+++ b/Foundation/Primitive/Types/OffsetSize.hs
@@ -18,6 +18,8 @@ module Foundation.Primitive.Types.OffsetSize
     , offsetCast
     , sizeCast
     , sizeLastOffset
+    , sizeAsOffset
+    , offsetAsSize
     , (+.)
     , (.==#)
     , Size(..)
@@ -105,6 +107,15 @@ sizeLastOffset :: Size a -> Offset a
 sizeLastOffset (Size s)
     | s > 0     = Offset (pred s)
     | otherwise = error "last offset on size 0"
+
+sizeAsOffset :: Size a -> Offset a
+sizeAsOffset (Size a) = Offset a
+{-# INLINE sizeAsOffset #-}
+
+offsetAsSize :: Offset a -> Size a
+offsetAsSize (Offset a) = Size a
+{-# INLINE offsetAsSize #-}
+
 
 -- | Size of a data structure in bytes.
 type Size8 = Size Word8

--- a/benchs/ToForeign.hs
+++ b/benchs/ToForeign.hs
@@ -1,0 +1,46 @@
+{-# OPTIONS_GHC -O2 -Wall #-}
+{-# LANGUAGE BangPatterns, OverloadedStrings #-}
+
+import qualified Data.ByteString.Char8 as BS
+import Criterion.Main
+import Data.ByteString (ByteString, unpack)
+import Data.ByteString.Internal (toForeignPtr, unsafeCreate, memcpy)
+import qualified Foundation as F
+import Foundation.Array
+import Foundation.Array.Internal (withPtr, fromForeignPtr, copyToPtr)
+import qualified Foundation.Primitive.Block as BLK
+
+fromByteString :: ByteString -> F.UArray F.Word8
+fromByteString = fromForeignPtr . toForeignPtr
+
+fromByteString2 :: ByteString -> F.UArray F.Word8
+fromByteString2 = fromForeignPtr . toForeignPtr
+
+
+toByteString :: F.UArray F.Word8 -> ByteString
+toByteString v = unsafeCreate len $ \dst -> withPtr v $ \src -> memcpy dst src len
+  where !len = F.length v
+
+toByteString2 :: F.UArray F.Word8 -> ByteString
+toByteString2 v = unsafeCreate len $ copyToPtr v
+  where !len = F.length v
+
+toByteStringBlock :: BLK.Block F.Word8 -> ByteString
+toByteStringBlock blk = unsafeCreate len $ BLK.unsafeCopyToPtr blk
+  where !len = BLK.length blk
+
+bs = "foundation is the future" :: BS.ByteString
+str = fromByteString bs :: UArray F.Word8
+str2 = F.fromList (unpack bs) :: UArray F.Word8
+
+blk = BLK.fromList (unpack bs) :: BLK.Block F.Word8
+
+main = defaultMain
+  [ bench "toByteString-copyPtr" $ whnf toByteString2 str
+  , bench "toByteString-withPtr" $ whnf toByteString str
+  , bench "toByteString-native-copyPtr" $ whnf toByteString2 str2
+  , bench "toByteString-native-withPtr" $ whnf toByteString str2
+  , bench "toByteString-block-copyPtr" $ whnf toByteStringBlock blk
+  , bench "BS.copy"  $ whnf BS.copy bs
+  ]
+

--- a/foundation.cabal
+++ b/foundation.cabal
@@ -157,6 +157,7 @@ Library
                      Foundation.IO.File
                      Foundation.IO.Terminal
                      Foundation.Primitive.Base16
+                     Foundation.Primitive.Block.Mutable
                      Foundation.Primitive.Endianness
                      Foundation.Primitive.Exception
                      Foundation.Primitive.Types

--- a/foundation.cabal
+++ b/foundation.cabal
@@ -157,6 +157,7 @@ Library
                      Foundation.IO.File
                      Foundation.IO.Terminal
                      Foundation.Primitive.Base16
+                     Foundation.Primitive.Block
                      Foundation.Primitive.Block.Mutable
                      Foundation.Primitive.Endianness
                      Foundation.Primitive.Exception

--- a/foundation.cabal
+++ b/foundation.cabal
@@ -88,6 +88,7 @@ Library
                      Foundation.Foreign
                      Foundation.Collection
                      Foundation.Primitive
+                     Foundation.Primitive.Block
                      Foundation.List.DList
                      Foundation.Monad
                      Foundation.Monad.Reader

--- a/foundation.cabal
+++ b/foundation.cabal
@@ -158,7 +158,7 @@ Library
                      Foundation.IO.File
                      Foundation.IO.Terminal
                      Foundation.Primitive.Base16
-                     Foundation.Primitive.Block
+                     Foundation.Primitive.Block.Base
                      Foundation.Primitive.Block.Mutable
                      Foundation.Primitive.Endianness
                      Foundation.Primitive.Exception

--- a/foundation.cabal
+++ b/foundation.cabal
@@ -158,6 +158,7 @@ Library
                      Foundation.IO.Terminal
                      Foundation.Primitive.Base16
                      Foundation.Primitive.Endianness
+                     Foundation.Primitive.Exception
                      Foundation.Primitive.Types
                      Foundation.Primitive.Types.OffsetSize
                      Foundation.Primitive.Monad
@@ -173,7 +174,6 @@ Library
                      Foundation.Monad.Identity
                      Foundation.Monad.Base
                      Foundation.Array.Chunked.Unboxed
-                     Foundation.Array.Common
                      Foundation.Array.Unboxed
                      Foundation.Array.Unboxed.Mutable
                      Foundation.Array.Unboxed.ByteArray

--- a/tests/Checks.hs
+++ b/tests/Checks.hs
@@ -94,7 +94,27 @@ main = defaultMain $ Group "foundation"
         ]
     , collectionProperties "DList a" (Proxy :: Proxy (DList Word8)) arbitrary
     , Group "Array"
-      [ Group "Unboxed"
+      [ Group "Block"
+        [ collectionProperties "Block(W8)"  (Proxy :: Proxy (Block Word8))  arbitrary
+        , collectionProperties "Block(W16)" (Proxy :: Proxy (Block Word16)) arbitrary
+        , collectionProperties "Block(W32)" (Proxy :: Proxy (Block Word32)) arbitrary
+        , collectionProperties "Block(W64)" (Proxy :: Proxy (Block Word64)) arbitrary
+        , collectionProperties "Block(I8)"  (Proxy :: Proxy (Block Int8))   arbitrary
+        , collectionProperties "Block(I16)" (Proxy :: Proxy (Block Int16))  arbitrary
+        , collectionProperties "Block(I32)" (Proxy :: Proxy (Block Int32))  arbitrary
+        , collectionProperties "Block(I64)" (Proxy :: Proxy (Block Int64))  arbitrary
+        , collectionProperties "Block(F32)" (Proxy :: Proxy (Block Float))  arbitrary
+        , collectionProperties "Block(F64)" (Proxy :: Proxy (Block Double)) arbitrary
+        , collectionProperties "Block(CChar)"  (Proxy :: Proxy (Block CChar))  (CChar <$> arbitrary)
+        , collectionProperties "Block(CUChar)" (Proxy :: Proxy (Block CUChar)) (CUChar <$> arbitrary)
+        , collectionProperties "Block(BE W16)" (Proxy :: Proxy (Block (BE Word16))) (toBE <$> arbitrary)
+        , collectionProperties "Block(BE W32)" (Proxy :: Proxy (Block (BE Word32))) (toBE <$> arbitrary)
+        , collectionProperties "Block(BE W64)" (Proxy :: Proxy (Block (BE Word64))) (toBE <$> arbitrary)
+        , collectionProperties "Block(LE W16)" (Proxy :: Proxy (Block (LE Word16))) (toLE <$> arbitrary)
+        , collectionProperties "Block(LE W32)" (Proxy :: Proxy (Block (LE Word32))) (toLE <$> arbitrary)
+        , collectionProperties "Block(LE W64)" (Proxy :: Proxy (Block (LE Word64))) (toLE <$> arbitrary)
+        ]
+      , Group "Unboxed"
         [ collectionProperties "UArray(W8)"  (Proxy :: Proxy (UArray Word8))  arbitrary
         , collectionProperties "UArray(W16)" (Proxy :: Proxy (UArray Word16)) arbitrary
         , collectionProperties "UArray(W32)" (Proxy :: Proxy (UArray Word32)) arbitrary


### PR DESCRIPTION
This is a leaner version of `UArray` which only works on top of the `Bytearray#` and doesn't have any slicing ability (no builtin size/offset). It's also not C friendly by default.

People shouldn't be using this generally but in certain case, using a Block inside a data structure to represent some binary data have significant advantages:

* No meta data: saving ~20 bytes or so compared to a `UArray`.
* No "part" sharing: if you set a field of a data structure to some `UArray`, specially after a take/drop, you're still holding on to the bigger UArray. so "having a Block" is more straightforward in memory tracking.
* Unpackable in a parent: since it doesn't have a sum type like UArray

possibly this could bring some further cleanup & refactoring in `UArray`