### PR TITLE
Enable `-Werror` on GHC 8.0 by default

### DIFF
--- a/Foundation/Array/Chunked/Unboxed.hs
+++ b/Foundation/Array/Chunked/Unboxed.hs
@@ -16,7 +16,6 @@ module Foundation.Array.Chunked.Unboxed
     ( ChunkedUArray
     ) where
 
-import qualified Data.List
 import           Data.Typeable
 import           Control.Arrow ((***))
 import           Foundation.Array.Boxed (Array)

--- a/Foundation/Collection/Collection.hs
+++ b/Foundation/Collection/Collection.hs
@@ -18,6 +18,7 @@
 --
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ExistentialQuantification #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 module Foundation.Collection.Collection
     ( Collection(..)
     -- * NonEmpty Property

--- a/Foundation/Conduit/Internal.hs
+++ b/Foundation/Conduit/Internal.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -Wno-inline-rule-shadowing #-}
 module Foundation.Conduit.Internal
     ( Pipe(..)
     , Conduit(..)

--- a/Foundation/Conduit/Internal.hs
+++ b/Foundation/Conduit/Internal.hs
@@ -11,7 +11,11 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE OverloadedStrings #-}
+
+#if __GLASGOW_HASKELL__ >= 800
 {-# OPTIONS_GHC -Wno-inline-rule-shadowing #-}
+#endif
+
 module Foundation.Conduit.Internal
     ( Pipe(..)
     , Conduit(..)

--- a/Foundation/String/ASCII.hs
+++ b/Foundation/String/ASCII.hs
@@ -17,6 +17,7 @@
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE UnboxedTuples              #-}
 {-# LANGUAGE FlexibleContexts           #-}
+{-# OPTIONS_GHC -Wno-inline-rule-shadowing #-}
 module Foundation.String.ASCII
     ( AsciiString
     --, Buffer

--- a/Foundation/String/ASCII.hs
+++ b/Foundation/String/ASCII.hs
@@ -17,7 +17,12 @@
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE UnboxedTuples              #-}
 {-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE CPP                        #-}
+
+#if __GLASGOW_HASKELL__ >= 800
 {-# OPTIONS_GHC -Wno-inline-rule-shadowing #-}
+#endif
+
 module Foundation.String.ASCII
     ( AsciiString
     --, Buffer

--- a/Foundation/System/Bindings.hs
+++ b/Foundation/System/Bindings.hs
@@ -1,5 +1,9 @@
 {-# OPTIONS_HADDOCK hide #-}
 {-# LANGUAGE CPP #-}
+
+-- Temporary workaround for -Werror on Windows
+{-# OPTIONS_GHC -Wno-dodgy-exports #-}
+
 module Foundation.System.Bindings
     ( module X
     ) where

--- a/Foundation/Time/StopWatch.hs
+++ b/Foundation/Time/StopWatch.hs
@@ -108,5 +108,7 @@ stopPrecise (StopWatchPrecise blk) = do
     pure $ NanoSeconds $ (endSec * secondInNano + endNSec) - (startSec * secondInNano + startNSec)
 #endif
 
+#if !defined(darwin_HOST_OS)
 secondInNano :: Word64
 secondInNano = 1000000000
+#endif

--- a/foundation.cabal
+++ b/foundation.cabal
@@ -255,6 +255,8 @@ library
   if os(windows)
     build-depends:    Win32
   ghc-options:       -Wall -fwarn-tabs
+  if impl(ghc == 8.0)
+    ghc-options:     -Werror
   default-language:  Haskell2010
   if impl(ghc >= 8.0)
     ghc-options:     -Wno-redundant-constraints

--- a/foundation.cabal
+++ b/foundation.cabal
@@ -255,11 +255,11 @@ library
   if os(windows)
     build-depends:    Win32
   ghc-options:       -Wall -fwarn-tabs
-  if impl(ghc == 8.0)
-    ghc-options:     -Werror
-  default-language:  Haskell2010
   if impl(ghc >= 8.0)
+    ghc-options:     -Wall -fwarn-tabs -Werror
+  if impl(ghc >= 8.2)
     ghc-options:     -Wno-redundant-constraints
+  default-language:  Haskell2010
   if flag(bounds-check)
     cpp-options: -DFOUNDATION_BOUNDS_CHECK
 


### PR DESCRIPTION
4 outstanding warnings fixed or surpressed:
 - `inline-rule-shadowing` was removed using `GHC_OPTIONS` pragma
 - `orphan` as well (needed in that particular case) 
 - `unused-import` was fixed