### PR TITLE
Fix #358

### DIFF
--- a/Foundation/System/Bindings/Time.hsc
+++ b/Foundation/System/Bindings/Time.hsc
@@ -11,6 +11,7 @@ import Foreign.C.Types
 
 #include <time.h>
 #include <sys/time.h>
+#include "foundation_system.h"
 
 type CClockId = CInt
 data CTimeSpec
@@ -34,24 +35,6 @@ size_CTimeZone = #const sizeof(struct timezone)
 
 size_CTimeT :: CSize
 size_CTimeT = #const sizeof(time_t)
-
-
-------------------------------------------------------------------------
-#ifdef __APPLE__
-
-#include <Availability.h>
-
--- in OSX 10.12, clock_* API family is defined
-#if !defined(__MAC_10_12) || __MAC_OS_X_VERSION_MIN_REQUIRED < __MAC_10_12
-#define FOUNDATION_SYSTEM_API_NO_CLOCK
-#endif
-
-#endif
-
-------------------------------------------------------------------------
-#ifdef _WIN32
-#define FOUNDATION_SYSTEM_API_NO_CLOCK
-#endif
 
 ------------------------------------------------------------------------
 #ifdef FOUNDATION_SYSTEM_API_NO_CLOCK

--- a/cbits/foundation_system.h
+++ b/cbits/foundation_system.h
@@ -3,6 +3,8 @@
 
 #ifdef _WIN32
    #define FOUNDATION_SYSTEM_WINDOWS
+   #define FOUNDATION_SYSTEM_API_NO_CLOCK
+
    //define something for Windows (32-bit and 64-bit, this part is common)
    #ifdef _WIN64
       #define FOUNDATION_SYSTEM_WINDOWS_64
@@ -30,7 +32,7 @@
     #define FOUNDATION_SYSTEM_UNIX
     #define FOUNDATION_SYSTEM_LINUX
     // linux
-#elif defined(__FreeBSD__) 
+#elif defined(__FreeBSD__)
     #define FOUNDATION_SYSTEM_UNIX
     #define FOUNDATION_SYSTEM_BSD
     #define FOUNDATION_SYSTEM_FREEBSD

--- a/tests/Test/Foundation/Misc.hs
+++ b/tests/Test/Foundation/Misc.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
 module Test.Foundation.Misc
     ( testHexadecimal
+    , testTime
     , testUUID
     ) where
 
@@ -28,6 +30,16 @@ hex = loop
 testHexadecimal = testGroup "hexadecimal"
     [ testProperty  "UArray(W8)" $ \l ->
         toList (toHexadecimal (fromListP (Proxy :: Proxy (UArray Word8)) l)) == hex l
+    ]
+
+testTime = testGroup "Time"
+    [ testProperty "foundation_time_clock_gettime links properly" $
+        $(let s :: String
+              s = fromString "Hello"
+
+              b :: Bool
+              b = s == s
+           in [| b |])
     ]
 
 testUUID = testGroup "UUID"

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -321,6 +321,7 @@ tests =
     , testNetworkIPv4
     , testNetworkIPv6
     , testHexadecimal
+    , testTime
     , testUUID
     , testGroup "Issues"
         [ testGroup "218"


### PR DESCRIPTION
Previously, `foundation_time_clock_gettime` wasn't actually being compiled since the C file it was defined in `foundation_time.c` was checking for the presence of the `FOUNDATION_SYSTEM_API_NO_CLOCK` macro. But this macro was defined in a Haskell file, `Time.hsc`! As a result, the macro was never detected in `foundation_time.c`.

Due to infelicities of how the runtime linker works, it would attempt to eagerly load the `foundation_time_clock_gettime` symbol on programs that didn't use it, causing strange linker errors like the ones observed in #358 and https://github.com/haskell-foundation/foundation/issues/326#issuecomment-309219955.

This shuffles around the `#define`s so that they're all in `foundation_system.h` where they belong. This also adds a test which uses Template Haskell to confirm that the runtime linker really does the right thing here.