### PR TITLE
Improve the appveyor script, avoid an error when it does work

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,4 +16,4 @@ environment:
 test_script:
 - stack setup > nul
 - echo "" | stack --no-terminal build --test
-- stack exec -- ghc -package=foundation -e "Foundation.Tuple2 1 1"
+- stack exec -- ghc -package=foundation -e 1


### PR DESCRIPTION
Turns out whether `Foundation.Foo` works or not is variable. Fortunately just loading foundation via `-package` reproduces the bug, so I'm reducing it to that.