### PR TITLE
Initial HLint work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@
 .stack-work
 exts
 dist
+report.html
+cabal.config
+.idea
+*.iml

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,0 +1,92 @@
+# HLint configuration file
+# https://github.com/ndmitchell/hlint
+##########################
+
+# This file contains a template configuration file, which is typically
+# placed as .hlint.yaml in the root of your project
+
+
+# Specify additional command line arguments
+#
+# - arguments: [--color, --cpp-simple, -XQuasiQuotes]
+
+
+# Control which extensions/flags/modules/functions can be used
+#
+# - extensions:
+#   - default: false # all extension are banned by default
+#   - name: [PatternGuards, ViewPatterns] # only these listed extensions can be used
+#   - {name: CPP, within: CrossPlatform} # CPP can only be used in a given module
+#
+# - flags:
+#   - {name: -w, within: []} # -w is allowed nowhere
+#
+# - modules:
+#   - {name: [Data.Set, Data.HashSet], as: Set} # if you import Data.Set qualified, it must be as 'Set'
+#   - {name: Control.Arrow, within: []} # Certain modules are banned entirely
+#
+# - functions:
+#   - {name: unsafePerformIO, within: []} # unsafePerformIO can only appear in no modules
+
+
+# Add custom hints for this project
+#
+# Will suggest replacing "wibbleMany [myvar]" with "wibbleOne myvar"
+# - error: {lhs: "wibbleMany [x]", rhs: wibbleOne x}
+
+
+# Turn on hints that are off by default
+#
+# Ban "module X(module X) where", to require a real export list
+# - warn: {name: Use explicit module export list}
+#
+# Replace a $ b $ c with a . b $ c
+# - group: {name: dollar, enabled: true}
+#
+# Generalise map to fmap, ++ to <>
+# - group: {name: generalise, enabled: true}
+
+
+# Ignore some builtin hints
+# - ignore: {name: Use let}
+# - ignore: {name: Use const, within: SpecialModule} # Only within certain modules
+- ignore: {name: Avoid lambda}
+- ignore: {name: Eta reduce}
+- ignore: {name: Evaluate, within: Foundation.IO.File}
+- ignore: {name: Move brackets to avoid $}
+- ignore: {name: Reduce duplication, within: Foundation.Collection.Zippable}
+- ignore: {name: Redundant bracket}
+- ignore: {name: Redundant do}
+- ignore: {name: Reduce duplication}
+- ignore: {name: Redundant lambda}
+- ignore: {name: Unused LANGUAGE pragma, within: Foundation.Internal.CallStack}
+- ignore: {name: Unused LANGUAGE pragma, within: Foundation.Primitive.Error}
+- ignore: {name: Unused LANGUAGE pragma, within: Foundation.Monad}
+- ignore: {name: Use break}
+- ignore: {name: Use camelCase}
+- ignore: {name: Use fewer imports, within: Foundation.Internal.ByteSwap}
+- ignore: {name: Use fmap, within: Foundation.Conduit.Internal}
+- ignore: {name: Use fmap, within: Foundation.Monad.State}
+- ignore: {name: Use fromMaybe, within: Foundation.Partial}
+- ignore: {name: Use if}
+- ignore: {name: Use infix}
+- ignore: {name: Use module export list}
+- ignore: {name: Use newtype instead of data}
+- ignore: {name: Use notElem, within: Foundation.Collection.Collection}
+- ignore: {name: Use print}
+- ignore: {name: Use section}
+- ignore: {name: Use span, within: Foundation.Collection.Sequential}
+- ignore: {name: Use String}
+- ignore: {name: Use traverse, within: Foundation.Collection.Mappable}
+- ignore: {name: Use void, within: Foundation.Monad.Exception}
+- ignore: {name: Use when}
+
+
+# Define some custom infix operators
+# - fixity: infixr 3 ~^#^~
+
+
+
+
+# To generate a suitable file for HLint do:
+# $ hlint --default > .hlint.yaml

--- a/Foundation.hs
+++ b/Foundation.hs
@@ -146,7 +146,7 @@ module Foundation
 import qualified Prelude
 --import           Prelude (Char, (.), Eq, Bool, IO)
 
-import           Data.Monoid (Monoid (..))
+import           Data.Monoid (Monoid (..), (<>))
 import           Control.Applicative
 import qualified Control.Category
 import qualified Control.Monad
@@ -185,7 +185,6 @@ import qualified Data.Tuple
 import qualified System.Environment
 import qualified Data.List
 
-import           Data.Monoid ((<>))
 
 default (Prelude.Integer, Prelude.Double)
 

--- a/Foundation/Array.hs
+++ b/Foundation/Array.hs
@@ -10,7 +10,6 @@
 -- Generally accessible in o(1)
 --
 {-# LANGUAGE MagicHash #-}
-{-# LANGUAGE UnboxedTuples #-}
 module Foundation.Array
     ( Array
     , MArray

--- a/Foundation/Array/Bitmap.hs
+++ b/Foundation/Array/Bitmap.hs
@@ -32,7 +32,7 @@ module Foundation.Array.Bitmap
 import           Foundation.Array.Unboxed (UArray)
 import qualified Foundation.Array.Unboxed as A
 import           Foundation.Array.Unboxed.Mutable (MUArray)
-import           Foundation.Class.Bifunctor (first)
+import           Foundation.Class.Bifunctor (first, second)
 import           Foundation.Primitive.Exception
 import           Foundation.Internal.Base
 import           Foundation.Primitive.Types.OffsetSize
@@ -389,7 +389,7 @@ snoc l v = unoptimised (flip C.snoc v) l
 
 -- unoptimised
 uncons :: Bitmap -> Maybe (Bool, Bitmap)
-uncons b = fmap (\(v, l) -> (v, fromList l)) $ C.uncons $ toList b
+uncons b = fmap (second fromList) $ C.uncons $ toList b
 
 -- unoptimised
 unsnoc :: Bitmap -> Maybe (Bitmap, Bool)

--- a/Foundation/Array/Bitmap.hs
+++ b/Foundation/Array/Bitmap.hs
@@ -32,6 +32,7 @@ module Foundation.Array.Bitmap
 import           Foundation.Array.Unboxed (UArray)
 import qualified Foundation.Array.Unboxed as A
 import           Foundation.Array.Unboxed.Mutable (MUArray)
+import           Foundation.Class.Bifunctor (first)
 import           Foundation.Primitive.Exception
 import           Foundation.Internal.Base
 import           Foundation.Primitive.Types.OffsetSize
@@ -392,7 +393,7 @@ uncons b = fmap (\(v, l) -> (v, fromList l)) $ C.uncons $ toList b
 
 -- unoptimised
 unsnoc :: Bitmap -> Maybe (Bitmap, Bool)
-unsnoc b = fmap (\(l, v) -> (fromList l, v)) $ C.unsnoc $ toList b
+unsnoc b = fmap (first fromList) $ C.unsnoc $ toList b
 
 intersperse :: Bool -> Bitmap -> Bitmap
 intersperse b = unoptimised (C.intersperse b)

--- a/Foundation/Array/Chunked/Unboxed.hs
+++ b/Foundation/Array/Chunked/Unboxed.hs
@@ -96,7 +96,7 @@ instance PrimType ty => C.IndexedCollection (ChunkedUArray ty) where
                 if predicate (unsafeIndex c i) then Just i else Nothing
 
 empty :: ChunkedUArray ty
-empty = ChunkedUArray (A.empty)
+empty = ChunkedUArray A.empty
 
 append :: ChunkedUArray ty -> ChunkedUArray ty -> ChunkedUArray ty
 append (ChunkedUArray a1) (ChunkedUArray a2) = ChunkedUArray (mappend a1 a2)

--- a/Foundation/Array/Chunked/Unboxed.hs
+++ b/Foundation/Array/Chunked/Unboxed.hs
@@ -8,7 +8,6 @@
 --
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}

--- a/Foundation/Array/Unboxed.hs
+++ b/Foundation/Array/Unboxed.hs
@@ -143,8 +143,8 @@ arrayType :: DataType
 arrayType = mkNoRepType "Foundation.UArray"
 
 instance NormalForm (UArray ty) where
-    toNormalForm (UVecBA _ _ _ _) = ()
-    toNormalForm (UVecAddr _ _ _) = ()
+    toNormalForm (UVecBA _ _ _ !_) = ()
+    toNormalForm (UVecAddr {}) = ()
 instance (PrimType ty, Show ty) => Show (UArray ty) where
     show v = show (toList v)
 instance (PrimType ty, Eq ty) => Eq (UArray ty) where

--- a/Foundation/Array/Unboxed.hs
+++ b/Foundation/Array/Unboxed.hs
@@ -1019,7 +1019,7 @@ reverse a
         loop !i
             | i == end  = return ()
             | otherwise = primMbaWrite ma i (primBaIndex ba (sizeAsOffset (endI - i))) >> loop (i+Offset 1)
-    goAddr !end !ma !(Ptr ba) !srcStart = loop (Offset 0)
+    goAddr !end !ma (Ptr ba) !srcStart = loop (Offset 0)
       where
         !endI = sizeAsOffset ((srcStart + end) - Offset 1)
         loop !i

--- a/Foundation/Array/Unboxed.hs
+++ b/Foundation/Array/Unboxed.hs
@@ -12,7 +12,6 @@
 --
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE UnboxedTuples #-}
-{-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE Rank2Types #-}
 module Foundation.Array.Unboxed

--- a/Foundation/Array/Unboxed/Mutable.hs
+++ b/Foundation/Array/Unboxed/Mutable.hs
@@ -163,8 +163,8 @@ new sz
 mutableSame :: MUArray ty st -> MUArray ty st -> Bool
 mutableSame (MUVecMA sa ea _ ma) (MUVecMA sb eb _ mb) = and [ sa == sb, ea == eb, bool# (sameMutableByteArray# ma mb)]
 mutableSame (MUVecAddr s1 e1 f1) (MUVecAddr s2 e2 f2) = and [ s1 == s2, e1 == e2, finalPtrSameMemory f1 f2 ]
-mutableSame (MUVecMA {})     (MUVecAddr {})   = False
-mutableSame (MUVecAddr {})   (MUVecMA {})     = False
+mutableSame MUVecMA {}     MUVecAddr {}   = False
+mutableSame MUVecAddr {}   MUVecMA {}     = False
 
 
 newNative :: (PrimMonad prim, PrimType ty) => CountOf ty -> (MutableByteArray# (PrimState prim) -> prim ()) -> prim (MUArray ty (PrimState prim))
@@ -172,7 +172,7 @@ newNative n f = do
     muvec <- new n
     case muvec of
         (MUVecMA _ _ _ mba) -> f mba >> return muvec
-        (MUVecAddr {})      -> error "internal error: unboxed new only supposed to allocate natively"
+        MUVecAddr {}        -> error "internal error: unboxed new only supposed to allocate natively"
 
 mutableForeignMem :: (PrimMonad prim, PrimType ty)
                   => FinalPtr ty -- ^ the start pointer with a finalizer

--- a/Foundation/Array/Unboxed/Mutable.hs
+++ b/Foundation/Array/Unboxed/Mutable.hs
@@ -161,8 +161,8 @@ new sz
 {-# INLINE new #-}
 
 mutableSame :: MUArray ty st -> MUArray ty st -> Bool
-mutableSame (MUVecMA sa ea _ ma) (MUVecMA sb eb _ mb) = and [ sa == sb, ea == eb, bool# (sameMutableByteArray# ma mb)]
-mutableSame (MUVecAddr s1 e1 f1) (MUVecAddr s2 e2 f2) = and [ s1 == s2, e1 == e2, finalPtrSameMemory f1 f2 ]
+mutableSame (MUVecMA sa ea _ ma) (MUVecMA sb eb _ mb) = (sa == sb) && (ea == eb) && bool# (sameMutableByteArray# ma mb)
+mutableSame (MUVecAddr s1 e1 f1) (MUVecAddr s2 e2 f2) = (s1 == s2) && (e1 == e2) && finalPtrSameMemory f1 f2
 mutableSame MUVecMA {}     MUVecAddr {}   = False
 mutableSame MUVecAddr {}   MUVecMA {}     = False
 

--- a/Foundation/Check.hs
+++ b/Foundation/Check.hs
@@ -64,7 +64,7 @@ validate propertyName prop = Check $ do
 pick :: String -> IO a -> Check a
 pick _ io = Check $ do
     -- TODO catch most exception to report failures
-    r <- liftIO $ io
+    r <- liftIO io
     pure r
 
 iterateProperty :: CountOf TestResult ->  GenParams -> (Word64 -> GenRng) -> Property -> IO (PropertyResult, CountOf TestResult)
@@ -73,7 +73,7 @@ iterateProperty limit genParams genRngIter prop = iterProp 1
     iterProp !iter
       | iter == limit = return (PropertySuccess, iter)
       | otherwise  = do
-          r <- liftIO $ toResult
+          r <- liftIO toResult
           case r of
               (PropertyFailed e, _)               -> return (PropertyFailed e, iter)
               (PropertySuccess, cont) | cont      -> iterProp (iter+1)

--- a/Foundation/Check.hs
+++ b/Foundation/Check.hs
@@ -10,8 +10,6 @@
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Foundation.Check
     ( Gen
     , Arbitrary(..)

--- a/Foundation/Check/Arbitrary.hs
+++ b/Foundation/Check/Arbitrary.hs
@@ -109,7 +109,7 @@ arbitraryInteger =
         ]
   where
     integerOfSize :: Bool -> Word -> Gen Integer
-    integerOfSize toSign n = ((if toSign then (\x -> 0 - x) else id) . foldl (\x y -> x + integralUpsize y) 0 . toList)
+    integerOfSize toSign n = ((if toSign then negate else id) . foldl (\x y -> x + integralUpsize y) 0 . toList)
                          <$> (arbitraryUArrayOf n :: Gen (UArray Word8))
 
 arbitraryNatural :: Gen Natural

--- a/Foundation/Check/Config.hs
+++ b/Foundation/Check/Config.hs
@@ -71,9 +71,9 @@ getInteger optionName s =
 
 parseArgs :: [String] -> Config -> Either ParamError Config
 parseArgs []                cfg   = Right cfg
-parseArgs ("--seed":[])    _      = Left "option `--seed' is missing a parameter"
+parseArgs ["--seed"]       _      = Left "option `--seed' is missing a parameter"
 parseArgs ("--seed":x:xs)  cfg    = getInteger "seed" x >>= \i -> parseArgs xs $ cfg { udfSeed = Just $ integralDownsize i }
-parseArgs ("--tests":[])   _      = Left "option `--tests' is missing a parameter"
+parseArgs ["--tests"]      _      = Left "option `--tests' is missing a parameter"
 parseArgs ("--tests":x:xs) cfg    = getInteger "tests" x >>= \i -> parseArgs xs $ cfg { numTests = integralDownsize i }
 parseArgs ("--quiet":xs)   cfg    = parseArgs xs $ cfg { displayOptions = DisplayTerminalErrorOnly }
 parseArgs ("--list-tests":xs) cfg = parseArgs xs $ cfg { listTests = True }

--- a/Foundation/Check/Main.hs
+++ b/Foundation/Check/Main.hs
@@ -67,7 +67,7 @@ filterTestMatching cfg testRoot
     | null (testNameMatch cfg) = Just testRoot
     | otherwise                = testFilter [] testRoot
   where
-    match acc s = or $ fmap (flip isInfixOf currentTestName) $ testNameMatch cfg
+    match acc s = or $ (flip isInfixOf currentTestName <$> testNameMatch cfg)
       where currentTestName = fqTestName (s:acc)
     or [] = False
     or (x:xs)

--- a/Foundation/Check/Main.hs
+++ b/Foundation/Check/Main.hs
@@ -67,7 +67,7 @@ filterTestMatching cfg testRoot
     | null (testNameMatch cfg) = Just testRoot
     | otherwise                = testFilter [] testRoot
   where
-    match acc s = or $ (flip isInfixOf currentTestName <$> testNameMatch cfg)
+    match acc s = or (flip isInfixOf currentTestName <$> testNameMatch cfg)
       where currentTestName = fqTestName (s:acc)
     or [] = False
     or (x:xs)

--- a/Foundation/Check/Main.hs
+++ b/Foundation/Check/Main.hs
@@ -71,7 +71,7 @@ filterTestMatching cfg testRoot
       where currentTestName = fqTestName (s:acc)
     or [] = False
     or (x:xs)
-        | x == True = True
+        | x         = True
         | otherwise = or xs
 
     testFilter acc x =

--- a/Foundation/Check/Main.hs
+++ b/Foundation/Check/Main.hs
@@ -177,8 +177,7 @@ test :: Test -> CheckMain TestResult
 test (Group s l) = pushGroup s l
 test (Unit _ _) = undefined
 test (CheckPlan name plan) = do
-    r <- testCheckPlan name plan
-    return r
+    testCheckPlan name plan
 test (Property name prop) = do
     r'@(PropertyResult _ nb r) <- testProperty name (property prop)
     case r of

--- a/Foundation/Check/Print.hs
+++ b/Foundation/Check/Print.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE Rank2Types                 #-}
 {-# LANGUAGE GADTs                      #-}
 {-# LANGUAGE OverloadedStrings          #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE FlexibleContexts           #-}
 module Foundation.Check.Print

--- a/Foundation/Check/Print.hs
+++ b/Foundation/Check/Print.hs
@@ -23,7 +23,7 @@ propertyToResult propertyTestArg =
             checks = getChecks propertyTestArg
          in if checkHasFailed checks
                 then printError args checks
-                else (PropertySuccess, length args > 0)
+                else (PropertySuccess, not (null args))
   where
     printError args checks = (PropertyFailed (mconcat $ loop 1 args), False)
       where

--- a/Foundation/Collection.hs
+++ b/Foundation/Collection.hs
@@ -8,7 +8,6 @@
 -- Different collections (list, vector, string, ..) unified under 1 API.
 -- an API to rules them all, and in the darkness bind them.
 --
-{-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE FlexibleInstances #-}
 module Foundation.Collection
     ( BoxedZippable(..)

--- a/Foundation/Collection/Indexed.hs
+++ b/Foundation/Collection/Indexed.hs
@@ -5,7 +5,6 @@
 -- Stability   : experimental
 -- Portability : portable
 --
-{-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE FlexibleInstances #-}
 module Foundation.Collection.Indexed
     ( IndexedCollection(..)

--- a/Foundation/Collection/Keyed.hs
+++ b/Foundation/Collection/Keyed.hs
@@ -5,7 +5,6 @@
 -- Stability   : experimental
 -- Portability : portable
 --
-{-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE FlexibleInstances #-}
 module Foundation.Collection.Keyed
     ( KeyedCollection(..)

--- a/Foundation/Collection/Sequential.hs
+++ b/Foundation/Collection/Sequential.hs
@@ -182,7 +182,7 @@ class (IsList c, Item c ~ Element c, Monoid c, Collection c) => Sequential c whe
             | i == endofs = c1 == c2Sub
             | c1 == c2Sub = True
             | otherwise   = loop (succ i)
-          where c2Sub = take len1 $ drop i $ c2
+          where c2Sub = take len1 $ drop i c2
 
 -- Temporary utility functions
 mconcatCollection :: (Monoid (Item c), Sequential c) => c -> Element c

--- a/Foundation/Foreign/MemoryMap/Types.hs
+++ b/Foundation/Foreign/MemoryMap/Types.hs
@@ -29,6 +29,6 @@ data FileMapping = FileMapping
 -- unmap memory when the pointer is garbage.
 fileMappingToFinalPtr :: FileMapping -> IO (FinalPtr Word8)
 fileMappingToFinalPtr (FileMapping ptr _ finalizer) =
-    toFinalPtr ptr (\_ -> finalizer)
+    toFinalPtr ptr (const finalizer)
 
 type FileMapReadF = FilePath -> IO FileMapping

--- a/Foundation/Hashing/FNV.hs
+++ b/Foundation/Hashing/FNV.hs
@@ -8,9 +8,7 @@
 -- Fowler Noll Vo Hash (1 and 1a / 32 / 64 bits versions)
 -- <http://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function>
 --
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash                  #-}
-{-# LANGUAGE UnboxedTuples              #-}
 {-# LANGUAGE BangPatterns               #-}
 module Foundation.Hashing.FNV
     (

--- a/Foundation/Hashing/FNV.hs
+++ b/Foundation/Hashing/FNV.hs
@@ -61,19 +61,19 @@ newtype FNV1a_32 = FNV1a_32 Word
 newtype FNV1a_64 = FNV1a_64 Word64
 
 fnv1_32_Mix8 :: Word8 -> FNV1_32 -> FNV1_32
-fnv1_32_Mix8 !w !(FNV1_32 acc) = FNV1_32 (0x01000193 * acc `xor32` w)
+fnv1_32_Mix8 !w (FNV1_32 acc) = FNV1_32 (0x01000193 * acc `xor32` w)
 {-# INLINE fnv1_32_Mix8 #-}
 
 fnv1a_32_Mix8 :: Word8 -> FNV1a_32 -> FNV1a_32
-fnv1a_32_Mix8 !w !(FNV1a_32 acc) = FNV1a_32 (0x01000193 * (acc `xor32` w))
+fnv1a_32_Mix8 !w (FNV1a_32 acc) = FNV1a_32 (0x01000193 * (acc `xor32` w))
 {-# INLINE fnv1a_32_Mix8 #-}
 
 fnv1_64_Mix8 :: Word8 -> FNV1_64 -> FNV1_64
-fnv1_64_Mix8 !w !(FNV1_64 acc) = FNV1_64 (0x100000001b3 * acc `xor64` w)
+fnv1_64_Mix8 !w (FNV1_64 acc) = FNV1_64 (0x100000001b3 * acc `xor64` w)
 {-# INLINE fnv1_64_Mix8 #-}
 
 fnv1a_64_Mix8 :: Word8 -> FNV1a_64 -> FNV1a_64
-fnv1a_64_Mix8 !w !(FNV1a_64 acc) = FNV1a_64 (0x100000001b3 * (acc `xor64` w))
+fnv1a_64_Mix8 !w (FNV1a_64 acc) = FNV1a_64 (0x100000001b3 * (acc `xor64` w))
 {-# INLINE fnv1a_64_Mix8 #-}
 
 instance Hasher FNV1_32 where
@@ -129,7 +129,7 @@ fnv1_32_mixBa baA !initialState = A.unsafeDewrap goVec goAddr ba
     {-# INLINE goVec #-}
 
     goAddr :: Ptr Word8 -> Offset Word8 -> ST s FNV1_32
-    goAddr !(Ptr ptr) !start = return $ loop start initialState
+    goAddr (Ptr ptr) !start = return $ loop start initialState
       where
         !len = start `offsetPlusE` A.length ba
         loop !idx !acc
@@ -154,7 +154,7 @@ fnv1a_32_mixBa baA !initialState  = A.unsafeDewrap goVec goAddr ba
     {-# INLINE goVec #-}
 
     goAddr :: Ptr Word8 -> Offset Word8 -> ST s FNV1a_32
-    goAddr !(Ptr ptr) !start = return $ loop start initialState
+    goAddr (Ptr ptr) !start = return $ loop start initialState
       where
         !len = start `offsetPlusE` A.length ba
         loop !idx !acc
@@ -179,7 +179,7 @@ fnv1_64_mixBa baA !initialState = A.unsafeDewrap goVec goAddr ba
     {-# INLINE goVec #-}
 
     goAddr :: Ptr Word8 -> Offset Word8 -> ST s FNV1_64
-    goAddr !(Ptr ptr) !start = return $ loop start initialState
+    goAddr (Ptr ptr) !start = return $ loop start initialState
       where
         !len = start `offsetPlusE` A.length ba
         loop !idx !acc
@@ -204,7 +204,7 @@ fnv1a_64_mixBa baA !initialState = A.unsafeDewrap goVec goAddr ba
     {-# INLINE goVec #-}
 
     goAddr :: Ptr Word8 -> Offset Word8 -> ST s FNV1a_64
-    goAddr !(Ptr ptr) !start = return $ loop start initialState
+    goAddr (Ptr ptr) !start = return $ loop start initialState
       where
         !len = start `offsetPlusE` A.length ba
         loop !idx !acc

--- a/Foundation/Hashing/SipHash.hs
+++ b/Foundation/Hashing/SipHash.hs
@@ -109,7 +109,7 @@ mix8Prim !c !w !ist !incremental =
         (# ist , constr ((acc .<<. 8) .|. Prelude.fromIntegral w) #)
 
 mix8 :: Int -> Word8 -> Sip -> Sip
-mix8 !c !w !(Sip ist incremental len) =
+mix8 !c !w (Sip ist incremental len) =
     case incremental of
         SipIncremental7 acc -> Sip (process c ist ((acc .<<. 8) .|. Prelude.fromIntegral w))
                                    SipIncremental0 (len+1)
@@ -125,7 +125,7 @@ mix8 !c !w !(Sip ist incremental len) =
         Sip ist (constr $ ((acc .<<. 8) .|. Prelude.fromIntegral w)) (len+1)
 
 mix32 :: Int -> Word32 -> Sip -> Sip
-mix32 !c !w !(Sip ist incremental len) =
+mix32 !c !w (Sip ist incremental len) =
     case incremental of
         SipIncremental0     -> Sip ist (SipIncremental4 $ Prelude.fromIntegral w) (len+4)
         SipIncremental1 acc -> consume acc 32 SipIncremental5
@@ -146,7 +146,7 @@ mix32 !c !w !(Sip ist incremental len) =
     {-# INLINE consumeProcess #-}
 
 mix64 :: Int -> Word64 -> Sip -> Sip
-mix64 !c !w !(Sip ist incremental len) =
+mix64 !c !w (Sip ist incremental len) =
     case incremental of
         SipIncremental0     -> Sip (process c ist w) SipIncremental0 (len+8)
         SipIncremental1 acc -> consume acc 56 8 SipIncremental1
@@ -190,7 +190,7 @@ mixBa !c !array (Sip initSt initIncr currentLen) =
     goVec ba start = loop8 initSt initIncr start totalLen
       where
         loop8 !st !incr            _     0 = Sip st incr (currentLen + totalLen)
-        loop8 !st !SipIncremental0 !ofs !l
+        loop8 !st SipIncremental0 !ofs !l
             | l < 8     = loop1 st SipIncremental0 ofs l
             | otherwise =
                 let v =     to64 56 (primBaIndex ba ofs)
@@ -216,7 +216,7 @@ mixBa !c !array (Sip initSt initIncr currentLen) =
     goAddr (Ptr ptr) start = return $ loop8 initSt initIncr start totalLen
       where
         loop8 !st !incr            _     0 = Sip st incr (currentLen + totalLen)
-        loop8 !st !SipIncremental0 !ofs !l
+        loop8 !st SipIncremental0 !ofs !l
             | l < 8     = loop1 st SipIncremental0 ofs l
             | otherwise =
                 let v =     to64 56 (primAddrIndex ptr ofs)

--- a/Foundation/Hashing/SipHash.hs
+++ b/Foundation/Hashing/SipHash.hs
@@ -122,7 +122,7 @@ mix8 !c !w (Sip ist incremental len) =
         SipIncremental0     -> Sip ist (SipIncremental1 $ Prelude.fromIntegral w) (len+1)
   where
     doAcc constr acc =
-        Sip ist (constr $ ((acc .<<. 8) .|. Prelude.fromIntegral w)) (len+1)
+        Sip ist (constr ((acc .<<. 8) .|. Prelude.fromIntegral w)) (len+1)
 
 mix32 :: Int -> Word32 -> Sip -> Sip
 mix32 !c !w (Sip ist incremental len) =

--- a/Foundation/IO/File.hs
+++ b/Foundation/IO/File.hs
@@ -146,7 +146,7 @@ foldTextFile chunkf ini fp = do
                         Just _ ->
                             error ("foldTextFile: invalid UTF8 sequence: byte position: " <> show (absPos + pos))
                     chunkf s acc >>= loop (absPos + Offset r)
-                else error ("foldTextFile: read failed") -- FIXME
+                else error "foldTextFile: read failed" -- FIXME
 {-# DEPRECATED foldTextFile "use conduit instead" #-}
 
 blockSize :: Int

--- a/Foundation/Internal/MonadTrans.hs
+++ b/Foundation/Internal/MonadTrans.hs
@@ -13,12 +13,13 @@ module Foundation.Internal.MonadTrans
     ) where
 
 import Foundation.Internal.Base
+import Control.Monad ((>=>))
 
 -- | Simple State monad
 newtype State s m a = State { runState :: s -> m (a, s) }
 
 instance Monad m => Functor (State s m) where
-    fmap f fa = State $ \st -> runState fa st >>= \(a, s2) -> return (f a, s2)
+    fmap f fa = State $ runState fa >=> (\(a, s2) -> return (f a, s2))
 instance Monad m => Applicative (State s m) where
     pure a = State $ \st -> return (a,st)
     fab <*> fa = State $ \s1 -> do
@@ -35,7 +36,7 @@ instance Monad m => Monad (State r m) where
 newtype Reader r m a = Reader { runReader :: r -> m a }
 
 instance Monad m => Functor (Reader r m) where
-    fmap f fa = Reader $ \r -> runReader fa r >>= \a -> return (f a)
+    fmap f fa = Reader $ runReader fa >=> (\a -> return (f a))
 instance Monad m => Applicative (Reader r m) where
     pure a = Reader $ \_ -> return a
     fab <*> fa = Reader $ \r -> do

--- a/Foundation/Monad/Reader.hs
+++ b/Foundation/Monad/Reader.hs
@@ -38,7 +38,7 @@ instance Monad m => Monad (ReaderT r m) where
     {-# INLINE (>>=) #-}
 
 instance MonadTrans (ReaderT r) where
-    lift f = ReaderT $ \_ -> f
+    lift f = ReaderT $ const f
     {-# INLINE lift #-}
 
 instance MonadIO m => MonadIO (ReaderT r m) where

--- a/Foundation/Monad/State.hs
+++ b/Foundation/Monad/State.hs
@@ -12,6 +12,7 @@ module Foundation.Monad.State
 
 import Foundation.Internal.Base (($), (.), const)
 import Foundation.Monad.Base
+import Control.Monad ((>=>))
 
 class Monad m => MonadState m where
     type State m
@@ -42,7 +43,7 @@ instance (Applicative m, Monad m) => Applicative (StateT s m) where
 instance (Functor m, Monad m) => Monad (StateT s m) where
     return a = StateT $ \s -> (,s) `fmap` return a
     {-# INLINE return #-}
-    ma >>= mab = StateT $ \s1 -> runStateT ma s1 >>= \(a, s2) -> runStateT (mab a) s2
+    ma >>= mab = StateT $ runStateT ma >=> (\(a, s2) -> runStateT (mab a) s2)
     {-# INLINE (>>=) #-}
 
 instance MonadTrans (StateT s) where

--- a/Foundation/Monad/State.hs
+++ b/Foundation/Monad/State.hs
@@ -10,6 +10,7 @@ module Foundation.Monad.State
     , runStateT
     ) where
 
+import Foundation.Class.Bifunctor (first)
 import Foundation.Internal.Base (($), (.), const)
 import Foundation.Monad.Base
 import Control.Monad ((>=>))
@@ -28,7 +29,7 @@ put s = withState $ const ((), s)
 newtype StateT s m a = StateT { runStateT :: s -> m (a, s) }
 
 instance Functor m => Functor (StateT s m) where
-    fmap f m = StateT $ \s1 -> (\(a, s2) -> (f a, s2)) `fmap` runStateT m s1
+    fmap f m = StateT $ \s1 -> (first f) `fmap` runStateT m s1
     {-# INLINE fmap #-}
 
 instance (Applicative m, Monad m) => Applicative (StateT s m) where

--- a/Foundation/Network/IPv6.hs
+++ b/Foundation/Network/IPv6.hs
@@ -7,9 +7,7 @@
 --
 -- IPv6 data type
 --
-{-# LANGUAGE ForeignFunctionInterface #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Foundation.Network.IPv6
     ( IPv6

--- a/Foundation/Numerical.hs
+++ b/Foundation/Numerical.hs
@@ -13,7 +13,6 @@
 -- the number of classes.
 --
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 module Foundation.Numerical

--- a/Foundation/Numerical/Additive.hs
+++ b/Foundation/Numerical/Additive.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE CPP               #-}
 {-# LANGUAGE MagicHash         #-}
 module Foundation.Numerical.Additive

--- a/Foundation/Numerical/Multiplicative.hs
+++ b/Foundation/Numerical/Multiplicative.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 module Foundation.Numerical.Multiplicative
     ( Multiplicative(..)

--- a/Foundation/Primitive.hs
+++ b/Foundation/Primitive.hs
@@ -8,7 +8,6 @@
 -- Different collections (list, vector, string, ..) unified under 1 API.
 -- an API to rules them all, and in the darkness bind them.
 --
-{-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE FlexibleInstances #-}
 module Foundation.Primitive
     ( PrimType(..)

--- a/Foundation/Primitive/Types.hs
+++ b/Foundation/Primitive/Types.hs
@@ -529,7 +529,7 @@ primOffsetRecast !ofs =
 {-# RULES "primOffsetRecast W8" [3] forall a . primOffsetRecast a = primOffsetRecastBytes a #-}
 
 primOffsetRecastBytes :: forall b . PrimType b => Offset Word8 -> Offset b
-primOffsetRecastBytes !(Offset o) = Offset (szA `Prelude.quot` o)
+primOffsetRecastBytes (Offset o) = Offset (szA `Prelude.quot` o)
   where !(CountOf szA) = primSizeInBytes (Proxy :: Proxy b)
 {-# INLINE [1] primOffsetRecastBytes #-}
 

--- a/Foundation/Primitive/UTF8/Base.hs
+++ b/Foundation/Primitive/UTF8/Base.hs
@@ -167,11 +167,11 @@ expectAscii (String ba) n v = Vec.unsafeIndex ba n == v
 {-# INLINE expectAscii #-}
 
 write :: PrimMonad prim => MutableString (PrimState prim) -> Offset8 -> Char -> prim Offset8
-write (MutableString mba) i c =
-    if      bool# (ltWord# x 0x80##   ) then encode1
-    else if bool# (ltWord# x 0x800##  ) then encode2
-    else if bool# (ltWord# x 0x10000##) then encode3
-    else                                     encode4
+write (MutableString mba) i c
+    | bool# (ltWord# x 0x80##   ) = encode1
+    | bool# (ltWord# x 0x800##  ) = encode2
+    | bool# (ltWord# x 0x10000##) = encode3
+    | otherwise = encode4
   where
     !(I# xi) = fromEnum c
     !x       = int2Word# xi

--- a/Foundation/Primitive/UTF8/Helper.hs
+++ b/Foundation/Primitive/UTF8/Helper.hs
@@ -8,7 +8,6 @@
 -- Most helpers are lowlevel and unsafe, don't use
 -- directly.
 {-# LANGUAGE BangPatterns               #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash                  #-}
 {-# LANGUAGE NoImplicitPrelude          #-}
 {-# LANGUAGE TypeFamilies               #-}

--- a/Foundation/Primitive/UTF8/Table.hs
+++ b/Foundation/Primitive/UTF8/Table.hs
@@ -7,7 +7,6 @@
 --
 -- UTF8 lookup tables for fast continuation & nb bytes per header queries
 {-# LANGUAGE MagicHash #-}
-{-# LANGUAGE UnboxedTuples #-}
 module Foundation.Primitive.UTF8.Table
     ( isContinuation
     , getNbBytes

--- a/Foundation/String/UTF8.hs
+++ b/Foundation/String/UTF8.hs
@@ -14,7 +14,6 @@
 -- The String data must contain UTF8 valid data.
 --
 {-# LANGUAGE BangPatterns               #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash                  #-}
 {-# LANGUAGE NoImplicitPrelude          #-}
 {-# LANGUAGE TypeFamilies               #-}

--- a/Foundation/String/UTF8.hs
+++ b/Foundation/String/UTF8.hs
@@ -278,11 +278,11 @@ nextWithIndexer getter off =
 writeWithBuilder :: (PrimMonad st, Monad st)
                  => Char
                  -> Builder (UArray Word8) (MVec.MUArray Word8) Word8 st ()
-writeWithBuilder c =
-    if      bool# (ltWord# x 0x80##   ) then encode1
-    else if bool# (ltWord# x 0x800##  ) then encode2
-    else if bool# (ltWord# x 0x10000##) then encode3
-    else                                     encode4
+writeWithBuilder c
+    | bool# (ltWord# x 0x80##   ) = encode1
+    | bool# (ltWord# x 0x800##  ) = encode2
+    | bool# (ltWord# x 0x10000##) = encode3
+    | otherwise = encode4
   where
     !(I# xi) = fromEnum c
     !x       = int2Word# xi

--- a/Foundation/String/UTF8.hs
+++ b/Foundation/String/UTF8.hs
@@ -1078,7 +1078,7 @@ readNatural str
     | sz == 0  = Nothing
     | otherwise =
         case decimalDigits 0 str 0 of
-            (# acc, True, endOfs #) | endOfs > 0 -> Just $ acc
+            (# acc, True, endOfs #) | endOfs > 0 -> Just acc
             _                                    -> Nothing
   where
     !sz = size str
@@ -1356,4 +1356,4 @@ isInfixOf (String needle) (String haystack)
         | i == endOfs           = needle == haystackSub
         | needle == haystackSub = True
         | otherwise             = loop (i+1)
-      where haystackSub = C.take needleLen $ C.drop i $ haystack
+      where haystackSub = C.take needleLen $ C.drop i haystack

--- a/Foundation/String/UTF8.hs
+++ b/Foundation/String/UTF8.hs
@@ -389,7 +389,7 @@ indexN !n (String ba) = Vec.unsafeDewrap goVec goAddr ba
     {-# INLINE goVec #-}
 
     goAddr :: Ptr Word8 -> Offset Word8 -> ST s (Offset Word8)
-    goAddr !(Ptr ptr) !start = return $ loop start (Offset 0)
+    goAddr (Ptr ptr) !start = return $ loop start (Offset 0)
       where
         !len = start `offsetPlusE` Vec.length ba
         loop :: Offset Word8 -> Offset Char -> Offset Word8

--- a/Foundation/String/UTF8.hs
+++ b/Foundation/String/UTF8.hs
@@ -941,7 +941,7 @@ fromChunkBytes :: [UArray Word8] -> [String]
 fromChunkBytes l = loop l
   where
     loop []         = []
-    loop (bytes:[]) =
+    loop [bytes]    =
         case validate bytes (Offset 0) (C.length bytes) of
             (_, Nothing)  -> [fromBytesUnsafe bytes]
             (_, Just err) -> doErr err

--- a/Foundation/Time/StopWatch.hs
+++ b/Foundation/Time/StopWatch.hs
@@ -91,7 +91,7 @@ stopPrecise (StopWatchPrecise blk) = do
     let p64 = castPtr p :: Ptr Word64
     end   <- peek p64
     start <- peek (p64 `ptrPlus` 8)
-    pure $ NanoSeconds $ ((end - start) * secondInNano `div` initPrecise)
+    pure $ NanoSeconds ((end - start) * secondInNano `div` initPrecise)
 #elif defined(darwin_HOST_OS)
     end <- sysMacos_absolute_time
     pure $ NanoSeconds $ case initPrecise of

--- a/Foundation/Time/StopWatch.hs
+++ b/Foundation/Time/StopWatch.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE OverloadedStrings #-}
 
 module Foundation.Time.StopWatch
     ( StopWatchPrecise
@@ -54,7 +53,7 @@ initPrecise = unsafePerformIO $ integralDownsize <$> queryPerformanceFrequency
 initPrecise :: (Word64, Word64)
 initPrecise = unsafePerformIO $ do
     mti <- newPinned (sizeOfCSize size_MachTimebaseInfo)
-    p   <- mutableGetAddr mti 
+    p   <- mutableGetAddr mti
     sysMacos_timebase_info (castPtr p)
     let p32 = castPtr p :: Ptr Word32
     !n <- peek (p32 `ptrPlus` ofs_MachTimebaseInfo_numer)

--- a/Foundation/Timing.hs
+++ b/Foundation/Timing.hs
@@ -5,7 +5,6 @@
 --
 -- An implementation of a timing framework
 --
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Foundation.Timing
     ( Timing(..)
     , Measure(..)

--- a/benchs/Main.hs
+++ b/benchs/Main.hs
@@ -103,7 +103,7 @@ benchsString = bgroup "String"
         fmap (\(n, dat) -> bgroup n $ diffTextString (filter (> 'b')) (Text.filter (> 'b')) dat)
             allDat
 
-    benchRead = bgroup "Read" $
+    benchRead = bgroup "Read"
         [ bgroup "Integer"
             [ bgroup "10000" (diffTextString stringReadInteger textReadInteger (toList $ show 10000))
             , bgroup "1234567891234567890" (diffTextString stringReadInteger textReadInteger (toList $ show 1234567891234567890))

--- a/benchs/compare-libs/Parser.hs
+++ b/benchs/compare-libs/Parser.hs
@@ -18,7 +18,7 @@ import qualified Prelude
 refBufStr :: [Char]
 refBufStr = "Foundation, the new hope"
 refBufW8 :: [Word8]
-refBufW8 = fmap (B.c2w) refBufStr
+refBufW8 = fmap B.c2w refBufStr
 refBufStrLarge :: [Char]
 refBufStrLarge = F.intercalate " " $ Prelude.replicate 100 refBufStr
 refBufW8Large :: [Word8]

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,40 @@
+How to contribute
+=================
+
+Any contributions is welcome, but a short list includes:
+
+* Improve the code base
+* Report an issue
+* Fix an issue
+* Improve the documentation
+* Make tutorial on how to use foundation
+* Make your project use foundation instead of base, report the missing coverage (IO, types, etc.), or what functionality is missing to make a succesful transition
+
+HLint
+-----
+
+[HLint]()
+is a tool for suggesting possible improvements to Haskell code.
+Foundation uses HLint to maintain a high level standard of code.
+
+It is recommended that the latest possible HLint version is used.
+To install the latest version, find out what the 
+[latest version of HLint in hackage](https://hackage.haskell.org/package/hlint)
+is, and install it via:
+
+```
+$ stack install hlint-<VERSION>
+```
+
+To succesfully run HLint locally, you need to pass in the directory on which to run.
+Foundation provides a default HLint configuration file with certain assumed exclusions, so HLint should be run from the Foundation repository root directory for the correct report to be generated.
+Also, it might be necessary to pass in specific CPP flags:
+
+```
+$ hlint \
+--cpp-define=__GLASGOW_HASKELL__=800 \
+--cpp-define=x86_64_HOST_ARCH=1 \
+--cpp-define=mingw32_HOST_OS=1 \
+--report \
+.
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,8 +17,8 @@ pages:
 - Advanced:
   - Runtime option: advanced-runtime.md
 - Porting: porting.md
-#- Project documentation:
-# - Contributors Guide: CONTRIBUTING.md
+- Project documentation:
+  - Contributors Guide: contributing.md
 #  - Maintainer guide: MAINTAINER_GUIDE.md
 
 markdown_extensions:

--- a/programs/Time.hs
+++ b/programs/Time.hs
@@ -102,10 +102,10 @@ stopWatchTest = do
     putStrLn "waiting summing number from 0 to 1000"
     ns3 <- do
             stopWatch <- startPrecise
-            !_ <- evaluate $ foldl' (\x y -> x + y) 0 [0 :: Int ..1000]
+            !_ <- evaluate $ foldl' (+) 0 [0 :: Int ..1000]
             stopPrecise stopWatch
     putStrLn $ show ns3
-    putStrLn . criterionSec =<< criterionDiff (foldl' (\x y -> x + y) 0) [0 :: Int ..1000]
+    putStrLn . criterionSec =<< criterionDiff (foldl' (+) 0) [0 :: Int ..1000]
   where
 #if USE_CRITERION
     criterionInit = C.initializeTime

--- a/tests/Checks.hs
+++ b/tests/Checks.hs
@@ -140,10 +140,10 @@ main = defaultMain $ Group "foundation"
         ]
     , collectionProperties "DList a" (Proxy :: Proxy (DList Word8)) arbitrary
     , Group "Array"
-      [ matrixToGroup "Block" $ primTypesMatrixArbitrary $ \prx arb ->
-            \s -> collectionProperties ("Block " <> s) (functorProxy (Proxy :: Proxy Block) prx) arb
-      , matrixToGroup "Unboxed" $ primTypesMatrixArbitrary $ \prx arb ->
-            \s -> collectionProperties ("Unboxed " <> s) (functorProxy (Proxy :: Proxy UArray) prx) arb
+      [ matrixToGroup "Block" $ primTypesMatrixArbitrary $ \prx arb s ->
+            collectionProperties ("Block " <> s) (functorProxy (Proxy :: Proxy Block) prx) arb
+      , matrixToGroup "Unboxed" $ primTypesMatrixArbitrary $ \prx arb s ->
+            collectionProperties ("Unboxed " <> s) (functorProxy (Proxy :: Proxy UArray) prx) arb
       , Group "Boxed"
         [ collectionProperties "Array(W8)"  (Proxy :: Proxy (Array Word8))  arbitrary
         , collectionProperties "Array(W16)" (Proxy :: Proxy (Array Word16)) arbitrary
@@ -169,8 +169,8 @@ main = defaultMain $ Group "foundation"
         ]
       ]
     , Group "ChunkedUArray"
-      [ matrixToGroup "Unboxed" $ primTypesMatrixArbitrary $ \prx arb ->
-            \s -> collectionProperties ("Unboxed " <> s) (functorProxy (Proxy :: Proxy ChunkedUArray) prx) arb
+      [ matrixToGroup "Unboxed" $ primTypesMatrixArbitrary $ \prx arb s ->
+            collectionProperties ("Unboxed " <> s) (functorProxy (Proxy :: Proxy ChunkedUArray) prx) arb
       ]
     , testRandom
     ]

--- a/tests/Test/Checks/Property/Collection.hs
+++ b/tests/Test/Checks/Property/Collection.hs
@@ -236,7 +236,7 @@ testSequentialProperties proxy genElement = Group "Sequential"
     , Property "init" $ withNonEmptyElements $ \els -> toList (init $ fromListNonEmptyP proxy els) === init els
     , Property "splitOn" $ withElements2E $ \(l, ch) ->
          fmap toList (splitOn (== ch) (fromListP proxy l)) === splitOn (== ch) l
-    , testSplitOn proxy (\_ -> True) mempty
+    , testSplitOn proxy (const True) mempty
     , Property "intercalate c (splitOn (c ==) col) == col" $ withElements2E $ \(c, ch) ->
         intercalate [ch] (splitOn (== ch) c) === c
     , Property "intercalate c (splitOn (c ==) (col ++ [c]) == (col ++ [c])" $ withElements2E $ \(c, ch) ->

--- a/tests/Test/Foundation/Collection.hs
+++ b/tests/Test/Foundation/Collection.hs
@@ -203,7 +203,7 @@ testSequentialOps proxy genElement = testGroup "Sequential"
     , testProperty "init" $ withNonEmptyElements $ \els -> toList (init $ fromListNonEmptyP proxy els) === init els
     , testProperty "splitOn" $ withElements2E $ \(l, ch) ->
          fmap toList (splitOn (== ch) (fromListP proxy l)) === splitOn (== ch) l
-    , testSplitOn proxy (\_ -> True) mempty
+    , testSplitOn proxy (const True) mempty
     , testProperty "intercalate c (splitOn (c ==) col) == col" $ withElements2E $ \(c, ch) ->
         intercalate [ch] (splitOn (== ch) c) === c
     , testProperty "intercalate c (splitOn (c ==) (col ++ [c]) == (col ++ [c])" $ withElements2E $ \(c, ch) ->

--- a/tests/Test/Foundation/Encoding.hs
+++ b/tests/Test/Foundation/Encoding.hs
@@ -24,8 +24,8 @@ testEncodings (x:xs, expected) = testEncoding x expected <> testEncodings (xs, e
 
 testEncoding :: EncodedString -> String -> [TestTree]
 testEncoding (EncodedString encoding ba) expected =
-    [ testCase (show encoding <> " -> UTF8") $ testFromBytes
-    , testCase ("UTF8 -> " <> show encoding) $ testToBytes
+    [ testCase (show encoding <> " -> UTF8") testFromBytes
+    , testCase ("UTF8 -> " <> show encoding) testToBytes
     ]
   where
     testFromBytes :: Assertion

--- a/tests/Test/Foundation/Misc.hs
+++ b/tests/Test/Foundation/Misc.hs
@@ -31,6 +31,6 @@ testHexadecimal = testGroup "hexadecimal"
     ]
 
 testUUID = testGroup "UUID"
-    [ testProperty "show" $ show (UUID.nil) === "00000000-0000-0000-0000-000000000000"
+    [ testProperty "show" $ show UUID.nil === "00000000-0000-0000-0000-000000000000"
     , testProperty "show-bin" $ fmap show (UUID.fromBinary (fromList [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16])) === Just "100f0e0d-0c0b-0a09-0807-060504030201"
     ]

--- a/tests/Test/Foundation/Number.hs
+++ b/tests/Test/Foundation/Number.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies        #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE CPP #-}
 module Test.Foundation.Number
     ( testNumber

--- a/tests/Test/Foundation/Random.hs
+++ b/tests/Test/Foundation/Random.hs
@@ -94,7 +94,7 @@ calculate buckets = RandomTestResult
         accEnt ent pr
             | pr > 0.0  = ent + (pr * xlog (1 Prelude./ pr))
             | otherwise = ent
-        xlog v = Prelude.logBase 10 v * (Prelude.log 10 Prelude./ Prelude.log 2)
+        xlog v = Prelude.logBase 10 v * (Prelude.logBase 2 10)
 
         accMeanChi :: (Word64, Double) -> (Int, Word64) -> (Word64, Double)
         accMeanChi (dataSum, chiSq) (i, ccount) =

--- a/tests/Test/Foundation/String.hs
+++ b/tests/Test/Foundation/String.hs
@@ -30,7 +30,7 @@ testStringRefs = testGroup "String"
            , testGroup "Encoding Sample1" (testEncodings sample1)
            , testGroup "Encoding Sample2" (testEncodings sample2)
            ]
-    , testGroup "ASCII" $
+    , testGroup "ASCII"
         [  testCollection "Sequential" (Proxy :: Proxy AsciiString) genAsciiChar
         ]
     ]

--- a/tests/Test/Utils/Foreign.hs
+++ b/tests/Test/Utils/Foreign.hs
@@ -24,5 +24,5 @@ createPtr l
         let (CountOf szElem) = size (Proxy :: Proxy e)
             nbBytes = szElem * (let (CountOf c) = length l in c)
         ptr <- mallocBytes nbBytes
-        forM_ (zip [0..] l) $ \(o, e) -> pokeOff ptr o e
+        forM_ (zip [0..] l) $ uncurry (pokeOff ptr)
         toFinalPtr ptr free

--- a/tests/Test/Utils/Foreign.hs
+++ b/tests/Test/Utils/Foreign.hs
@@ -25,4 +25,4 @@ createPtr l
             nbBytes = szElem * (let (CountOf c) = length l in c)
         ptr <- mallocBytes nbBytes
         forM_ (zip [0..] l) $ \(o, e) -> pokeOff ptr o e
-        toFinalPtr ptr (\p -> free p)
+        toFinalPtr ptr free

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -222,7 +222,7 @@ tests =
     [ testArrayRefs
     , testChunkedUArrayRefs
     , Bits.tests
-    , testCollection "Bitmap"  (Proxy :: Proxy (Bitmap))  arbitrary
+    , testCollection "Bitmap"  (Proxy :: Proxy Bitmap)  arbitrary
     , testStringRefs
     , testGroup "VFS"
         [ testGroup "FilePath" $ testCaseFilePath <> (testPath (arbitrary :: Gen FilePath))


### PR DESCRIPTION
Initial HLint work fixing warnings.

Error free `hlint` output can be achieved via:

```
hlint --cpp-define=__GLASGOW_HASKELL__=800 --cpp-define=x86_64_HOST_ARCH=1 --cpp-define=mingw32_HOST_OS=1 .
```

Still TODO:
- [x] Add documentation on HLint.
- [x] Move "How To Contribute" section to docs section and add HLint there. 
- [ ] Link from README to contributing guide.
- [x] Deal with suggestions.
- [ ] Add to CI.