### PR TITLE
Add upper and lower, partially fixes #261

### DIFF
--- a/Foundation/String.hs
+++ b/Foundation/String.hs
@@ -30,6 +30,8 @@ module Foundation.String
     , ValidationFailure(..)
     , lines
     , words
+    , upper
+    , lower
     ) where
 
 import Foundation.String.UTF8

--- a/Foundation/String/UTF8.hs
+++ b/Foundation/String/UTF8.hs
@@ -72,6 +72,8 @@ module Foundation.String.UTF8
     , readDouble
     , readRational
     , readFloatingExact
+    , upper
+    , lower
     -- * Legacy utility
     , lines
     , words
@@ -109,6 +111,7 @@ import           GHC.Char
 import qualified Data.List
 import           Data.Data
 import           Data.Ratio
+import           Data.Char
 import qualified Prelude
 
 import           Foundation.String.ModifiedUTF8     (fromModified)
@@ -1574,3 +1577,13 @@ decimalDigitsPtr startAcc ptr !endOfs !startOfs = loop startAcc startOfs
 {-# SPECIALIZE decimalDigitsPtr :: Natural -> Ptr Word8 -> Offset Word8 -> Offset Word8 -> (# Natural, Bool, Offset Word8 #) #-}
 {-# SPECIALIZE decimalDigitsPtr :: Int -> Ptr Word8 -> Offset Word8 -> Offset Word8 -> (# Int, Bool, Offset Word8 #) #-}
 {-# SPECIALIZE decimalDigitsPtr :: Word -> Ptr Word8 -> Offset Word8 -> Offset Word8 -> (# Word, Bool, Offset Word8 #) #-}
+
+-- | Convert a 'String' to the upper-case equivalent.
+--   Does not properly support multicharacter Unicode conversions.
+upper :: String -> String
+upper = charMap toUpper
+
+-- | Convert a 'String' to the upper-case equivalent.
+--   Does not properly support multicharacter Unicode conversions.
+lower :: String -> String
+lower = charMap toLower

--- a/tests/Checks.hs
+++ b/tests/Checks.hs
@@ -10,6 +10,7 @@ import Foundation.Foreign
 import Foundation.List.DList
 import Foundation.Primitive
 import Foundation.Check
+import Foundation.String
 import Foundation.String.Read
 import qualified Prelude
 import Data.Ratio
@@ -85,6 +86,10 @@ main = defaultMain $ Group "foundation"
             , Group "rational"
                 [ Property "case1" $ readRational "124.098" === Just (124098 % 1000)
                 ]
+            ]
+        , Group "conversion"
+            [ Property "lower" $ lower "This is MY test" === "this is my test"
+            , Property "upper" $ upper "This is MY test" === "THIS IS MY TEST"
             ]
         ]
     , collectionProperties "DList a" (Proxy :: Proxy (DList Word8)) arbitrary


### PR DESCRIPTION
I suggest we add the functions, documenting their weaknesses. If you agree, I'll also open a ticket to convert the case mapping tables from the Unicode consortium into foundation stuff. However, it probably makes sense to do that at the same time as optimising upper/lower - since that will alter the encoding size.