### PR TITLE
Remove `foldl` from Foundation

### DIFF
--- a/Collection.md
+++ b/Collection.md
@@ -89,7 +89,7 @@ Operation supported by different collections:
 | take,drop,break,span | ✔          | ✔          | ✔          |       |         |           |             |
 | splitAt,splitOn      | ✔          | ✔          | ✔          |       |         |           |             |
 | empty, null          | ✔          | ✔          | ✔          | ✔     | ✔       | ✔         | ✔           |
-| foldl, foldr         | ✔          | ✔          | ✔          | ✔     | ✔       | ✔         | ✔           |
+| foldl', foldr        | ✔          | ✔          | ✔          | ✔     | ✔       | ✔         | ✔           |
 | foldlKey, foldrKey   | ✔          | ✔          | ✔          |       | ✔       |           |             |
 | map                  | ✔          | ✔          | ✔          | ✔     | ✔       | ✔         | ✔           |
 | mapWithKey           | ✔          | ✔          | ✔          |       | ✔       |           |             |

--- a/Foundation/Array/Bitmap.hs
+++ b/Foundation/Array/Bitmap.hs
@@ -78,7 +78,6 @@ instance C.InnerFunctor Bitmap where
     imap = map
 
 instance C.Foldable Bitmap where
-    foldl = foldl
     foldr = foldr
     foldl' = foldl'
     foldr' = foldr'
@@ -289,7 +288,7 @@ vFromList allBools = runST $ do
 
     toPacked :: [Bool] -> Word32
     toPacked l =
-        C.foldl (.|.) 0 $ Prelude.zipWith (\b w -> if b then (1 `shiftL` w) else 0) l (C.reverse [0..31])
+        C.foldl' (.|.) 0 $ Prelude.zipWith (\b w -> if b then (1 `shiftL` w) else 0) l (C.reverse [0..31])
 -}
     len        = C.length allBools
 
@@ -415,14 +414,6 @@ filter predicate vec = unoptimised (Data.List.filter predicate) vec
 
 reverse :: Bitmap -> Bitmap
 reverse bits = unoptimised C.reverse bits
-
-foldl :: (a -> Bool -> a) -> a -> Bitmap -> a
-foldl f initialAcc vec = loop 0 initialAcc
-  where
-    len = length vec
-    loop i acc
-        | i .==# len = acc
-        | otherwise  = loop (i+1) (f acc (unsafeIndex vec i))
 
 foldr :: (Bool -> a -> a) -> a -> Bitmap -> a
 foldr f initialAcc vec = loop 0

--- a/Foundation/Array/Boxed.hs
+++ b/Foundation/Array/Boxed.hs
@@ -56,7 +56,6 @@ module Foundation.Array.Boxed
     , find
     , foldl'
     , foldr
-    , foldl
     , builderAppend
     , builderBuild
     ) where
@@ -634,14 +633,6 @@ reverse a = create len toEnd
   where
     len@(CountOf s) = length a
     toEnd (Offset i) = unsafeIndex a (Offset (s - 1 - i))
-
-foldl :: (a -> ty -> a) -> a -> Array ty -> a
-foldl f initialAcc vec = loop 0 initialAcc
-  where
-    len = length vec
-    loop !i acc
-        | i .==# len = acc
-        | otherwise  = loop (i+1) (f acc (unsafeIndex vec i))
 
 foldr :: (ty -> a -> a) -> a -> Array ty -> a
 foldr f initialAcc vec = loop 0

--- a/Foundation/Array/Unboxed.hs
+++ b/Foundation/Array/Unboxed.hs
@@ -82,7 +82,6 @@ module Foundation.Array.Unboxed
     , sortBy
     , filter
     , reverse
-    , foldl
     , foldr
     , foldl'
     , foreignMem
@@ -1027,14 +1026,6 @@ reverse a
             | i == end  = return ()
             | otherwise = primMbaWrite ma i (primAddrIndex ba (sizeAsOffset (endI - i))) >> loop (i+Offset 1)
 {-# SPECIALIZE [3] reverse :: UArray Word8 -> UArray Word8 #-}
-
-foldl :: PrimType ty => (a -> ty -> a) -> a -> UArray ty -> a
-foldl f initialAcc vec = loop 0 initialAcc
-  where
-    len = length vec
-    loop i acc
-        | i .==# len = acc
-        | otherwise  = loop (i+1) (f acc (unsafeIndex vec i))
 
 foldr :: PrimType ty => (ty -> a -> a) -> a -> UArray ty -> a
 foldr f initialAcc vec = loop 0

--- a/Foundation/Check/Arbitrary.hs
+++ b/Foundation/Check/Arbitrary.hs
@@ -109,7 +109,7 @@ arbitraryInteger =
         ]
   where
     integerOfSize :: Bool -> Word -> Gen Integer
-    integerOfSize toSign n = ((if toSign then (\x -> 0 - x) else id) . foldl (\x y -> x + integralUpsize y) 0 . toList)
+    integerOfSize toSign n = ((if toSign then (\x -> 0 - x) else id) . foldl' (\x y -> x + integralUpsize y) 0 . toList)
                          <$> (arbitraryUArrayOf n :: Gen (UArray Word8))
 
 arbitraryNatural :: Gen Natural

--- a/Foundation/Collection/Foldable.hs
+++ b/Foundation/Collection/Foldable.hs
@@ -27,11 +27,10 @@ class Foldable collection where
     -- > foldl f z [x1, x2, ..., xn] == (...((z `f` x1) `f` x2) `f`...) `f` xn
     -- Note that to produce the outermost application of the operator the entire input list must be traversed. This means that foldl' will diverge if given an infinite list.
     --
-    -- Also note that if you want an efficient left-fold, you probably want to use foldl' instead of foldl. The reason for this is that latter does not force the "inner" results (e.g. z f x1 in the above example) before applying them to the operator (e.g. to (f x2)). This results in a thunk chain O(n) elements long, which then must be evaluated from the outside-in.
-    foldl :: (a -> Element collection -> a) -> a -> collection -> a
+    -- Note that Foundation only provides `foldl'`, a strict version of `foldl` because
+    -- the lazy version is seldom useful.
 
-
-    -- | Left-associative fold of a structure but with strict application of the operator.
+    -- | Left-associative fold of a structure with strict application of the operator.
     foldl' :: (a -> Element collection -> a) -> a -> collection -> a
 
     -- | Right-associative fold of a structure.
@@ -41,26 +40,22 @@ class Foldable collection where
 
     -- | Right-associative fold of a structure, but with strict application of the operator.
     foldr' :: (Element collection -> a -> a) -> a -> collection -> a
-    foldr' f z0 xs = foldl f' id xs z0 where f' k x z = k $! f x z
+    foldr' f z0 xs = foldl' f' id xs z0 where f' k x z = k $! f x z
 
 ----------------------------
 -- Foldable instances
 ----------------------------
 
 instance Foldable [a] where
-    foldl = Data.List.foldl
     foldr = Data.List.foldr
     foldl' = Data.List.foldl'
 
 instance UV.PrimType ty => Foldable (UV.UArray ty) where
-    foldl = UV.foldl
     foldr = UV.foldr
     foldl' = UV.foldl'
 instance Foldable (BA.Array ty) where
-    foldl = BA.foldl
     foldr = BA.foldr
     foldl' = BA.foldl'
 instance UV.PrimType ty => Foldable (BLK.Block ty) where
-    foldl = BLK.foldl
     foldr = BLK.foldr
     foldl' = BLK.foldl'

--- a/Foundation/Foreign/MemoryMap/Posix.hsc
+++ b/Foundation/Foreign/MemoryMap/Posix.hsc
@@ -131,7 +131,7 @@ data MemorySyncFlag =
     deriving (Show,Eq)
 
 cvalueOfMemoryProts :: [MemoryProtection] -> CInt
-cvalueOfMemoryProts = foldl (.|.) 0 . fmap toProt
+cvalueOfMemoryProts = foldl' (.|.) 0 . fmap toProt
   where toProt :: MemoryProtection -> CInt
         toProt MemoryProtectionNone    = (#const PROT_NONE)
         toProt MemoryProtectionRead    = (#const PROT_READ)
@@ -139,7 +139,7 @@ cvalueOfMemoryProts = foldl (.|.) 0 . fmap toProt
         toProt MemoryProtectionExecute = (#const PROT_EXEC)
 
 cvalueOfMemorySync :: [MemorySyncFlag] -> CInt
-cvalueOfMemorySync = foldl (.|.) 0 . fmap toSync
+cvalueOfMemorySync = foldl' (.|.) 0 . fmap toSync
   where toSync MemorySyncAsync      = (#const MS_ASYNC)
         toSync MemorySyncSync       = (#const MS_SYNC)
         toSync MemorySyncInvalidate = (#const MS_INVALIDATE)

--- a/Foundation/List/DList.hs
+++ b/Foundation/List/DList.hs
@@ -51,7 +51,6 @@ type instance Element (DList a) = a
 
 instance Foldable (DList a) where
     foldr f b = foldr f b . toList
-    foldl f b = foldl f b . toList
     foldl' f b = foldl' f b . toList
 
 instance Collection (DList a) where

--- a/Foundation/List/SList.hs
+++ b/Foundation/List/SList.hs
@@ -30,7 +30,6 @@ module Foundation.List.SList
     , cons
     , map
     , elem
-    , foldl
     , append
     , minimum
     , maximum
@@ -123,9 +122,6 @@ drop (SList l) = SList (Prelude.drop n l)
 
 map :: (a -> b) -> SList n a -> SList n b
 map f (SList l) = SList (Prelude.map f l)
-
-foldl :: (b -> a -> b) -> b -> SList n a -> b
-foldl f acc (SList l) = Prelude.foldl f acc l
 
 zip :: SList n a -> SList n b -> SList n (a,b)
 zip (SList l1) (SList l2) = SList (Prelude.zip l1 l2)

--- a/Foundation/Primitive/Block.hs
+++ b/Foundation/Primitive/Block.hs
@@ -32,7 +32,6 @@ module Foundation.Primitive.Block
     , replicate
     , index
     , map
-    , foldl
     , foldl'
     , foldr
     , cons
@@ -139,14 +138,6 @@ index array n
 map :: (PrimType a, PrimType b) => (a -> b) -> Block a -> Block b
 map f a = create lenB (\i -> f $ unsafeIndex a (offsetCast Proxy i))
   where !lenB = sizeCast (Proxy :: Proxy (a -> b)) (length a)
-
-foldl :: PrimType ty => (a -> ty -> a) -> a -> Block ty -> a
-foldl f initialAcc vec = loop 0 initialAcc
-  where
-    !len = length vec
-    loop i acc
-        | i .==# len = acc
-        | otherwise  = loop (i+1) (f acc (unsafeIndex vec i))
 
 foldr :: PrimType ty => (ty -> a -> a) -> a -> Block ty -> a
 foldr f initialAcc vec = loop 0

--- a/tests/Test/Foundation/String.hs
+++ b/tests/Test/Foundation/String.hs
@@ -49,7 +49,7 @@ testStringCases =
                         (s, merr, nextBa) = fromBytes UTF8 ba'
                      in (nextBa, merr : errs, s : acc)
 
-                (remainingBa, allErrs, chunkS) = foldl reconstruct (mempty, [], []) $ chunks randomInts wholeBA
+                (remainingBa, allErrs, chunkS) = foldl' reconstruct (mempty, [], []) $ chunks randomInts wholeBA
              in (catMaybes allErrs === []) .&&. (remainingBa === mempty) .&&. (mconcat (reverse chunkS) === wholeS)
         ]
     , testGroup "Cases"


### PR DESCRIPTION
Slightly adjusted the documentation of `Foldable`. There were 2 or 3 calls to `foldl` in the code - a slight glance did not reveal any anomalies.