### PR TITLE
Improve the appveyor script

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,5 @@ environment:
 
 test_script:
 - stack setup > nul
-- echo "" | stack --no-terminal build
-- stack test
-- stack exec -- ghci -e "Fondation.Tuple2 1 1"
+- echo "" | stack --no-terminal build --test --bench
+- stack exec -- ghci -e "Foundation.Tuple2 1 1"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,3 +17,4 @@ test_script:
 - stack setup > nul
 - echo "" | stack --no-terminal build
 - stack test
+- stack exec -- ghci -e "Fondation.Tuple2 1 1"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,5 +15,5 @@ environment:
 
 test_script:
 - stack setup > nul
-- echo "" | stack --no-terminal build --test --bench
+- echo "" | stack --no-terminal build --test
 - stack exec -- ghci -e "Foundation.Tuple2 1 1"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,10 +7,6 @@ before_test:
 - set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
 - curl -ostack.zip -L --insecure http://www.stackage.org/stack/windows-i386
 - 7z x stack.zip stack.exe
-- curl -ocabal.tar.gz https://www.haskell.org/cabal/release/cabal-install-1.22.0.0/cabal-1.22.0.0-i386-unknown-mingw32.tar.gz
-- 7z x cabal.tar.gz
-- 7z x cabal.tar
-- ren cabal-1.22.0.0-i386-unknown-mingw32.exe cabal.exe
 
 clone_folder: "c:\\project"
 environment:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,4 +16,4 @@ environment:
 test_script:
 - stack setup > nul
 - echo "" | stack --no-terminal build --test
-- stack exec -- ghci -e "Foundation.Tuple2 1 1"
+- stack exec -- ghc -package=foundation -e "Foundation.Tuple2 1 1"


### PR DESCRIPTION
Does 3 things:

* Removes entirely redundant cabal download and extract (it wasn't ever needed).
* Simplifies the test stuff.
* Add a test that GHC isn't bust on Windows. This currently fails due to #358, which is a good thing.

I tried to run the benchmarks on the Appveyor server, but it takes too long. Perhaps if anyone were reinventing a benchmark running system they'd give the ability to set a target execution time, so you can run benchmarks quickly.

(You probably want to squash these commits - a lot of it was experimenting on Appveyor)