### PR TITLE
Prime Types faster arbitrary

### DIFF
--- a/Foundation/Check/Arbitrary.hs
+++ b/Foundation/Check/Arbitrary.hs
@@ -12,7 +12,6 @@ module Foundation.Check.Arbitrary
 import           Foundation.Primitive.Imports
 import           Foundation.Primitive
 import           Foundation.Primitive.IntegralConv
-import           Foundation.Primitive.Floating
 import           Foundation.Primitive.Types.OffsetSize
 import           Foundation.Check.Gen
 import           Foundation.Random
@@ -64,13 +63,9 @@ instance Arbitrary String where
         fromList <$> (genMax (genMaxSizeString params) >>= \i -> replicateM (integralCast i) arbitrary)
 
 instance Arbitrary Float where
-    arbitrary = toFloat <$> arbitrary <*> arbitrary <*> arbitrary
-      where toFloat i n Nothing  = integerToFloat i + (naturalToFloat n / 100000)
-            toFloat i n (Just e) = (integerToFloat i + (naturalToFloat n / 1000000)) * integerToFloat e
+    arbitrary = arbitraryF32
 instance Arbitrary Double where
-    arbitrary = toDouble <$> arbitrary <*> arbitrary <*> arbitrary
-      where toDouble i n Nothing  = integerToDouble i + (naturalToDouble n / 100000)
-            toDouble i n (Just e) = (integerToDouble i + (naturalToDouble n / 1000000)) * integerToDouble e
+    arbitrary = arbitraryF64
 
 instance Arbitrary a => Arbitrary (Maybe a) where
     arbitrary = frequency $ nonEmpty_ [ (1, pure Nothing), (4, Just <$> arbitrary) ]
@@ -126,6 +121,12 @@ arbitraryWord64 = genWithRng getRandomWord64
 
 arbitraryInt64 :: Gen Int64
 arbitraryInt64 = integralCast <$> arbitraryWord64
+
+arbitraryF64 :: Gen Double
+arbitraryF64 = genWithRng getRandomF64
+
+arbitraryF32 :: Gen Float
+arbitraryF32 = genWithRng getRandomF32
 
 arbitraryUArrayOf :: (PrimType ty, Arbitrary ty) => Word -> Gen (UArray ty)
 arbitraryUArrayOf size = between (0, size) >>=

--- a/Foundation/Check/Main.hs
+++ b/Foundation/Check/Main.hs
@@ -98,7 +98,7 @@ defaultMain allTestRoot = do
             Right c -> pure c
 
     -- use the user defined seed or generate a new seed
-    seed <- maybe getRandomPrimType pure $ udfSeed cfg
+    seed <- maybe getRandomWord64 pure $ udfSeed cfg
 
     let testState = newState cfg seed
 

--- a/Foundation/Primitive/IntegralConv.hs
+++ b/Foundation/Primitive/IntegralConv.hs
@@ -9,6 +9,7 @@ module Foundation.Primitive.IntegralConv
     , IntegralUpsize(..)
     , IntegralCast(..)
     , intToInt64
+    , int64ToInt
     , wordToWord64
     , word64ToWord32s
     , word64ToWord

--- a/cbits/foundation_random.c
+++ b/cbits/foundation_random.c
@@ -143,3 +143,7 @@ int foundation_rngV1_generate(uint8_t newkey[CHACHA_KEY_SIZE], uint8_t *dst, uin
 	return 0;
 }
 
+int foundation_rngV1_generate_word64(uint8_t newkey[CHACHA_KEY_SIZE], uint64_t *dst_w, uint8_t key[CHACHA_KEY_SIZE])
+{
+	return foundation_rngV1_generate(newkey, (uint8_t*)dst_w, key, sizeof(uint64_t));
+}

--- a/cbits/foundation_random.c
+++ b/cbits/foundation_random.c
@@ -143,7 +143,34 @@ int foundation_rngV1_generate(uint8_t newkey[CHACHA_KEY_SIZE], uint8_t *dst, uin
 	return 0;
 }
 
+int foundation_rngV1_generate_word32(uint8_t newkey[CHACHA_KEY_SIZE], uint32_t *dst_w, uint8_t key[CHACHA_KEY_SIZE])
+{
+	return foundation_rngV1_generate(newkey, (uint8_t*)dst_w, key, sizeof(uint32_t));
+}
+
 int foundation_rngV1_generate_word64(uint8_t newkey[CHACHA_KEY_SIZE], uint64_t *dst_w, uint8_t key[CHACHA_KEY_SIZE])
 {
 	return foundation_rngV1_generate(newkey, (uint8_t*)dst_w, key, sizeof(uint64_t));
+}
+
+int foundation_rngV1_generate_f32(uint8_t newkey[CHACHA_KEY_SIZE], float *dst_w, uint8_t key[CHACHA_KEY_SIZE])
+{
+	uint32_t const UPPER_MASK = 0x3F800000UL;
+	uint32_t const LOWER_MASK = 0x007FFFFFUL;
+	uint32_t tmp32;
+	int r = foundation_rngV1_generate_word32(newkey, &tmp32, key);
+	tmp32 = UPPER_MASK | (tmp32 & LOWER_MASK);
+	*dst_w = (float)tmp32 - 1.0;
+	return r;
+}
+
+int foundation_rngV1_generate_f64(uint8_t newkey[CHACHA_KEY_SIZE], double *dst_w, uint8_t key[CHACHA_KEY_SIZE])
+{
+	uint64_t const UPPER_MASK = 0x3FF0000000000000ULL;
+	uint64_t const LOWER_MASK = 0x000FFFFFFFFFFFFFULL;
+	uint64_t tmp64;
+	int r = foundation_rngV1_generate_word64(newkey, &tmp64, key);
+	tmp64 = UPPER_MASK | (tmp64 & LOWER_MASK);
+	*dst_w = (double)tmp64 - 1.0;
+	return r;
 }

--- a/tests/Checks.hs
+++ b/tests/Checks.hs
@@ -75,13 +75,13 @@ readFloatingExact' :: String -> Maybe (Bool, Natural, Word, Maybe Int)
 readFloatingExact' str = readFloatingExact str (\s x y z -> Just (s,x,y,z))
 
 doubleEqualApprox :: Double -> Double -> PropertyCheck
-doubleEqualApprox d1 d2 = (propertyCompare pName1 (<) (negate lim) d) `propertyAnd` (propertyCompare pName2 (<) d lim)
+doubleEqualApprox d1 d2 = propertyCompare name (<) (abs d) lim
   where
         d = d2 - d1
 
-        pName1 = show (negate lim) <> " < " <> show d2 <> " - " <> show d1 <> " (== " <> show d <> " )"
-        pName2 = show d1 <> " - " <> show d2 <> " (== " <> show d <> " )" <> " < " <> show lim
-        lim = 1.0e-8
+        name = show d1 <> " - " <> show d2 <> " (differential=" <> show (abs d) <> " )" <> " < " <> show lim
+
+        lim = min d1 d2 * (10^^(-15 :: Int))
 
 main = defaultMain $ Group "foundation"
     [ Group "Numerical"


### PR DESCRIPTION
This will make `:check-foundation` test suite run 2 times faster.

For the `Floating` points and the `Double` random number generator I am masking the results of the `Word32` and `Word64` random generator to a _sensible_ scope.

This generates more precise number generator but now I get the following error:

```
Seed: 3243238201641105201

foundation
  String
    reading
       ✗ Double failed after 1 test
         ✗ Prelude.read failed after 3 tests:
           use param: --seed 3243238201641105201
parameter 1 : 4.6114233520297733e18
Property `cond1 && cond2' failed where:
   cond1 = Property `a -1.0e-8 < 4.6114233520297733e18 - 4.611423352029774e18 (== -512.0 ) b' failed where:

               a = -1.0e-8 :: Double
                    ^^^^^^^ ^^^^^^^^
               b = -512.0 :: Double
                    ^^^^^^^ ^^^^^^^
   cond2 = Succeed

Failed 1 out of 1

Test suite failure for package foundation-0.0.10
    check-foundation:  exited with: ExitFailure 1
```

1. The new random generator algorithm generates `4.6114233520297733e18`
2. `Prelude.show` gave `"4.6114233520297733e18"`
3. `Foundation.readDouble` gave `4.6114233520297733e18`
4. `Prelude.read` gave `4.611423352029774e18`

i.e.:

```
Foundation: 4.6114233520297733e18
Prelude:    4.6114233520297740e18
                             ^
```

This is obviously... intriguing... Did I change something totally wrong ?

@vincenthz what do you think ?