### PR TITLE
Optimize `Collection' functions for internal types

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -80,6 +80,8 @@
 - ignore: {name: Use traverse, within: Foundation.Collection.Mappable}
 - ignore: {name: Use void, within: Foundation.Monad.Exception}
 - ignore: {name: Use when}
+- ignore: {name: Use and, within: Foundation.Array.Bitmap}
+- ignore: {name: Use or, within: Foundation.Array.Bitmap}
 
 
 # Define some custom infix operators

--- a/Foundation/Array/Bitmap.hs
+++ b/Foundation/Array/Bitmap.hs
@@ -91,8 +91,8 @@ instance C.Collection Bitmap where
                  in foldl' min (unsafeIndex bm' 0) bm'
     maximum bm = let bm' = C.getNonEmpty bm
                  in foldl' max (unsafeIndex bm' 0) bm'
-    all p      = foldl' (\acc x -> p x && acc) True
-    any p      = foldl' (\acc x -> p x || acc) False
+    all = all
+    any = any
 
 instance C.Sequential Bitmap where
     take = take
@@ -445,6 +445,24 @@ foldl' f initialAcc vec = loop 0 initialAcc
     loop i !acc
         | i .==# len = acc
         | otherwise  = loop (i+1) (f acc (unsafeIndex vec i))
+
+all :: (Bool -> Bool) -> Bitmap -> Bool
+all p bm = loop 0
+  where
+    len = length bm
+    loop !i
+      | i .==# len = True
+      | not $ p (unsafeIndex bm i) = False
+      | otherwise = loop (i + 1)
+
+any :: (Bool -> Bool) -> Bitmap -> Bool
+any p bm = loop 0
+  where
+    len = length bm
+    loop !i
+      | i .==# len = False
+      | p (unsafeIndex bm i) = True
+      | otherwise = loop (i + 1)
 
 unoptimised :: ([Bool] -> [Bool]) -> Bitmap -> Bitmap
 unoptimised f = vFromList . f . vToList

--- a/Foundation/Array/Bitmap.hs
+++ b/Foundation/Array/Bitmap.hs
@@ -87,10 +87,13 @@ instance C.Collection Bitmap where
     null = null
     length = length
     elem e = Data.List.elem e . toList
-    minimum = Data.List.minimum . toList . C.getNonEmpty -- TODO can shortcircuit all this massively
-    maximum = Data.List.maximum . toList . C.getNonEmpty -- TODO DITTO
-    all p = Data.List.all p . toList
-    any p = Data.List.any p . toList
+    minimum bm = let bm' = getNonEmpty bm
+                 in foldl' min (UV.unsafeIndex bm' 0) bm'
+    maximum bm = let bm' = getNonEmpty bm
+                 in foldl' max (UV.unsafeIndex bm' 0) bm'
+    all p      = foldl' (\acc x -> p x && acc) True
+    any p      = foldl' (\acc x -> p x || acc) False
+
 instance C.Sequential Bitmap where
     take = take
     drop = drop

--- a/Foundation/Array/Bitmap.hs
+++ b/Foundation/Array/Bitmap.hs
@@ -87,10 +87,10 @@ instance C.Collection Bitmap where
     null = null
     length = length
     elem e = Data.List.elem e . toList
-    minimum bm = let bm' = getNonEmpty bm
-                 in foldl' min (UV.unsafeIndex bm' 0) bm'
-    maximum bm = let bm' = getNonEmpty bm
-                 in foldl' max (UV.unsafeIndex bm' 0) bm'
+    minimum bm = let bm' = C.getNonEmpty bm
+                 in foldl' min (unsafeIndex bm' 0) bm'
+    maximum bm = let bm' = C.getNonEmpty bm
+                 in foldl' max (unsafeIndex bm' 0) bm'
     all p      = foldl' (\acc x -> p x && acc) True
     any p      = foldl' (\acc x -> p x || acc) False
 

--- a/Foundation/Array/Bitmap.hs
+++ b/Foundation/Array/Bitmap.hs
@@ -87,10 +87,8 @@ instance C.Collection Bitmap where
     null = null
     length = length
     elem e = Data.List.elem e . toList
-    minimum bm = let bm' = C.getNonEmpty bm
-                 in foldl' min (unsafeIndex bm' 0) bm'
-    maximum bm = let bm' = C.getNonEmpty bm
-                 in foldl' max (unsafeIndex bm' 0) bm'
+    maximum = any id . C.getNonEmpty
+    minimum = all id . C.getNonEmpty
     all = all
     any = any
 

--- a/Foundation/Array/Boxed.hs
+++ b/Foundation/Array/Boxed.hs
@@ -57,6 +57,9 @@ module Foundation.Array.Boxed
     , foldl'
     , foldr
     , foldl
+    , foldl1'
+    , foldr1
+    , foldl1
     , all
     , any
     , builderAppend
@@ -67,6 +70,7 @@ import           GHC.Prim
 import           GHC.Types
 import           GHC.ST
 import           Foundation.Numerical
+import           Foundation.Collection.NonEmpty
 import           Foundation.Internal.Base
 import           Foundation.Internal.Proxy
 import           Foundation.Internal.MonadTrans
@@ -660,6 +664,18 @@ foldl' f initialAcc vec = loop 0 initialAcc
     loop !i !acc
         | i .==# len = acc
         | otherwise  = loop (i+1) (f acc (unsafeIndex vec i))
+
+foldl1 :: (ty -> ty -> ty) -> NonEmpty (Array ty) -> ty
+foldl1 f arr = let (initialAcc, rest) = splitAt 1 $ getNonEmpty arr
+               in foldl f (unsafeIndex initialAcc 0) rest
+
+foldl1' :: (ty -> ty -> ty) -> NonEmpty (Array ty) -> ty
+foldl1' f arr = let (initialAcc, rest) = splitAt 1 $ getNonEmpty arr
+               in foldl' f (unsafeIndex initialAcc 0) rest
+
+foldr1 :: (ty -> ty -> ty) -> NonEmpty (Array ty) -> ty
+foldr1 f arr = let (initialAcc, rest) = revSplitAt 1 $ getNonEmpty arr
+               in foldr f (unsafeIndex initialAcc 0) rest
 
 all :: (ty -> Bool) -> Array ty -> Bool
 all p ba = loop 0

--- a/Foundation/Array/Boxed.hs
+++ b/Foundation/Array/Boxed.hs
@@ -57,6 +57,8 @@ module Foundation.Array.Boxed
     , foldl'
     , foldr
     , foldl
+    , all
+    , any
     , builderAppend
     , builderBuild
     ) where
@@ -658,6 +660,24 @@ foldl' f initialAcc vec = loop 0 initialAcc
     loop !i !acc
         | i .==# len = acc
         | otherwise  = loop (i+1) (f acc (unsafeIndex vec i))
+
+all :: (ty -> Bool) -> Array ty -> Bool
+all p ba = loop 0
+  where
+    len = length ba
+    loop !i
+      | i .==# len = True
+      | not $ p (unsafeIndex ba i) = False
+      | otherwise = loop (i + 1)
+
+any :: (ty -> Bool) -> Array ty -> Bool
+any p ba = loop 0
+  where
+    len = length ba
+    loop !i
+      | i .==# len = False
+      | p (unsafeIndex ba i) = True
+      | otherwise = loop (i + 1)
 
 builderAppend :: PrimMonad state => ty -> Builder (Array ty) (MArray ty) ty state ()
 builderAppend v = Builder $ State $ \(i, st) ->

--- a/Foundation/Array/Boxed.hs
+++ b/Foundation/Array/Boxed.hs
@@ -59,7 +59,6 @@ module Foundation.Array.Boxed
     , foldl
     , foldl1'
     , foldr1
-    , foldl1
     , all
     , any
     , builderAppend
@@ -664,10 +663,6 @@ foldl' f initialAcc vec = loop 0 initialAcc
     loop !i !acc
         | i .==# len = acc
         | otherwise  = loop (i+1) (f acc (unsafeIndex vec i))
-
-foldl1 :: (ty -> ty -> ty) -> NonEmpty (Array ty) -> ty
-foldl1 f arr = let (initialAcc, rest) = splitAt 1 $ getNonEmpty arr
-               in foldl f (unsafeIndex initialAcc 0) rest
 
 foldl1' :: (ty -> ty -> ty) -> NonEmpty (Array ty) -> ty
 foldl1' f arr = let (initialAcc, rest) = splitAt 1 $ getNonEmpty arr

--- a/Foundation/Array/Chunked/Unboxed.hs
+++ b/Foundation/Array/Chunked/Unboxed.hs
@@ -67,8 +67,8 @@ instance PrimType ty => C.Collection (ChunkedUArray ty) where
     elem   = elem
     minimum = minimum
     maximum = maximum
-    all p = foldl' (\acc x -> p x && acc) True
-    any p = foldl' (\acc x -> p x || acc) False
+    all p (ChunkedUArray cua) = A.all (U.all p) cua
+    any p (ChunkedUArray cua) = A.any (U.any p) cua
 
 instance PrimType ty => C.Sequential (ChunkedUArray ty) where
     take = take

--- a/Foundation/Array/Chunked/Unboxed.hs
+++ b/Foundation/Array/Chunked/Unboxed.hs
@@ -156,12 +156,12 @@ foldr :: PrimType ty => (ty -> a -> a) -> a -> ChunkedUArray ty -> a
 foldr f initialAcc (ChunkedUArray cua) = A.foldr (flip $ U.foldr f) initialAcc cua
 
 minimum :: (Ord ty, PrimType ty) => C.NonEmpty (ChunkedUArray ty) -> ty
-minimum cua = foldl' min (unsafeIndex cua' 0) cua'
+minimum cua = foldl' min (unsafeIndex cua' 0) (drop 1 cua')
   where
     cua' = C.getNonEmpty cua
 
 maximum :: (Ord ty, PrimType ty) => C.NonEmpty (ChunkedUArray ty) -> ty
-maximum cua = foldl' max (unsafeIndex cua' 0) cua'
+maximum cua = foldl' max (unsafeIndex cua' 0) (drop 1 cua')
   where
     cua' = C.getNonEmpty cua
 

--- a/Foundation/Array/Chunked/Unboxed.hs
+++ b/Foundation/Array/Chunked/Unboxed.hs
@@ -67,8 +67,8 @@ instance PrimType ty => C.Collection (ChunkedUArray ty) where
     elem   = elem
     minimum = minimum
     maximum = maximum
-    all p = Data.List.all p . toList
-    any p = Data.List.any p . toList
+    all p = foldl' (\acc x -> p x && acc) True
+    any p = foldl' (\acc x -> p x || acc) False
 
 instance PrimType ty => C.Sequential (ChunkedUArray ty) where
     take = take

--- a/Foundation/Array/Chunked/Unboxed.hs
+++ b/Foundation/Array/Chunked/Unboxed.hs
@@ -55,7 +55,6 @@ instance PrimType ty => IsList (ChunkedUArray ty) where
     toList = vToList
 
 instance PrimType ty => C.Foldable (ChunkedUArray ty) where
-    foldl = foldl
     foldl' = foldl'
     foldr = foldr
     -- Use the default foldr' instance
@@ -143,11 +142,8 @@ elem el (ChunkedUArray array) = loop 0
                 True  -> True
                 False -> loop (i+1)
 
--- | Fold a `ChunkedUArray' leftwards lazily. Implemented internally using a double
+-- | Fold a `ChunkedUArray' leftwards strictly. Implemented internally using a double
 -- fold on the nested Array structure. Other folds implemented analogously.
-foldl :: PrimType ty => (a -> ty -> a) -> a -> ChunkedUArray ty -> a
-foldl f initialAcc (ChunkedUArray cua) = A.foldl (U.foldl f) initialAcc cua
-
 foldl' :: PrimType ty => (a -> ty -> a) -> a -> ChunkedUArray ty -> a
 foldl' f initialAcc (ChunkedUArray cua) = A.foldl' (U.foldl' f) initialAcc cua
 

--- a/Foundation/Array/Chunked/Unboxed.hs
+++ b/Foundation/Array/Chunked/Unboxed.hs
@@ -55,6 +55,12 @@ instance PrimType ty => IsList (ChunkedUArray ty) where
     fromList = vFromList
     toList = vToList
 
+instance PrimType ty => C.Foldable (ChunkedUArray ty) where
+    foldl = foldl
+    foldl' = foldl'
+    foldr = foldr
+    -- Use the default foldr' instance
+
 instance PrimType ty => C.Collection (ChunkedUArray ty) where
     null = null
     length = length
@@ -138,13 +144,26 @@ elem el (ChunkedUArray array) = loop 0
                 True  -> True
                 False -> loop (i+1)
 
--- | TODO: Improve implementation.
-minimum :: (Ord ty, PrimType ty) => C.NonEmpty (ChunkedUArray ty) -> ty
-minimum = Data.List.minimum . toList . C.getNonEmpty
+-- | Fold a `ChunkedUArray' leftwards lazily. Implemented internally using a double
+-- fold on the nested Array structure. Other folds implemented analogously.
+foldl :: PrimType ty => (a -> ty -> a) -> a -> ChunkedUArray ty -> a
+foldl f initialAcc (ChunkedUArray cua) = A.foldl (U.foldl f) initialAcc cua
 
--- | TODO: Improve implementation.
+foldl' :: PrimType ty => (a -> ty -> a) -> a -> ChunkedUArray ty -> a
+foldl' f initialAcc (ChunkedUArray cua) = A.foldl' (U.foldl' f) initialAcc cua
+
+foldr :: PrimType ty => (ty -> a -> a) -> a -> ChunkedUArray ty -> a
+foldr f initialAcc (ChunkedUArray cua) = A.foldr (flip $ U.foldr f) initialAcc cua
+
+minimum :: (Ord ty, PrimType ty) => C.NonEmpty (ChunkedUArray ty) -> ty
+minimum cua = foldl' min (unsafeIndex cua' 0) cua'
+  where
+    cua' = C.getNonEmpty cua
+
 maximum :: (Ord ty, PrimType ty) => C.NonEmpty (ChunkedUArray ty) -> ty
-maximum = Data.List.maximum . toList . C.getNonEmpty
+maximum cua = foldl' max (unsafeIndex cua' 0) cua'
+  where
+    cua' = C.getNonEmpty cua
 
 -- | Equality between `ChunkedUArray`.
 -- This function is fiddly to write as is not enough to compare for

--- a/Foundation/Array/Unboxed.hs
+++ b/Foundation/Array/Unboxed.hs
@@ -85,6 +85,9 @@ module Foundation.Array.Unboxed
     , foldl
     , foldr
     , foldl'
+    , foldl1
+    , foldr1
+    , foldl1'
     , all
     , any
     , foreignMem
@@ -109,6 +112,7 @@ import           Foundation.Internal.Primitive
 import           Foundation.Internal.Proxy
 import           Foundation.Primitive.Types.OffsetSize
 import           Foundation.Internal.MonadTrans
+import           Foundation.Collection.NonEmpty
 import qualified Foundation.Primitive.Base16 as Base16
 import           Foundation.Primitive.Monad
 import           Foundation.Primitive.Types
@@ -1053,6 +1057,18 @@ foldl' f initialAcc vec = loop 0 initialAcc
     loop i !acc
         | i .==# len = acc
         | otherwise  = loop (i+1) (f acc (unsafeIndex vec i))
+
+foldl1 :: PrimType ty => (ty -> ty -> ty) -> NonEmpty (UArray ty) -> ty
+foldl1 f arr = let (initialAcc, rest) = splitAt 1 $ getNonEmpty arr
+               in foldl f (unsafeIndex initialAcc 0) rest
+
+foldl1' :: PrimType ty => (ty -> ty -> ty) -> NonEmpty (UArray ty) -> ty
+foldl1' f arr = let (initialAcc, rest) = splitAt 1 $ getNonEmpty arr
+               in foldl' f (unsafeIndex initialAcc 0) rest
+
+foldr1 :: PrimType ty => (ty -> ty -> ty) -> NonEmpty (UArray ty) -> ty
+foldr1 f arr = let (initialAcc, rest) = revSplitAt 1 $ getNonEmpty arr
+               in foldr f (unsafeIndex initialAcc 0) rest
 
 all :: PrimType ty => (ty -> Bool) -> UArray ty -> Bool
 all p uv = loop 0

--- a/Foundation/Array/Unboxed.hs
+++ b/Foundation/Array/Unboxed.hs
@@ -85,6 +85,8 @@ module Foundation.Array.Unboxed
     , foldl
     , foldr
     , foldl'
+    , all
+    , any
     , foreignMem
     , fromForeignPtr
     , builderAppend
@@ -1051,6 +1053,24 @@ foldl' f initialAcc vec = loop 0 initialAcc
     loop i !acc
         | i .==# len = acc
         | otherwise  = loop (i+1) (f acc (unsafeIndex vec i))
+
+all :: PrimType ty => (ty -> Bool) -> UArray ty -> Bool
+all p uv = loop 0
+  where
+    len = length uv
+    loop !i
+      | i .==# len = True
+      | not $ p (unsafeIndex uv i) = False
+      | otherwise = loop (i + 1)
+
+any :: PrimType ty => (ty -> Bool) -> UArray ty -> Bool
+any p uv = loop 0
+  where
+    len = length uv
+    loop !i
+      | i .==# len = False
+      | p (unsafeIndex uv i) = True
+      | otherwise = loop (i + 1)
 
 builderAppend :: (PrimType ty, PrimMonad state) => ty -> Builder (UArray ty) (MUArray ty) ty state ()
 builderAppend v = Builder $ State $ \(i, st) ->

--- a/Foundation/Array/Unboxed.hs
+++ b/Foundation/Array/Unboxed.hs
@@ -85,7 +85,6 @@ module Foundation.Array.Unboxed
     , foldl
     , foldr
     , foldl'
-    , foldl1
     , foldr1
     , foldl1'
     , all
@@ -1057,10 +1056,6 @@ foldl' f initialAcc vec = loop 0 initialAcc
     loop i !acc
         | i .==# len = acc
         | otherwise  = loop (i+1) (f acc (unsafeIndex vec i))
-
-foldl1 :: PrimType ty => (ty -> ty -> ty) -> NonEmpty (UArray ty) -> ty
-foldl1 f arr = let (initialAcc, rest) = splitAt 1 $ getNonEmpty arr
-               in foldl f (unsafeIndex initialAcc 0) rest
 
 foldl1' :: PrimType ty => (ty -> ty -> ty) -> NonEmpty (UArray ty) -> ty
 foldl1' f arr = let (initialAcc, rest) = splitAt 1 $ getNonEmpty arr

--- a/Foundation/Collection/Collection.hs
+++ b/Foundation/Collection/Collection.hs
@@ -123,22 +123,26 @@ instance UV.PrimType ty => Collection (BLK.Block ty) where
     any = BLK.any
 
 instance UV.PrimType ty => Collection (UV.UArray ty) where
-    null = UV.null
-    length = UV.length
-    elem = UV.elem
-    minimum = Data.List.minimum . toList . getNonEmpty
-    maximum = Data.List.maximum . toList . getNonEmpty
-    all p = Data.List.all p . toList
-    any p = Data.List.any p . toList
+    null       = UV.null
+    length     = UV.length
+    elem       = UV.elem
+    minimum uv = let uv' = getNonEmpty uv
+                 in UV.foldl' min (UV.unsafeIndex uv' 0) uv'
+    maximum uv = let uv' = getNonEmpty uv
+                 in UV.foldl' max (UV.unsafeIndex uv' 0) uv'
+    all p      = UV.foldl' (\acc x -> p x && acc) True
+    any p      = UV.foldl' (\acc x -> p x || acc) False
 
 instance Collection (BA.Array ty) where
-    null = BA.null
-    length = BA.length
-    elem = BA.elem
-    minimum = Data.List.minimum . toList . getNonEmpty -- TODO
-    maximum = Data.List.maximum . toList . getNonEmpty -- TODO
-    all p = Data.List.all p . toList
-    any p = Data.List.any p . toList
+    null       = BA.null
+    length     = BA.length
+    elem       = BA.elem
+    minimum ba = let ba' = getNonEmpty ba
+                 in BA.foldl' min (BA.unsafeIndex ba' 0) ba'
+    maximum ba = let ba' = getNonEmpty ba
+                 in BA.foldl' max (BA.unsafeIndex ba' 0) ba'
+    all p      = BA.foldl' (\acc x -> p x && acc) True
+    any p      = BA.foldl' (\acc x -> p x || acc) False
 
 instance Collection S.String where
     null = S.null

--- a/Foundation/Collection/Collection.hs
+++ b/Foundation/Collection/Collection.hs
@@ -31,17 +31,12 @@ module Foundation.Collection.Collection
 import           Foundation.Internal.Base
 import           Foundation.Primitive.Types.OffsetSize
 import           Foundation.Collection.Element
+import           Foundation.Collection.NonEmpty
 import qualified Data.List
 import qualified Foundation.Primitive.Block as BLK
 import qualified Foundation.Array.Unboxed as UV
 import qualified Foundation.Array.Boxed as BA
 import qualified Foundation.String.UTF8 as S
-
--- | NonEmpty property for any Collection
---
--- This can only be made, through the 'nonEmpty' smart contructor
-newtype NonEmpty a = NonEmpty { getNonEmpty :: a }
-    deriving (Show,Eq)
 
 -- | Smart constructor to create a NonEmpty collection
 --

--- a/Foundation/Collection/Collection.hs
+++ b/Foundation/Collection/Collection.hs
@@ -117,8 +117,10 @@ instance UV.PrimType ty => Collection (BLK.Block ty) where
     null = (==) 0 . BLK.length
     length = BLK.length
     elem = BLK.elem
-    minimum = Data.List.minimum . toList . getNonEmpty
-    maximum = Data.List.maximum . toList . getNonEmpty
+    minimum blk = let blk' = getNonEmpty blk
+                 in BLK.foldl' min (BLK.unsafeIndex blk' 0) blk'
+    maximum blk = let blk' = getNonEmpty blk
+                 in BLK.foldl' max (BLK.unsafeIndex blk' 0) blk'
     all = BLK.all
     any = BLK.any
 

--- a/Foundation/Collection/Collection.hs
+++ b/Foundation/Collection/Collection.hs
@@ -112,35 +112,29 @@ instance UV.PrimType ty => Collection (BLK.Block ty) where
     null = (==) 0 . BLK.length
     length = BLK.length
     elem = BLK.elem
-    minimum blk = let blk' = getNonEmpty blk
-                 in BLK.foldl' min (BLK.unsafeIndex blk' 0) blk'
-    maximum blk = let blk' = getNonEmpty blk
-                 in BLK.foldl' max (BLK.unsafeIndex blk' 0) blk'
+    minimum = BLK.foldl1' min
+    maximum = BLK.foldl1' max
     all = BLK.all
     any = BLK.any
 
 instance UV.PrimType ty => Collection (UV.UArray ty) where
-    null       = UV.null
-    length     = UV.length
-    elem       = UV.elem
-    minimum uv = let uv' = getNonEmpty uv
-                 in UV.foldl' min (UV.unsafeIndex uv' 0) uv'
-    maximum uv = let uv' = getNonEmpty uv
-                 in UV.foldl' max (UV.unsafeIndex uv' 0) uv'
-    all        = UV.all
-    any        = UV.any
+    null    = UV.null
+    length  = UV.length
+    elem    = UV.elem
+    minimum = UV.foldl1' min
+    maximum = UV.foldl1' max
+    all     = UV.all
+    any     = UV.any
 
 
 instance Collection (BA.Array ty) where
-    null       = BA.null
-    length     = BA.length
-    elem       = BA.elem
-    minimum ba = let ba' = getNonEmpty ba
-                 in BA.foldl' min (BA.unsafeIndex ba' 0) ba'
-    maximum ba = let ba' = getNonEmpty ba
-                 in BA.foldl' max (BA.unsafeIndex ba' 0) ba'
-    all        = BA.all
-    any        = BA.any
+    null    = BA.null
+    length  = BA.length
+    elem    = BA.elem
+    minimum = BA.foldl1' min
+    maximum = BA.foldl1' max
+    all     = BA.all
+    any     = BA.any
 
 
 

--- a/Foundation/Collection/Collection.hs
+++ b/Foundation/Collection/Collection.hs
@@ -132,8 +132,9 @@ instance UV.PrimType ty => Collection (UV.UArray ty) where
                  in UV.foldl' min (UV.unsafeIndex uv' 0) uv'
     maximum uv = let uv' = getNonEmpty uv
                  in UV.foldl' max (UV.unsafeIndex uv' 0) uv'
-    all p      = UV.foldl' (\acc x -> p x && acc) True
-    any p      = UV.foldl' (\acc x -> p x || acc) False
+    all        = UV.all
+    any        = UV.any
+
 
 instance Collection (BA.Array ty) where
     null       = BA.null
@@ -143,8 +144,10 @@ instance Collection (BA.Array ty) where
                  in BA.foldl' min (BA.unsafeIndex ba' 0) ba'
     maximum ba = let ba' = getNonEmpty ba
                  in BA.foldl' max (BA.unsafeIndex ba' 0) ba'
-    all p      = BA.foldl' (\acc x -> p x && acc) True
-    any p      = BA.foldl' (\acc x -> p x || acc) False
+    all        = BA.all
+    any        = BA.any
+
+
 
 instance Collection S.String where
     null = S.null

--- a/Foundation/Collection/Foldable.hs
+++ b/Foundation/Collection/Foldable.hs
@@ -47,8 +47,6 @@ class Foldable collection where
 
 -- | Fold1's. Like folds, but they assume to operate on a NonEmpty collection.
 class Foldable f => Fold1able f where
-    -- | Left associative lazy fold.
-    foldl1  :: (Element f -> Element f -> Element f) -> NonEmpty f -> Element f
     -- | Left associative strict fold.
     foldl1' :: (Element f -> Element f -> Element f) -> NonEmpty f -> Element f
     -- | Right associative lazy fold.
@@ -85,19 +83,15 @@ instance UV.PrimType ty => Foldable (BLK.Block ty) where
 -- Fold1able instances
 ----------------------------
 instance Fold1able [a] where
-  foldl1 f  = Data.List.foldl1 f . getNonEmpty
   foldr1 f  = Data.List.foldr1 f . getNonEmpty
   foldl1' f = Data.List.foldl1' f . getNonEmpty
 
 instance UV.PrimType ty => Fold1able (UV.UArray ty) where
-    foldl1 = UV.foldl1
     foldr1 = UV.foldr1
     foldl1' = UV.foldl1'
 instance Fold1able (BA.Array ty) where
-    foldl1  = BA.foldl1
     foldr1  = BA.foldr1
     foldl1' = BA.foldl1'
 instance UV.PrimType ty => Fold1able (BLK.Block ty) where
-    foldl1  = BLK.foldl1
     foldr1  = BLK.foldr1
     foldl1' = BLK.foldl1'

--- a/Foundation/Collection/Foldable.hs
+++ b/Foundation/Collection/Foldable.hs
@@ -9,10 +9,12 @@
 --
 module Foundation.Collection.Foldable
     ( Foldable(..)
+    , Fold1able(..)
     ) where
 
 import           Foundation.Internal.Base
 import           Foundation.Collection.Element
+import           Foundation.Collection.NonEmpty
 import qualified Data.List
 import qualified Foundation.Array.Unboxed as UV
 import qualified Foundation.Primitive.Block as BLK
@@ -43,6 +45,20 @@ class Foldable collection where
     foldr' :: (Element collection -> a -> a) -> a -> collection -> a
     foldr' f z0 xs = foldl f' id xs z0 where f' k x z = k $! f x z
 
+-- | Fold1's. Like folds, but they assume to operate on a NonEmpty collection.
+class Foldable f => Fold1able f where
+    -- | Left associative lazy fold.
+    foldl1  :: (Element f -> Element f -> Element f) -> NonEmpty f -> Element f
+    -- | Left associative strict fold.
+    foldl1' :: (Element f -> Element f -> Element f) -> NonEmpty f -> Element f
+    -- | Right associative lazy fold.
+    foldr1  :: (Element f -> Element f -> Element f) -> NonEmpty f -> Element f
+    -- | Right associative strict fold.
+    --foldr1' :: (Element f -> Element f -> Element f) -> NonEmpty f -> Element f
+    --foldr1' f xs = foldl f' id . getNonEmpty
+    --  where f' k x z = k $! f x z
+
+
 ----------------------------
 -- Foldable instances
 ----------------------------
@@ -64,3 +80,24 @@ instance UV.PrimType ty => Foldable (BLK.Block ty) where
     foldl = BLK.foldl
     foldr = BLK.foldr
     foldl' = BLK.foldl'
+
+----------------------------
+-- Fold1able instances
+----------------------------
+instance Fold1able [a] where
+  foldl1 f  = Data.List.foldl1 f . getNonEmpty
+  foldr1 f  = Data.List.foldr1 f . getNonEmpty
+  foldl1' f = Data.List.foldl1' f . getNonEmpty
+
+instance UV.PrimType ty => Fold1able (UV.UArray ty) where
+    foldl1 = UV.foldl1
+    foldr1 = UV.foldr1
+    foldl1' = UV.foldl1'
+instance Fold1able (BA.Array ty) where
+    foldl1  = BA.foldl1
+    foldr1  = BA.foldr1
+    foldl1' = BA.foldl1'
+instance UV.PrimType ty => Fold1able (BLK.Block ty) where
+    foldl1  = BLK.foldl1
+    foldr1  = BLK.foldr1
+    foldl1' = BLK.foldl1'

--- a/Foundation/Collection/NonEmpty.hs
+++ b/Foundation/Collection/NonEmpty.hs
@@ -1,0 +1,18 @@
+-- |
+-- Module      : Foundation.Collection.NonEmpty
+-- License     : BSD-style
+-- Maintainer  : Foundation
+-- Stability   : experimental
+-- Portability : portable
+--
+-- A newtype wrapper around a non-empty Collection.
+
+module Foundation.Collection.NonEmpty
+    ( NonEmpty(..)
+    ) where
+
+import Foundation.Internal.Base
+
+-- | NonEmpty property for any Collection
+newtype NonEmpty a = NonEmpty { getNonEmpty :: a }
+    deriving (Show,Eq)

--- a/Foundation/Primitive/Block.hs
+++ b/Foundation/Primitive/Block.hs
@@ -35,6 +35,9 @@ module Foundation.Primitive.Block
     , foldl
     , foldl'
     , foldr
+    , foldl1
+    , foldl1'
+    , foldr1
     , cons
     , snoc
     , uncons
@@ -64,6 +67,7 @@ import qualified Data.List
 import           Foundation.Internal.Base
 import           Foundation.Internal.Proxy
 import           Foundation.Internal.Primitive
+import           Foundation.Collection.NonEmpty
 import           Foundation.Primitive.Types.OffsetSize
 import           Foundation.Primitive.Monad
 import           Foundation.Primitive.Exception
@@ -163,6 +167,18 @@ foldl' f initialAcc vec = loop 0 initialAcc
     loop i !acc
         | i .==# len = acc
         | otherwise  = loop (i+1) (f acc (unsafeIndex vec i))
+
+foldl1 :: PrimType ty => (ty -> ty -> ty) -> NonEmpty (Block ty) -> ty
+foldl1 f arr = let (initialAcc, rest) = splitAt 1 $ getNonEmpty arr
+               in foldl f (unsafeIndex initialAcc 0) rest
+
+foldl1' :: PrimType ty => (ty -> ty -> ty) -> NonEmpty (Block ty) -> ty
+foldl1' f arr = let (initialAcc, rest) = splitAt 1 $ getNonEmpty arr
+               in foldl' f (unsafeIndex initialAcc 0) rest
+
+foldr1 :: PrimType ty => (ty -> ty -> ty) -> NonEmpty (Block ty) -> ty
+foldr1 f arr = let (initialAcc, rest) = revSplitAt 1 $ getNonEmpty arr
+               in foldr f (unsafeIndex initialAcc 0) rest
 
 cons :: PrimType ty => ty -> Block ty -> Block ty
 cons e vec

--- a/Foundation/Primitive/Block.hs
+++ b/Foundation/Primitive/Block.hs
@@ -35,7 +35,6 @@ module Foundation.Primitive.Block
     , foldl
     , foldl'
     , foldr
-    , foldl1
     , foldl1'
     , foldr1
     , cons
@@ -167,10 +166,6 @@ foldl' f initialAcc vec = loop 0 initialAcc
     loop i !acc
         | i .==# len = acc
         | otherwise  = loop (i+1) (f acc (unsafeIndex vec i))
-
-foldl1 :: PrimType ty => (ty -> ty -> ty) -> NonEmpty (Block ty) -> ty
-foldl1 f arr = let (initialAcc, rest) = splitAt 1 $ getNonEmpty arr
-               in foldl f (unsafeIndex initialAcc 0) rest
 
 foldl1' :: PrimType ty => (ty -> ty -> ty) -> NonEmpty (Block ty) -> ty
 foldl1' f arr = let (initialAcc, rest) = splitAt 1 $ getNonEmpty arr

--- a/foundation.cabal
+++ b/foundation.cabal
@@ -138,6 +138,7 @@ library
                      Foundation.Collection.InnerFunctor
                      Foundation.Collection.Collection
                      Foundation.Collection.Copy
+                     Foundation.Collection.NonEmpty
                      Foundation.Collection.Sequential
                      Foundation.Collection.Keyed
                      Foundation.Collection.Indexed


### PR DESCRIPTION
I chose to go with a `foldl'` implementation of these functions.

Also, `ChunkUArray` can be made an instance of `Foldable` by double-folding on the arrays, which allows the `Collection` functions to utilise those `fold`s.