### PR TITLE
Fixed #289 (String.replace function)

### DIFF
--- a/Foundation/Array/Unboxed.hs
+++ b/Foundation/Array/Unboxed.hs
@@ -1031,21 +1031,23 @@ reverse a
 
 -- Finds where are the insertion points when we search for a `needle`
 -- within an `haystack`.
+-- Throws an error in case `needle` is empty.
 indices :: PrimType ty => UArray ty -> UArray ty -> [Offset ty]
-indices ned hy =
-  case haystackLen < needleLen of
-    True  -> []
-    False -> go (Offset 0) []
+indices needle hy
+  | needleLen <= 0 = error "Foundation.Array.Unboxed.indices: needle is empty."
+  | otherwise = case haystackLen < needleLen of
+                  True  -> []
+                  False -> go (Offset 0) []
   where
     !haystackLen = length hy
 
-    !needleLen = length ned
+    !needleLen = length needle
 
     go currentOffset ipoints
       | (currentOffset `offsetPlusE` needleLen) > (sizeAsOffset haystackLen) = ipoints
       | otherwise =
         let matcher = take needleLen . drop (offsetAsSize currentOffset) $ hy
-        in case matcher == ned of
+        in case matcher == needle of
              -- TODO: Move away from right-appending as it's gonna be slow.
              True  -> go (currentOffset `offsetPlusE` needleLen) (ipoints <> [currentOffset])
              False -> go (currentOffset + Offset 1) ipoints

--- a/Foundation/Array/Unboxed.hs
+++ b/Foundation/Array/Unboxed.hs
@@ -1055,11 +1055,14 @@ indices ned hy =
 -- the `haystack` string.
 replace :: PrimType ty => UArray ty -> UArray ty -> UArray ty -> UArray ty
 replace (needle :: UArray ty) replacement haystack = runST $ do
-    let insertionPoints = indices needle haystack
-    let !occs           = Prelude.length insertionPoints
-    let !newLen         = haystackLen - (multBy needleLen occs) + (multBy replacementLen occs)
-    ms <- new newLen
-    loop ms (Offset 0) (Offset 0) insertionPoints
+    case null needle of
+      True -> error "Foundation.Array.Unboxed.replace: empty needle"
+      False -> do
+        let insertionPoints = indices needle haystack
+        let !occs           = Prelude.length insertionPoints
+        let !newLen         = haystackLen - (multBy needleLen occs) + (multBy replacementLen occs)
+        ms <- new newLen
+        loop ms (Offset 0) (Offset 0) insertionPoints
   where
 
     multBy (CountOf x) y = CountOf (x * y)

--- a/Foundation/String.hs
+++ b/Foundation/String.hs
@@ -32,6 +32,7 @@ module Foundation.String
     , words
     , upper
     , lower
+    , replace
     ) where
 
 import Foundation.String.UTF8

--- a/Foundation/String.hs
+++ b/Foundation/String.hs
@@ -33,6 +33,7 @@ module Foundation.String
     , upper
     , lower
     , replace
+    , indices
     ) where
 
 import Foundation.String.UTF8

--- a/Foundation/String/UTF8.hs
+++ b/Foundation/String/UTF8.hs
@@ -897,7 +897,8 @@ replace needle replacement@(String rp) haystack@(String hy) = runST $ do
         let !newOffset = currentOffset `offsetPlusE` unchangedDataLen
         -- 2. Copy the replacement.
         Vec.unsafeCopyAtRO mba newOffset rp (Offset 0) replacementLen
-        loop ms (newOffset `offsetPlusE` replacementLen) (offsetInOriginalString `offsetPlusE` needleLen) xs
+        let !offsetInOriginalString' = offsetInOriginalString `offsetPlusE` unchangedDataLen `offsetPlusE` needleLen
+        loop ms (newOffset `offsetPlusE` replacementLen) offsetInOriginalString' xs
 
 -- | Return the nth character in a String
 --

--- a/Foundation/String/UTF8.hs
+++ b/Foundation/String/UTF8.hs
@@ -869,8 +869,8 @@ replace needle replacement@(String rp) haystack@(String hy) = runST $ do
     !haystackLen = size haystack
 
     -- Go through each insertion point and copy things over.
-    -- We keep around the last insertion point to have a base
-    -- to compare things with.
+    -- We keep around the offset to the original string to
+    -- be able to copy bytes which didn't change.
     loop :: PrimMonad prim
          => MutableString (PrimState prim)
          -> Offset8

--- a/Foundation/String/UTF8.hs
+++ b/Foundation/String/UTF8.hs
@@ -884,13 +884,6 @@ replace needle replacement@(String rp) haystack@(String hy) = runST $ do
       Vec.unsafeCopyAtRO mba currentOffset hy offsetInOriginalString unchangedDataLen
       freeze ms
     loop ms@(MutableString mba) currentOffset offsetInOriginalString (x:xs) = do
-      {-
-               => MArray ty (PrimState prim) -- ^ destination array
-               -> Offset ty                  -- ^ offset at destination
-               -> Array ty                   -- ^ source array
-               -> Offset ty                  -- ^ offset at source
-               -> CountOf ty                    -- ^ number of elements to copy
-      -}
         -- 1. Copy from the old string.
         let !unchangedDataLen = (x - offsetInOriginalString)
         Vec.unsafeCopyAtRO mba currentOffset hy offsetInOriginalString unchangedDataLen

--- a/Foundation/String/UTF8.hs
+++ b/Foundation/String/UTF8.hs
@@ -891,15 +891,12 @@ replace needle replacement@(String rp) haystack@(String hy) = runST $ do
                -> Offset ty                  -- ^ offset at source
                -> CountOf ty                    -- ^ number of elements to copy
       -}
-        -- General idea: Fill `mba` with stuff from `haystack` FROM
-        -- the prev insertion point and UP UNTIL the next insertion point.
-        -- Then fill `mba` with `replacement`.
         -- 1. Copy from the old string.
         let !unchangedDataLen = (x - offsetInOriginalString)
         Vec.unsafeCopyAtRO mba currentOffset hy offsetInOriginalString unchangedDataLen
         let !newOffset = currentOffset `offsetPlusE` unchangedDataLen
         -- 2. Copy the replacement.
-        Vec.unsafeCopyAtRO mba newOffset rp x replacementLen
+        Vec.unsafeCopyAtRO mba newOffset rp (Offset 0) replacementLen
         loop ms (newOffset `offsetPlusE` replacementLen) (offsetInOriginalString `offsetPlusE` needleLen) xs
 
 -- | Return the nth character in a String

--- a/Foundation/String/UTF8.hs
+++ b/Foundation/String/UTF8.hs
@@ -20,7 +20,6 @@
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE UnboxedTuples              #-}
 {-# LANGUAGE FlexibleContexts           #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE CPP                        #-}
 module Foundation.String.UTF8
     ( String(..)

--- a/tests/Test/Foundation/String.hs
+++ b/tests/Test/Foundation/String.hs
@@ -52,13 +52,25 @@ testStringCases =
                 (remainingBa, allErrs, chunkS) = foldl reconstruct (mempty, [], []) $ chunks randomInts wholeBA
              in (catMaybes allErrs === []) .&&. (remainingBa === mempty) .&&. (mconcat (reverse chunkS) === wholeS)
         ]
-    , testGroup "Replace" [
-          testCase "replace 'aa' 'bb' '' == ''" $ do
+    , testGroup "replace" [
+          testCase "indices 'aa' 'bb' == (0, [])" $ do
+            indices "aa" "bb" @?= (0,[])
+        , testCase "indices 'aa' 'aabbccabbccEEaaaaabb' is correct" $ do
+            indices "aa" "aabbccabbccEEaaaaabb" @?= (3,[Offset 0,Offset 13,Offset 15])
+        , testCase "indices 'aa' 'aaccaadd' is correct" $ do
+            indices "aa" "aaccaadd" @?= (2,[Offset 0,Offset 4])
+        , testCase "replace 'aa' 'bb' '' == ''" $ do
             replace "aa" "bb" "" @?= ""
+        , testCase "replace 'aa' '' 'aabbcc' == 'aabbcc'" $ do
+            replace "aa" "" "aabbcc" @?= "bbcc"
         , testCase "replace 'aa' 'bb' 'aa' == 'bb'" $ do
             replace "aa" "bb" "aa" @?= "bb"
         , testCase "replace 'aa' 'bb' 'aabb' == 'bbbb'" $ do
             replace "aa" "bb" "aabb" @?= "bbbb"
+        , testCase "replace 'aa' 'bb' 'aaccaadd' == 'bbccbbdd'" $ do
+            replace "aa" "bb" "aaccaadd" @?= "bbccbbdd"
+        , testCase "replace 'aa' 'bb' 'aabbccabbccEEaaaaabb' == 'bbbbccabbccEEbbbbabb'" $ do
+            replace "aa" "bb" "aabbccabbccEEaaaaabb" @?= "bbbbccabbccEEbbbbabb"
                           ]
     , testGroup "Cases"
         [ testGroup "Invalid-UTF8"

--- a/tests/Test/Foundation/String.hs
+++ b/tests/Test/Foundation/String.hs
@@ -71,6 +71,8 @@ testStringCases =
             replace "aa" "bb" "aaccaadd" @?= "bbccbbdd"
         , testCase "replace 'aa' 'bb' 'aabbccabbccEEaaaaabb' == 'bbbbccabbccEEbbbbabb'" $ do
             replace "aa" "bb" "aabbccabbccEEaaaaabb" @?= "bbbbccabbccEEbbbbabb"
+        , testCase "replace '😀' '😺' '😀 🙂 😉 😌' == '😺 🙂 😉 😌'" $ do
+            replace "😀" "😺" "😀 🙂 😉 😌" @?= "😺 🙂 😉 😌"
                           ]
     , testGroup "Cases"
         [ testGroup "Invalid-UTF8"

--- a/tests/Test/Foundation/String.hs
+++ b/tests/Test/Foundation/String.hs
@@ -10,6 +10,8 @@ module Test.Foundation.String
 import Foundation
 import Foundation.String
 import Foundation.String.ASCII (AsciiString)
+import Control.Exception
+import Data.Either
 
 import Test.Tasty
 import Test.Tasty.QuickCheck
@@ -59,6 +61,9 @@ testStringCases =
             indices "aa" "aabbccabbccEEaaaaabb" @?= [Offset 0,Offset 13,Offset 15]
         , testCase "indices 'aa' 'aaccaadd' is correct" $ do
             indices "aa" "aaccaadd" @?= [Offset 0,Offset 4]
+        , testCase "replace '' 'bb' 'foo' raises an error" $ do
+            (res :: Either SomeException String) <- try (evaluate $ replace "" "bb" "foo")
+            assertBool "Expecting an error to be thrown, but it did not." (isLeft res)
         , testCase "replace 'aa' 'bb' '' == ''" $ do
             replace "aa" "bb" "" @?= ""
         , testCase "replace 'aa' '' 'aabbcc' == 'aabbcc'" $ do

--- a/tests/Test/Foundation/String.hs
+++ b/tests/Test/Foundation/String.hs
@@ -52,6 +52,14 @@ testStringCases =
                 (remainingBa, allErrs, chunkS) = foldl reconstruct (mempty, [], []) $ chunks randomInts wholeBA
              in (catMaybes allErrs === []) .&&. (remainingBa === mempty) .&&. (mconcat (reverse chunkS) === wholeS)
         ]
+    , testGroup "Replace" [
+          testCase "replace 'aa' 'bb' '' == ''" $ do
+            replace "aa" "bb" "" @?= ""
+        , testCase "replace 'aa' 'bb' 'aa' == 'bb'" $ do
+            replace "aa" "bb" "aa" @?= "bb"
+        , testCase "replace 'aa' 'bb' 'aabb' == 'bbbb'" $ do
+            replace "aa" "bb" "aabb" @?= "bbbb"
+                          ]
     , testGroup "Cases"
         [ testGroup "Invalid-UTF8"
             [ testCase "ff" $ expectFromBytesErr ("", Just InvalidHeader, 0) (fromList [0xff])

--- a/tests/Test/Foundation/String.hs
+++ b/tests/Test/Foundation/String.hs
@@ -54,11 +54,11 @@ testStringCases =
         ]
     , testGroup "replace" [
           testCase "indices 'aa' 'bb' == (0, [])" $ do
-            indices "aa" "bb" @?= (0,[])
+            indices "aa" "bb" @?= []
         , testCase "indices 'aa' 'aabbccabbccEEaaaaabb' is correct" $ do
-            indices "aa" "aabbccabbccEEaaaaabb" @?= (3,[Offset 0,Offset 13,Offset 15])
+            indices "aa" "aabbccabbccEEaaaaabb" @?= [Offset 0,Offset 13,Offset 15]
         , testCase "indices 'aa' 'aaccaadd' is correct" $ do
-            indices "aa" "aaccaadd" @?= (2,[Offset 0,Offset 4])
+            indices "aa" "aaccaadd" @?= [Offset 0,Offset 4]
         , testCase "replace 'aa' 'bb' '' == ''" $ do
             replace "aa" "bb" "" @?= ""
         , testCase "replace 'aa' '' 'aabbcc' == 'aabbcc'" $ do

--- a/tests/Test/Foundation/String.hs
+++ b/tests/Test/Foundation/String.hs
@@ -69,6 +69,8 @@ testStringCases =
             replace "aa" "bb" "aabb" @?= "bbbb"
         , testCase "replace 'aa' 'bb' 'aaccaadd' == 'bbccbbdd'" $ do
             replace "aa" "bb" "aaccaadd" @?= "bbccbbdd"
+        , testCase "replace 'aa' 'LongLong' 'aaccaadd' == 'LongLongccLongLongdd'" $ do
+            replace "aa" "LongLong" "aaccaadd" @?= "LongLongccLongLongdd"
         , testCase "replace 'aa' 'bb' 'aabbccabbccEEaaaaabb' == 'bbbbccabbccEEbbbbabb'" $ do
             replace "aa" "bb" "aabbccabbccEEaaaaabb" @?= "bbbbccabbccEEbbbbabb"
         , testCase "replace '😀' '😺' '😀 🙂 😉 😌' == '😺 🙂 😉 😌'" $ do

--- a/tests/Test/Foundation/String.hs
+++ b/tests/Test/Foundation/String.hs
@@ -83,8 +83,8 @@ testStringCases =
             replace "aa" "LongLong" "aaccaadd" @?= "LongLongccLongLongdd"
         , testCase "replace 'aa' 'bb' 'aabbccabbccEEaaaaabb' == 'bbbbccabbccEEbbbbabb'" $ do
             replace "aa" "bb" "aabbccabbccEEaaaaabb" @?= "bbbbccabbccEEbbbbabb"
-        , testCase "replace '😀' '😺' '😀 🙂 😉 😌' == '😺 🙂 😉 😌'" $ do
-            replace "😀" "😺" "😀 🙂 😉 😌" @?= "😺 🙂 😉 😌"
+        , testCase "replace 'å' 'ä' 'ååññ' == 'ääññ'" $ do
+            replace "å" "ä" "ååññ" @?= "ääññ"
                           ]
     , testGroup "Cases"
         [ testGroup "Invalid-UTF8"

--- a/tests/Test/Foundation/String.hs
+++ b/tests/Test/Foundation/String.hs
@@ -55,7 +55,12 @@ testStringCases =
              in (catMaybes allErrs === []) .&&. (remainingBa === mempty) .&&. (mconcat (reverse chunkS) === wholeS)
         ]
     , testGroup "replace" [
-          testCase "indices 'aa' 'bb' == (0, [])" $ do
+          testCase "indices '' 'bb' should raise an error" $ do
+            res <- try (evaluate $ indices "" "bb")
+            case res of
+              (Left (_ :: SomeException)) -> return ()
+              Right _ -> fail "Expecting an error to be thrown, but it did not."
+        , testCase "indices 'aa' 'bb' == []" $ do
             indices "aa" "bb" @?= []
         , testCase "indices 'aa' 'aabbccabbccEEaaaaabb' is correct" $ do
             indices "aa" "aabbccabbccEEaaaaabb" @?= [Offset 0,Offset 13,Offset 15]


### PR DESCRIPTION
This PR adds support for the `String.replace` function, with the familiar type signature:

```
replace :: Needle -> Replacement -> Haystack -> New
```

It uses an approach similar to what [text does](https://github.com/bos/text/blob/c29d57cfd7f9b6236b9ec6f8c0e5bcaa98902d61/Data/Text.hs#L691): We first get all the `indices` where the replacement will happen (called `insertionPoints` here) and then we proceed to do the insertion.

Note the algorithm is still slow in a couple of places (but I expect performance to be decent enough to start with):

* We allocate an intermedia array inside `loop`, which we should scrap in favour of a byte-to-byte, zero-alloc equality function;
* Inside `indices` we right append; we should use something like a DList but here I couldn't due to circular dependencies error.

Let me know what you guys think.