### PR TITLE
Pinning flag cleanup

### DIFF
--- a/Foundation/Array/Unboxed.hs
+++ b/Foundation/Array/Unboxed.hs
@@ -307,9 +307,9 @@ withPtr (UVecAddr start _ fptr)  f =
   where
     sz           = primSizeInBytes (Proxy :: Proxy ty)
     !(Offset os) = offsetOfE sz start
-withPtr (UVecBA start _ pstatus a) f
-    | isPinned pstatus = f (Ptr (byteArrayContents# a) `plusPtr` os)
-    | otherwise        = do
+withPtr vec@(UVecBA start _ _ a) f
+    | isPinned vec == Pinned = f (Ptr (byteArrayContents# a) `plusPtr` os)
+    | otherwise              = do
         -- TODO don't copy the whole vector, and just allocate+copy the slice.
         let !sz# = sizeofByteArray# a
         (TmpBA ba) <- primitive $ \s -> do

--- a/Foundation/Array/Unboxed.hs
+++ b/Foundation/Array/Unboxed.hs
@@ -196,7 +196,7 @@ unsafeSlide :: (PrimType ty, PrimMonad prim) => MUArray ty (PrimState prim) -> O
 unsafeSlide mua s e = doSlide mua s e
   where
     doSlide :: (PrimType ty, PrimMonad prim) => MUArray ty (PrimState prim) -> Offset ty -> Offset ty -> prim ()
-    doSlide (MUVecMA mbStart _ _ mba) start end  =
+    doSlide (MUVecMA mbStart _ mba) start end  =
         primMutableByteArraySlideToStart mba (offsetInBytes $ mbStart+start) (offsetInBytes end)
     doSlide (MUVecAddr mbStart _ fptr) start end = withFinalPtr fptr $ \(Ptr addr) ->
         primMutableAddrSlideToStart addr (offsetInBytes $ mbStart+start) (offsetInBytes end)
@@ -285,7 +285,7 @@ copyToPtr :: forall ty prim . (PrimType ty, PrimMonad prim)
           => UArray ty -- ^ the source array to copy
           -> Ptr ty    -- ^ The destination address where the copy is going to start
           -> prim ()
-copyToPtr (UVecBA start sz _ ba) (Ptr p) = primitive $ \s1 ->
+copyToPtr (UVecBA start sz ba) (Ptr p) = primitive $ \s1 ->
     (# compatCopyByteArrayToAddr# ba offset p szBytes s1, () #)
   where
     !(Offset (I# offset)) = offsetInBytes start
@@ -307,7 +307,7 @@ withPtr (UVecAddr start _ fptr)  f =
   where
     sz           = primSizeInBytes (Proxy :: Proxy ty)
     !(Offset os) = offsetOfE sz start
-withPtr vec@(UVecBA start _ _ a) f
+withPtr vec@(UVecBA start _ a) f
     | isPinned vec == Pinned = f (Ptr (byteArrayContents# a) `plusPtr` os)
     | otherwise              = do
         -- TODO don't copy the whole vector, and just allocate+copy the slice.
@@ -342,19 +342,19 @@ recast array
     missing = alen `mod` bs
 
 unsafeRecast :: (PrimType a, PrimType b) => UArray a -> UArray b
-unsafeRecast (UVecBA start len pinStatus b) = UVecBA (primOffsetRecast start) (sizeRecast len) pinStatus b
+unsafeRecast (UVecBA start len b) = UVecBA (primOffsetRecast start) (sizeRecast len) b
 unsafeRecast (UVecAddr start len a) = UVecAddr (primOffsetRecast start) (sizeRecast len) (castFinalPtr a)
 {-# INLINE [1] unsafeRecast #-}
 {-# RULES "unsafeRecast from Word8" [2] forall a . unsafeRecast a = unsafeRecastBytes a #-}
 
 unsafeRecastBytes :: PrimType a => UArray Word8 -> UArray a
-unsafeRecastBytes (UVecBA start len pinStatus b) = UVecBA (primOffsetRecast start) (sizeRecast len) pinStatus b
+unsafeRecastBytes (UVecBA start len b) = UVecBA (primOffsetRecast start) (sizeRecast len) b
 unsafeRecastBytes (UVecAddr start len a) = UVecAddr (primOffsetRecast start) (sizeRecast len) (castFinalPtr a)
 {-# INLINE [1] unsafeRecastBytes #-}
 
 null :: UArray ty -> Bool
-null (UVecBA _ sz _ _) = sz == CountOf 0
-null (UVecAddr _ l _)  = l == CountOf 0
+null (UVecBA _ sz _)  = sz == CountOf 0
+null (UVecAddr _ l _) = l == CountOf 0
 
 -- | Take a count of elements from the array and create an array with just those elements
 take :: PrimType ty => CountOf ty -> UArray ty -> UArray ty
@@ -363,14 +363,14 @@ take n v
     | n >= vlen = v
     | otherwise =
         case v of
-            UVecBA start _ pinst ba -> UVecBA start n pinst ba
-            UVecAddr start _ fptr   -> UVecAddr start n fptr
+            UVecBA start _ ba     -> UVecBA start n ba
+            UVecAddr start _ fptr -> UVecAddr start n fptr
   where
     vlen = length v
 
 unsafeTake :: PrimType ty => CountOf ty -> UArray ty -> UArray ty
-unsafeTake sz (UVecBA start _ pinst ba) = UVecBA start sz pinst ba
-unsafeTake sz (UVecAddr start _ fptr)   = UVecAddr start sz fptr
+unsafeTake sz (UVecBA start _ ba)     = UVecBA start sz ba
+unsafeTake sz (UVecAddr start _ fptr) = UVecAddr start sz fptr
 
 -- | Drop a count of elements from the array and return the new array minus those dropped elements
 drop :: PrimType ty => CountOf ty -> UArray ty -> UArray ty
@@ -379,14 +379,14 @@ drop n v
     | n >= vlen = mempty
     | otherwise =
         case v of
-            UVecBA start len pinst ba -> UVecBA (start `offsetPlusE` n) (len - n) pinst ba
-            UVecAddr start len fptr   -> UVecAddr (start `offsetPlusE` n) (len - n) fptr
+            UVecBA start len ba     -> UVecBA (start `offsetPlusE` n) (len - n) ba
+            UVecAddr start len fptr -> UVecAddr (start `offsetPlusE` n) (len - n) fptr
   where
     vlen = length v
 
 unsafeDrop :: PrimType ty => CountOf ty -> UArray ty -> UArray ty
-unsafeDrop n (UVecBA start sz pinst ba) = UVecBA (start `offsetPlusE` sz) (sz `sizeSub` n) pinst ba
-unsafeDrop n (UVecAddr start sz fptr)   = UVecAddr (start `offsetPlusE` sz) (sz `sizeSub` n) fptr
+unsafeDrop n (UVecBA start sz ba)     = UVecBA (start `offsetPlusE` sz) (sz `sizeSub` n) ba
+unsafeDrop n (UVecAddr start sz fptr) = UVecAddr (start `offsetPlusE` sz) (sz `sizeSub` n) fptr
 
 -- | Split an array into two, with a count of at most N elements in the first one
 -- and the remaining in the other.
@@ -396,21 +396,19 @@ splitAt nbElems v
     | n == vlen    = (v, mempty)
     | otherwise    =
         case v of
-            UVecBA start len pinst ba -> ( UVecBA start                   n         pinst ba
-                                         , UVecBA (start `offsetPlusE` n) (len - n) pinst ba)
-            UVecAddr start len fptr    -> ( UVecAddr start                   n         fptr
-                                          , UVecAddr (start `offsetPlusE` n) (len - n) fptr)
+            UVecBA start len ba     -> ( UVecBA start n ba     , UVecBA (start `offsetPlusE` n) (len - n) ba)
+            UVecAddr start len fptr -> ( UVecAddr start n fptr , UVecAddr (start `offsetPlusE` n) (len - n) fptr)
   where
     n    = min nbElems vlen
     vlen = length v
 
 splitElem :: PrimType ty => ty -> UArray ty -> (# UArray ty, UArray ty #)
-splitElem !ty r@(UVecBA start len pinst ba)
+splitElem !ty r@(UVecBA start len ba)
     | k == end   = (# r, mempty #)
     | k == start = (# mempty, r #)
     | otherwise  =
-        (# UVecBA start (offsetAsSize k - offsetAsSize start) pinst ba
-        ,  UVecBA k     (len - (offsetAsSize k - offsetAsSize start)) pinst ba
+        (# UVecBA start (offsetAsSize k - offsetAsSize start) ba
+        ,  UVecBA k     (len - (offsetAsSize k - offsetAsSize start)) ba
         #)
   where
     !end = start `offsetPlusE` len
@@ -478,8 +476,8 @@ sub vec startIdx expectedEndIdx
     | startIdx >= endIdx = mempty
     | otherwise          =
         case vec of
-            UVecBA start _ pinst ba -> UVecBA (start + startIdx) newLen pinst ba
-            UVecAddr start _ fptr   -> UVecAddr (start + startIdx) newLen fptr
+            UVecBA start _ ba     -> UVecBA (start + startIdx) newLen ba
+            UVecAddr start _ fptr -> UVecAddr (start + startIdx) newLen fptr
   where
     newLen = endIdx - startIdx
     endIdx = min expectedEndIdx (0 `offsetPlusE` len)
@@ -529,7 +527,7 @@ breakElem xelem xv = let (# v1, v2 #) = splitElem xelem xv in (v1, v2)
 {-# SPECIALIZE [2] breakElem :: Word32 -> UArray Word32 -> (UArray Word32, UArray Word32) #-}
 
 elem :: PrimType ty => ty -> UArray ty -> Bool
-elem !ty (UVecBA start len _ ba)
+elem !ty (UVecBA start len ba)
     | k == end   = False
     | otherwise  = True
   where
@@ -668,7 +666,7 @@ filter predicate arr = runST $ do
                 case arr of
                     (UVecAddr start len fptr) -> withFinalPtr fptr $ \(Ptr addr) ->
                                                     PrimAddr.filter predicate mba addr start (start `offsetPlusE` len)
-                    (UVecBA start len _ ba)   -> PrimBA.filter predicate mba ba start (start `offsetPlusE` len)
+                    (UVecBA start len ba)     -> PrimBA.filter predicate mba ba start (start `offsetPlusE` len)
     unsafeFreezeShrink ma newLen
 
 reverse :: PrimType ty => UArray ty -> UArray ty
@@ -677,7 +675,7 @@ reverse a
     | otherwise     = runST $ do
         ((), ma) <- newNative len $ \mba ->
                 case a of
-                    (UVecBA start _ _ ba)   -> goNative endOfs mba ba start
+                    (UVecBA start _ ba)     -> goNative endOfs mba ba start
                     (UVecAddr start _ fptr) -> withFinalPtr fptr $ \ptr -> goAddr endOfs mba ptr start
         unsafeFreeze ma
   where

--- a/Foundation/Array/Unboxed/Mutable.hs
+++ b/Foundation/Array/Unboxed/Mutable.hs
@@ -79,10 +79,10 @@ write array n val
 {-# INLINE write #-}
 
 empty :: PrimMonad prim => prim (MUArray ty (PrimState prim))
-empty = primitive $ \s1 -> case newByteArray# 0# s1 of { (# s2, mba #) -> (# s2, MUVecMA 0 0 Unpinned mba #) }
+empty = primitive $ \s1 -> case newByteArray# 0# s1 of { (# s2, mba #) -> (# s2, MUVecMA 0 0 mba #) }
 
 mutableSame :: MUArray ty st -> MUArray ty st -> Bool
-mutableSame (MUVecMA sa ea _ ma) (MUVecMA sb eb _ mb) = (sa == sb) && (ea == eb) && bool# (sameMutableByteArray# ma mb)
+mutableSame (MUVecMA sa ea ma) (MUVecMA sb eb mb)     = (sa == sb) && (ea == eb) && bool# (sameMutableByteArray# ma mb)
 mutableSame (MUVecAddr s1 e1 f1) (MUVecAddr s2 e2 f2) = (s1 == s2) && (e1 == e2) && finalPtrSameMemory f1 f2
 mutableSame MUVecMA {}     MUVecAddr {}   = False
 mutableSame MUVecAddr {}   MUVecMA {}     = False
@@ -98,10 +98,10 @@ sub :: (PrimMonad prim, PrimType ty)
     -> Int -- The number of elements to drop ahead
     -> Int -- Then the number of element to retain
     -> prim (MUArray ty (PrimState prim))
-sub (MUVecMA start sz pstatus mba) dropElems' takeElems
+sub (MUVecMA start sz mba) dropElems' takeElems
     | takeElems <= 0 = empty
     | resultEmpty    = empty
-    | otherwise      = return $ MUVecMA (start `offsetPlusE` dropElems) (min (CountOf takeElems) (sz - dropElems)) pstatus mba
+    | otherwise      = return $ MUVecMA (start `offsetPlusE` dropElems) (min (CountOf takeElems) (sz - dropElems)) mba
   where
     dropElems = max 0 (CountOf dropElems')
     resultEmpty = dropElems >= sz
@@ -131,11 +131,11 @@ copyAddr (MUVecAddr start _ fptr) od src os sz =
 
 -- | return the numbers of elements in a mutable array
 mutableLength :: PrimType ty => MUArray ty st -> Int
-mutableLength (MUVecMA _ (CountOf end) _ _) = end
+mutableLength (MUVecMA _ (CountOf end) _)   = end
 mutableLength (MUVecAddr _ (CountOf end) _) = end
 
 mutableLengthSize :: PrimType ty => MUArray ty st -> CountOf ty
-mutableLengthSize (MUVecMA _ end _ _) = end
+mutableLengthSize (MUVecMA _ end _)   = end
 mutableLengthSize (MUVecAddr _ end _) = end
 
 withMutablePtrHint :: forall ty prim a . (PrimMonad prim, PrimType ty)
@@ -149,7 +149,7 @@ withMutablePtrHint _ _ (MUVecAddr start _ fptr)  f =
   where
     sz           = primSizeInBytes (Proxy :: Proxy ty)
     !(Offset os) = offsetOfE sz start
-withMutablePtrHint skipCopy skipCopyBack vec@(MUVecMA start vecSz _ a) f
+withMutablePtrHint skipCopy skipCopyBack vec@(MUVecMA start vecSz a) f
     | isMutablePinned vec == Pinned = mutableByteArrayContent a >>= \ptr -> f (ptr `plusPtr` os)
     | otherwise                     = do
         trampoline <- newPinned vecSz
@@ -187,7 +187,7 @@ withMutablePtr = withMutablePtrHint False False
 -- | Copy from a pointer, @count@ elements, into the mutable array
 copyFromPtr :: forall prim ty . (PrimMonad prim, PrimType ty)
             => Ptr ty -> CountOf ty -> MUArray ty (PrimState prim) -> prim ()
-copyFromPtr (Ptr p) count (MUVecMA ofs arrSz _ mba)
+copyFromPtr (Ptr p) count (MUVecMA ofs arrSz mba)
     | count > arrSz = primOutOfBound OOB_MemCopy (sizeAsOffset count) arrSz
     | otherwise     = primitive $ \st -> (# copyAddrToByteArray# p mba od countBytes st, () #)
   where
@@ -208,7 +208,7 @@ copyToPtr :: forall ty prim . (PrimType ty, PrimMonad prim)
           => MUArray ty (PrimState prim) -- ^ the source mutable array to copy
           -> Ptr ty                      -- ^ The destination address where the copy is going to start
           -> prim ()
-copyToPtr (MUVecMA start sz _ ma) (Ptr p) = primitive $ \s1 ->
+copyToPtr (MUVecMA start sz ma) (Ptr p) = primitive $ \s1 ->
     case unsafeFreezeByteArray# ma s1 of
         (# s2, ba #) -> (# compatCopyByteArrayToAddr# ba offset p szBytes s2, () #)
   where

--- a/Foundation/Internal/PrimTypes.hs
+++ b/Foundation/Internal/PrimTypes.hs
@@ -10,6 +10,8 @@ module Foundation.Internal.PrimTypes
     ( FileSize#
     , Offset#
     , CountOf#
+    , Bool#
+    , Pinned#
     ) where
 
 import GHC.Prim
@@ -26,3 +28,9 @@ type Offset# = Int#
 --
 -- for code documentation purpose only, just a simple type alias on Int#
 type CountOf# = Int#
+
+-- | Lowlevel Boolean
+type Bool# = Int#
+
+-- | Pinning status
+type Pinned# = Bool#

--- a/Foundation/Internal/Primitive.hs
+++ b/Foundation/Internal/Primitive.hs
@@ -9,7 +9,6 @@
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE UnliftedFFITypes #-}
-{-# LANGUAGE PatternSynonyms #-}
 module Foundation.Internal.Primitive
     ( bool#
     , PinnedStatus(..), toPinnedStatus#
@@ -46,8 +45,8 @@ data PinnedStatus = Pinned | Unpinned
     deriving (Prelude.Eq)
 
 toPinnedStatus# :: Pinned# -> PinnedStatus
-toPinnedStatus# 0# = Pinned
-toPinnedStatus# _  = Unpinned
+toPinnedStatus# 0# = Unpinned
+toPinnedStatus# _  = Pinned
 
 -- | turn an Int# into a Bool
 --

--- a/Foundation/Internal/Primitive.hs
+++ b/Foundation/Internal/Primitive.hs
@@ -29,6 +29,8 @@ import           GHC.Word
 import           GHC.IO
 #endif
 
+import           Foundation.Internal.PrimTypes
+
 --  GHC 8.0  | Base 4.9
 --  GHC 7.10 | Base 4.8
 --  GHC 7.8  | Base 4.7
@@ -36,7 +38,10 @@ import           GHC.IO
 --  GHC 7.4  | Base 4.5
 
 -- | Flag record whether a specific byte array is pinned or not
-data PinnedStatus = PinnedStatus Int#
+data PinnedStatus = PinnedStatus Pinned#
+
+toPinnedStatus :: Pinned# -> PinnedStatus
+toPinnedStatus = PinnedStatus
 
 isPinned :: PinnedStatus -> Prelude.Bool
 isPinned (PinnedStatus 0#) = Prelude.False

--- a/Foundation/Internal/Primitive.hs
+++ b/Foundation/Internal/Primitive.hs
@@ -9,9 +9,10 @@
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE UnliftedFFITypes #-}
+{-# LANGUAGE PatternSynonyms #-}
 module Foundation.Internal.Primitive
     ( bool#
-    , PinnedStatus, toPinnedStatus, pinned, unpinned, isPinned
+    , PinnedStatus(..), toPinnedStatus#
     , compatAndI#
     , compatQuotRemInt#
     , compatCopyAddrToByteArray#
@@ -41,20 +42,12 @@ import           Foundation.Internal.PrimTypes
 --  GHC 7.4  | Base 4.5
 
 -- | Flag record whether a specific byte array is pinned or not
-data PinnedStatus = PinnedStatus Pinned#
+data PinnedStatus = Pinned | Unpinned
+    deriving (Prelude.Eq)
 
-toPinnedStatus :: Pinned# -> PinnedStatus
-toPinnedStatus = PinnedStatus
-
-isPinned :: PinnedStatus -> Prelude.Bool
-isPinned (PinnedStatus 0#) = Prelude.False
-isPinned _                 = Prelude.True
-
-pinned :: PinnedStatus
-pinned = PinnedStatus 1#
-
-unpinned :: PinnedStatus
-unpinned = PinnedStatus 0#
+toPinnedStatus# :: Pinned# -> PinnedStatus
+toPinnedStatus# 0# = Pinned
+toPinnedStatus# _  = Unpinned
 
 -- | turn an Int# into a Bool
 --

--- a/Foundation/Internal/Primitive.hs
+++ b/Foundation/Internal/Primitive.hs
@@ -8,9 +8,10 @@
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE UnliftedFFITypes #-}
 module Foundation.Internal.Primitive
     ( bool#
-    , PinnedStatus, pinned, unpinned, isPinned
+    , PinnedStatus, toPinnedStatus, pinned, unpinned, isPinned
     , compatAndI#
     , compatQuotRemInt#
     , compatCopyAddrToByteArray#
@@ -19,6 +20,8 @@ module Foundation.Internal.Primitive
     , compatGetSizeofMutableByteArray#
     , compatShrinkMutableByteArray#
     , compatResizeMutableByteArray#
+    , compatIsByteArrayPinned#
+    , compatIsMutableByteArrayPinned#
     , Word(..)
     ) where
 
@@ -168,3 +171,17 @@ compatResizeMutableByteArray# src i s =
     !len = sizeofMutableByteArray# src
 #endif
 {-# INLINE compatResizeMutableByteArray# #-}
+
+#if __GLASGOW_HASKELL__ >= 802
+compatIsByteArrayPinned# :: ByteArray# -> Pinned#
+compatIsByteArrayPinned# ba = isByteArrayPinned# ba
+
+compatIsMutableByteArrayPinned# :: MutableByteArray# s -> Pinned#
+compatIsMutableByteArrayPinned# ba = isMutableByteArrayPinned# ba
+#else
+foreign import ccall unsafe "foundation_is_bytearray_pinned"
+    compatIsByteArrayPinned# :: ByteArray# -> Pinned#
+
+foreign import ccall unsafe "foundation_is_bytearray_pinned"
+    compatIsMutableByteArrayPinned# :: MutableByteArray# s -> Pinned#
+#endif

--- a/Foundation/Primitive/UTF8/Base.hs
+++ b/Foundation/Primitive/UTF8/Base.hs
@@ -122,7 +122,7 @@ sFromList l = runST (new bytes >>= startCopy)
 next :: String -> Offset8 -> (# Char, Offset8 #)
 next (String array) n =
     case array of
-        Vec.UVecBA start _ _ ba   -> let (# c, o #) = PrimBA.next ba (start + n)
+        Vec.UVecBA start _ ba     -> let (# c, o #) = PrimBA.next ba (start + n)
                                       in (# c, o `offsetSub` start #)
         Vec.UVecAddr start _ fptr -> unt2 $ withUnsafeFinalPtr fptr $ \(Ptr ptr) -> pureST $ t2 start (PrimAddr.next ptr (start + n))
   where
@@ -134,7 +134,7 @@ next (String array) n =
 prev :: String -> Offset8 -> (# Char, Offset8 #)
 prev (String array) n =
     case array of
-        Vec.UVecBA start _ _ ba   -> let (# c, o #) = PrimBA.prev ba (start + n)
+        Vec.UVecBA start _ ba     -> let (# c, o #) = PrimBA.prev ba (start + n)
                                       in (# c, o `offsetSub` start #)
         Vec.UVecAddr start _ fptr -> unt2 $ withUnsafeFinalPtr fptr $ \(Ptr ptr) -> pureST $ t2 start (PrimAddr.prev ptr (start + n))
   where
@@ -158,7 +158,7 @@ expectAscii (String ba) n v = Vec.unsafeIndex ba n == v
 write :: PrimMonad prim => MutableString (PrimState prim) -> Offset8 -> Char -> prim Offset8
 write (MutableString marray) ofs c =
     case marray of
-        MVec.MUVecMA start _ _ mba  -> PrimBA.write mba (start + ofs) c
+        MVec.MUVecMA start _ mba    -> PrimBA.write mba (start + ofs) c
         MVec.MUVecAddr start _ fptr -> withFinalPtr fptr $ \(Ptr ptr) -> PrimAddr.write ptr (start + ofs) c
 
 -- | Allocate a MutableString of a specific size in bytes.

--- a/Foundation/String/UTF8.hs
+++ b/Foundation/String/UTF8.hs
@@ -761,7 +761,7 @@ filter :: (Char -> Bool) -> String -> String
 filter predicate (String arr) = runST $ do
     (finalSize, dst) <- newNative sz $ \mba ->
         case arr of
-            C.UVecBA start _ _ ba -> BackendBA.copyFilter predicate sz mba ba start
+            C.UVecBA start _ ba     -> BackendBA.copyFilter predicate sz mba ba start
             C.UVecAddr start _ fptr -> withFinalPtr fptr $ \(Ptr addr) -> BackendAddr.copyFilter predicate sz mba addr start
     freezeShrink finalSize dst
   where

--- a/cbits/foundation_rts.c
+++ b/cbits/foundation_rts.c
@@ -1,0 +1,8 @@
+#include "Rts.h"
+
+#if __GLASGOW_HASKELL__ < 802
+int foundation_is_bytearray_pinned(void *p)
+{
+    return Bdescr((StgPtr) p)->flags & BF_PINNED;
+}
+#endif

--- a/foundation.cabal
+++ b/foundation.cabal
@@ -223,6 +223,7 @@ library
                      cbits/foundation_network.c
                      cbits/foundation_mem.c
                      cbits/foundation_time.c
+                     cbits/foundation_rts.c
 
   if flag(experimental)
     exposed-modules: Foundation.Network.HostName


### PR DESCRIPTION
Cleanup the temporary pinning flag explicitly tracked in UArray by using the new primitive isByteArrayPinned# available in 8.2 or some C compat.

net benefits:

* reduce each UArray by a word
* reflect the actual status known by GHC/RTS instead of what we think we know (e.g. if we want unpinned memory, but the size is too big to allow it)

(step0 before trying the unpacked sum type)