### PR TITLE
Add foundation Semigroup&Monoid

### DIFF
--- a/Foundation/Boot/List.hs
+++ b/Foundation/Boot/List.hs
@@ -1,6 +1,7 @@
 module Foundation.Boot.List
     ( length
     , sum
+    , foldr
     ) where
 
 import Foundation.Internal.Base
@@ -19,3 +20,6 @@ sum (i:is) = loop i is
     loop !acc [] = acc
     loop !acc (x:xs) = loop (acc+x) xs
     {-# INLINE loop #-}
+
+foldr f z []     = z
+foldr f z (x:xs) = x `f` foldr f z xs

--- a/Foundation/Class/Monoid.hs
+++ b/Foundation/Class/Monoid.hs
@@ -1,0 +1,36 @@
+module Foundation.Class.Monoid
+    ( Monoid(..)
+    ) where
+
+import           Foundation.Internal.Base hiding ((<>), Monoid(..))
+import           Foundation.Class.Semigroup
+import qualified Foundation.Boot.List as List
+
+-- | Element with an empty element that is neutral w.r.t
+-- to the Semigroup (<>) law
+--
+-- the following property should hold:
+--
+-- * mempty <> a = a
+-- * a <> mempty = a
+--
+class Semigroup a => Monoid a where
+    -- | Empty element
+    mempty  :: a 
+
+    -- | Concat 
+    mconcat :: [a] -> a
+    mconcat = List.foldr (<>) mempty
+
+instance Semigroup a => Monoid (Maybe a) where
+    mempty = Nothing
+instance (Monoid a, Monoid b) => Monoid (a,b) where
+    mempty = (mempty, mempty)
+instance (Monoid a, Monoid b, Monoid c) => Monoid (a,b,c) where
+    mempty = (mempty, mempty, mempty)
+instance (Monoid a, Monoid b, Monoid c, Monoid d) => Monoid (a,b,c,d) where
+    mempty = (mempty, mempty, mempty, mempty)
+instance (Monoid a, Monoid b, Monoid c, Monoid d, Monoid e) => Monoid (a,b,c,d,e) where
+    mempty = (mempty, mempty, mempty, mempty, mempty)
+instance (Monoid a, Monoid b, Monoid c, Monoid d, Monoid e, Monoid f) => Monoid (a,b,c,d,e,f) where
+    mempty = (mempty, mempty, mempty, mempty, mempty, mempty)

--- a/Foundation/Class/Semigroup.hs
+++ b/Foundation/Class/Semigroup.hs
@@ -1,0 +1,39 @@
+module Foundation.Class.Semigroup
+    ( Semigroup(..)
+    ) where
+
+import Foundation.Internal.Base hiding ((<>))
+
+infixr 6 <>
+
+class Semigroup a where
+    (<>) :: a -> a -> a
+
+instance Semigroup a => Semigroup (Maybe a) where
+    Nothing <> b       = b
+    a       <> Nothing = a
+    Just a  <> Just b  = Just (a <> b)
+
+instance (Semigroup left, Semigroup right) => Semigroup (Either left right) where
+    Left _ <> b = b
+    a      <> _ = a
+
+instance Semigroup Ordering where
+    LT <> _ = LT
+    EQ <> x = x
+    GT <> _ = GT
+
+instance (Semigroup a, Semigroup b) => Semigroup (a,b) where
+    (<>) (a1,b1) (a2,b2) = (a1 <> a2, b1 <> b2)
+
+instance (Semigroup a, Semigroup b, Semigroup c) => Semigroup (a,b,c) where
+    (<>) (a1,b1,c1) (a2,b2,c2) = (a1 <> a2, b1 <> b2, c1 <> c2)
+
+instance (Semigroup a, Semigroup b, Semigroup c, Semigroup d) => Semigroup (a,b,c,d) where
+    (<>) (a1,b1,c1,d1) (a2,b2,c2,d2) = (a1 <> a2, b1 <> b2, c1 <> c2, d1 <> d2)
+
+instance (Semigroup a, Semigroup b, Semigroup c, Semigroup d, Semigroup e) => Semigroup (a,b,c,d,e) where
+    (<>) (a1,b1,c1,d1,e1) (a2,b2,c2,d2,e2) = (a1 <> a2, b1 <> b2, c1 <> c2, d1 <> d2, e1 <> e2)
+
+instance (Semigroup a, Semigroup b, Semigroup c, Semigroup d, Semigroup e, Semigroup f) => Semigroup (a,b,c,d,e,f) where
+    (<>) (a1,b1,c1,d1,e1,f1) (a2,b2,c2,d2,e2,f2) = (a1 <> a2, b1 <> b2, c1 <> c2, d1 <> d2, e1 <> e2, f1 <> f2)

--- a/foundation.cabal
+++ b/foundation.cabal
@@ -72,6 +72,8 @@ library
                      Foundation.Bits
                      Foundation.Class.Bifunctor
                      Foundation.Class.Storable
+                     Foundation.Class.Semigroup
+                     Foundation.Class.Monoid
                      Foundation.Conduit
                      Foundation.Conduit.Textual
                      Foundation.Convertible


### PR DESCRIPTION
The reason to add:

* base Semigroup currently use NonEmpty which is different in foundation
* base Semigroup use an Int as parameter for stimes however negative
  and zero values are wrong and not prevented by design.
* base Monoid doesn't depends on Semigroup

The caveat:

* in practice that means interacting with base, and regular Semigroup & Monoid stuff
  is harder.