### PR TITLE
Drop legacy compilers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,6 @@ matrix:
   - env: BUILD=cabal
     language: haskell
     ghc: 7.8
-  - env: BUILD=stack RESOLVER=ghc-7.8
-    language: generic
-    addons: { apt: { packages: [ libgmp-dev ] } }
-    compiler: ghc-7.8
   - env: BUILD=stack RESOLVER=ghc-7.10
     language: generic
     addons: { apt: { packages: [ libgmp-dev ] } }

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ cache:
 # cabal-install, and BUILD=stack which uses Stack.
 matrix:
   include:
-  - env: BUILD=cabal
-    language: haskell
-    ghc: 7.6
   - env: BUILD=stack RESOLVER=ghc-8.0
     language: generic
     addons: { apt: { packages: [ libgmp-dev ] } }
@@ -37,18 +34,12 @@ matrix:
     os: osx
     language: generic
     compiler: ghc-8.0
-  - env: BUILD=cabal
-    language: haskell
-    ghc: 7.4
   - env: BUILD=stack RESOLVER=ghc-8.0 EXPERIMENTAL="--flag foundation:experimental"
     language: generic
     addons: { apt: { packages: [ libgmp-dev ] } }
     compiler: ghc-8.0
 
   allow_failures:
-  - env: BUILD=cabal
-    language: haskell
-    ghc: 7.4
   - env: BUILD=stack RESOLVER=ghc-8.2
     language: generic
   - env: BUILD=stack RESOLVER=ghc-8.0 EXPERIMENTAL="--flag foundation:experimental"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ matrix:
     compiler: ghc-8.0
   - env: BUILD=stack RESOLVER=ghc-8.2
     language: generic
+    compiler: ghc-8.2
     addons: { apt: { packages: [ libgmp-dev ] } }
   - env: BUILD=cabal
     language: haskell

--- a/.travis/stack-ghc-7.8.yaml
+++ b/.travis/stack-ghc-7.8.yaml
@@ -1,6 +1,0 @@
-resolver: lts-2.22
-packages:
-- '.'
-extra-deps: []
-flags: {}
-extra-package-dbs: []

--- a/foundation.cabal
+++ b/foundation.cabal
@@ -30,7 +30,7 @@ Build-Type:          Simple
 Homepage:            https://github.com/haskell-foundation/foundation
 Bug-Reports:         https://github.com/haskell-foundation/foundation/issues
 Cabal-Version:       >=1.10
-tested-with:         GHC == 7.6.3, GHC == 7.8.4, GHC == 7.10.3, GHC == 8.0.2
+tested-with:         GHC == 7.8.4, GHC == 7.10.3, GHC == 8.0.2
 extra-source-files:  README.md
                      cbits/*.h
 


### PR DESCRIPTION
fix #278 

also remove a duplicate test, we already test ghc 7.8 with the cabal build test, no need to also add the stack one.