### PR TITLE
Rewrite 'uncurryN' to use 'Fstable' etc., add 'curryN'

### DIFF
--- a/Foundation/Collection/Zippable.hs
+++ b/Foundation/Collection/Zippable.hs
@@ -21,8 +21,9 @@ import qualified Foundation.Array.Boxed as BA
 import qualified Foundation.String.UTF8 as S
 import           Foundation.Collection.Element
 import           Foundation.Collection.Sequential
-import           Foundation.Internal.Base
-import qualified Prelude
+import           Foundation.Internal.Base hiding (fst, snd)
+import           Foundation.Tuple
+--import qualified Prelude
 import           GHC.ST
 
 class Sequential col => Zippable col where
@@ -272,11 +273,12 @@ uncons7 xs = let (as, bs, cs, ds, es, fs, gs) = xs
                    return ( (a', b', c', d', e', f', g')
                           , (as', bs', cs', ds', es', fs', gs') )
 
-uncurry2 :: (a -> b -> c) -> (a, b) -> c
-uncurry2 = Prelude.uncurry
+uncurry2 :: (Fstable p, Sndable p) => (ProductFirst p -> ProductSecond p -> d) -> p -> d
+uncurry2 fn p = fn (fst p) (snd p)
 
-uncurry3 :: (a -> b -> c -> d) -> (a, b, c) -> d
-uncurry3 fn (a, b, c) = fn a b c
+uncurry3 :: (Fstable p, Sndable p, Thdable p) =>
+              (ProductFirst p -> ProductSecond p -> ProductThird p -> d) -> p -> d
+uncurry3 fn p = fn (fst p) (snd p) (thd p)
 
 uncurry4 :: (a -> b -> c -> d -> g) -> (a, b, c, d) -> g
 uncurry4 fn (a, b, c, d) = fn a b c d

--- a/Foundation/Collection/Zippable.hs
+++ b/Foundation/Collection/Zippable.hs
@@ -272,23 +272,3 @@ uncons7 xs = let (as, bs, cs, ds, es, fs, gs) = xs
                    (g', gs') <- uncons gs
                    return ( (a', b', c', d', e', f', g')
                           , (as', bs', cs', ds', es', fs', gs') )
-
-uncurry2 :: (Fstable p, Sndable p)
-         => (ProductFirst p -> ProductSecond p -> d) -> p -> d
-uncurry2 fn p = fn (fst p) (snd p)
-
-uncurry3 :: (Fstable p, Sndable p, Thdable p)
-         => (ProductFirst p -> ProductSecond p -> ProductThird p -> d) -> p -> d
-uncurry3 fn p = fn (fst p) (snd p) (thd p)
-
-uncurry4 :: (a -> b -> c -> d -> g) -> (a, b, c, d) -> g
-uncurry4 fn (a, b, c, d) = fn a b c d
-
-uncurry5 :: (a -> b -> c -> d -> e -> f) -> (a, b, c, d, e) -> f
-uncurry5 fn (a, b, c, d, e) = fn a b c d e
-
-uncurry6 :: (a -> b -> c -> d -> e -> f -> g) -> (a, b, c, d, e, f) -> g
-uncurry6 fn (a, b, c, d, e, f) = fn a b c d e f
-
-uncurry7 :: (a -> b -> c -> d -> e -> f -> g -> h) -> (a, b, c, d, e, f, g) -> h
-uncurry7 fn (a, b, c, d, e, f, g) = fn a b c d e f g

--- a/Foundation/Collection/Zippable.hs
+++ b/Foundation/Collection/Zippable.hs
@@ -191,7 +191,7 @@ class Zippable col => BoxedZippable col where
   -- | Like 'unzip', but works on a collection of 7-element tuples.
   unzip7 :: ( Sequential a, Sequential b, Sequential c, Sequential d, Sequential e, Sequential f, Sequential g
             , Element col ~ (Element a, Element b, Element c, Element d, Element e, Element f, Element g) )
-        => col -> (a, b, c, d, e, f, g)
+         => col -> (a, b, c, d, e, f, g)
   unzip7 = go . toList
     where go [] = (mempty, mempty, mempty, mempty, mempty, mempty, mempty)
           go ((a, b, c, d, e, f, g):xs) =
@@ -273,11 +273,12 @@ uncons7 xs = let (as, bs, cs, ds, es, fs, gs) = xs
                    return ( (a', b', c', d', e', f', g')
                           , (as', bs', cs', ds', es', fs', gs') )
 
-uncurry2 :: (Fstable p, Sndable p) => (ProductFirst p -> ProductSecond p -> d) -> p -> d
+uncurry2 :: (Fstable p, Sndable p)
+         => (ProductFirst p -> ProductSecond p -> d) -> p -> d
 uncurry2 fn p = fn (fst p) (snd p)
 
-uncurry3 :: (Fstable p, Sndable p, Thdable p) =>
-              (ProductFirst p -> ProductSecond p -> ProductThird p -> d) -> p -> d
+uncurry3 :: (Fstable p, Sndable p, Thdable p)
+         => (ProductFirst p -> ProductSecond p -> ProductThird p -> d) -> p -> d
 uncurry3 fn p = fn (fst p) (snd p) (thd p)
 
 uncurry4 :: (a -> b -> c -> d -> g) -> (a, b, c, d) -> g

--- a/Foundation/Tuple.hs
+++ b/Foundation/Tuple.hs
@@ -14,9 +14,21 @@ module Foundation.Tuple
     , Fstable(..)
     , Sndable(..)
     , Thdable(..)
+    , curry2
+    , curry3
+    , curry4
+    , curry5
+    , curry6
+    , curry7
+    , uncurry2
+    , uncurry3
+    , uncurry4
+    , uncurry5
+    , uncurry6
+    , uncurry7
     ) where
 
-import Foundation.Internal.Base
+import Foundation.Internal.Base hiding (fst, snd)
 import Foundation.Class.Bifunctor
 import Foundation.Primitive
 
@@ -109,3 +121,45 @@ instance Thdable (Tuple3 a b c) where
 instance Thdable (Tuple4 a b c d) where
     type ProductThird (Tuple4 a b c d) = c
     thd (Tuple4 _ _ c _) = c
+
+-- | `uncurryN' converts a n-ary function to a function on a n-tuple. Dual of `curry'
+-- `uncurry2' and `uncurry3' are parametrised over arbitrary prdct types with projections
+-- `fst', `snd' and `thd', while all higher alternatives are specialized to tuples.
+uncurry2 :: (Fstable p, Sndable p)
+         => (ProductFirst p -> ProductSecond p -> d) -> p -> d
+uncurry2 fn p = fn (fst p) (snd p)
+
+uncurry3 :: (Fstable p, Sndable p, Thdable p)
+         => (ProductFirst p -> ProductSecond p -> ProductThird p -> d) -> p -> d
+uncurry3 fn p = fn (fst p) (snd p) (thd p)
+
+uncurry4 :: (a -> b -> c -> d -> g) -> (a, b, c, d) -> g
+uncurry4 fn (a, b, c, d) = fn a b c d
+
+uncurry5 :: (a -> b -> c -> d -> e -> f) -> (a, b, c, d, e) -> f
+uncurry5 fn (a, b, c, d, e) = fn a b c d e
+
+uncurry6 :: (a -> b -> c -> d -> e -> f -> g) -> (a, b, c, d, e, f) -> g
+uncurry6 fn (a, b, c, d, e, f) = fn a b c d e f
+
+uncurry7 :: (a -> b -> c -> d -> e -> f -> g -> h) -> (a, b, c, d, e, f, g) -> h
+uncurry7 fn (a, b, c, d, e, f, g) = fn a b c d e f g
+
+-- | `curryN' converts an uncurried function to a n-ary function. Dual of `curry'.
+curry2 :: ((a, b) -> c) -> a -> b -> c
+curry2 fn a b = fn (a, b)
+
+curry3 :: ((a, b, c) -> d) -> a -> b -> c -> d
+curry3 fn a b c = fn (a, b, c)
+
+curry4 :: ((a, b, c, d) -> e) -> a -> b -> c -> d -> e
+curry4 fn a b c d = fn (a, b, c, d)
+
+curry5 :: ((a, b, c, d, e) -> f) -> a -> b -> c -> d -> e -> f
+curry5 fn a b c d e = fn (a, b, c, d, e)
+
+curry6 :: ((a, b, c, d, e, f) -> g) -> a -> b -> c -> d -> e -> f -> g
+curry6 fn a b c d e f = fn (a, b, c, d, e, f)
+
+curry7 :: ((a, b, c, d, e, f, g) -> h) -> a -> b -> c -> d -> e -> f -> g -> h
+curry7 fn a b c d e f g = fn (a, b, c, d, e, f, g)

--- a/Foundation/Tuple.hs
+++ b/Foundation/Tuple.hs
@@ -126,14 +126,14 @@ instance Thdable (Tuple4 a b c d) where
 -- `uncurry2' and `uncurry3' are parametrised over arbitrary prdct types with projections
 -- `fst', `snd' and `thd', while all higher alternatives are specialized to tuples.
 uncurry2 :: (Fstable p, Sndable p)
-         => (ProductFirst p -> ProductSecond p -> d) -> p -> d
+         => (ProductFirst p -> ProductSecond p -> c) -> p -> c
 uncurry2 fn p = fn (fst p) (snd p)
 
 uncurry3 :: (Fstable p, Sndable p, Thdable p)
          => (ProductFirst p -> ProductSecond p -> ProductThird p -> d) -> p -> d
 uncurry3 fn p = fn (fst p) (snd p) (thd p)
 
-uncurry4 :: (a -> b -> c -> d -> g) -> (a, b, c, d) -> g
+uncurry4 :: (a -> b -> c -> d -> e) -> (a, b, c, d) -> e
 uncurry4 fn (a, b, c, d) = fn a b c d
 
 uncurry5 :: (a -> b -> c -> d -> e -> f) -> (a, b, c, d, e) -> f


### PR DESCRIPTION
Moved `uncurry` from `Foundation.Collection.Zippable` to `Foundation.Tuple`.
 - Reason: `uncurry` is a more powerful abstraction and useful as a `Foundation.Tuple` export.

Implemented `curry` in `Foundation.Tuple`. Also export `curry`.

`uncurry2` and `uncurry3` now use `Fstable`, `Sndable` and `Thdable`.

Further ideas:
 - Make any instance of `Fstable` also an instance of `Nthable 1` (e.g. `instance Fstable a => Nthable 1 a`).
 - Same for `Sndable`, etc.