### PR TITLE
Array bench refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,9 @@ matrix:
     language: generic
     addons: { apt: { packages: [ libgmp-dev ] } }
     compiler: ghc-8.0
+  - env: BUILD=hlint
+    language: generic
+    compiler: hlint
 
 install:
   - export PATH=$HOME/.local/bin::$HOME/.cabal/bin:$PATH

--- a/Foundation/Array/Unboxed.hs
+++ b/Foundation/Array/Unboxed.hs
@@ -89,6 +89,7 @@ module Foundation.Array.Unboxed
     , foldl1'
     , all
     , any
+    , isPrefixOf
     , foreignMem
     , fromForeignPtr
     , builderAppend
@@ -893,3 +894,12 @@ convert3 table (W8# a) (W8# b) (W8# c) =
   where
     idx :: Word# -> Word8
     idx i = W8# (indexWord8OffAddr# table (word2Int# i))
+
+isPrefixOf :: PrimType ty => UArray ty -> UArray ty -> Bool
+isPrefixOf pre arr
+    | pLen > pArr = False
+    | otherwise   = pre == unsafeTake pLen arr
+  where
+    !pLen = length pre
+    !pArr = length arr
+{-# SPECIALIZE [3] isPrefixOf :: UArray Word8 -> UArray Word8 -> Bool #-}

--- a/Foundation/Array/Unboxed.hs
+++ b/Foundation/Array/Unboxed.hs
@@ -161,7 +161,7 @@ foreignMem fptr nb = UArrayAddr (Offset 0) nb fptr
 fromForeignPtr :: PrimType ty
                => (ForeignPtr ty, Int, Int) -- ForeignPtr, an offset in prim elements, a size in prim elements
                -> UArray ty
-fromForeignPtr (fptr, ofs, len)   = UArrayAddr (Offset ofs) (CountOf len) (toFinalPtrForeign fptr)
+fromForeignPtr (fptr, ofs, len) = UArrayAddr (Offset ofs) (CountOf len) (toFinalPtrForeign fptr)
 
 
 -- | Allocate a new array with a fill function that has access to the elements of

--- a/Foundation/Array/Unboxed.hs
+++ b/Foundation/Array/Unboxed.hs
@@ -184,7 +184,7 @@ freeze ma = do
     ma' <- new len
     copyAt ma' (Offset 0) ma (Offset 0) len
     unsafeFreeze ma'
-  where len = CountOf $ mutableLength ma
+  where len = mutableLength ma
 
 freezeShrink :: (PrimType ty, PrimMonad prim) => MUArray ty (PrimState prim) -> CountOf ty -> prim (UArray ty)
 freezeShrink ma n = do

--- a/Foundation/Array/Unboxed.hs
+++ b/Foundation/Array/Unboxed.hs
@@ -286,9 +286,9 @@ copyToPtr :: forall ty prim . (PrimType ty, PrimMonad prim)
           -> Ptr ty    -- ^ The destination address where the copy is going to start
           -> prim ()
 copyToPtr (UArrayBA start sz ba) (Ptr p) = primitive $ \s1 ->
-    (# compatCopyByteArrayToAddr# ba offset p szBytes s1, () #)
+    (# compatCopyByteArrayToAddr# ba os p szBytes s1, () #)
   where
-    !(Offset (I# offset)) = offsetInBytes start
+    !(Offset (I# os)) = offsetInBytes start
     !(CountOf (I# szBytes)) = sizeInBytes sz
 copyToPtr (UArrayAddr start sz fptr) dst =
     unsafePrimFromIO $ withFinalPtr fptr $ \ptr -> copyBytes dst (ptr `plusPtr` os) szBytes

--- a/Foundation/Array/Unboxed.hs
+++ b/Foundation/Array/Unboxed.hs
@@ -344,31 +344,31 @@ null :: UArray ty -> Bool
 null arr = length arr == 0
 
 -- | Take a count of elements from the array and create an array with just those elements
-take :: PrimType ty => CountOf ty -> UArray ty -> UArray ty
+take :: CountOf ty -> UArray ty -> UArray ty
 take n arr@(UArray start len backend)
-    | n <= 0    = mempty
+    | n <= 0    = empty
     | n >= len  = arr
     | otherwise = UArray start n backend
 
-unsafeTake :: PrimType ty => CountOf ty -> UArray ty -> UArray ty
+unsafeTake :: CountOf ty -> UArray ty -> UArray ty
 unsafeTake sz (UArray start _ ba) = UArray start sz ba
 
 -- | Drop a count of elements from the array and return the new array minus those dropped elements
-drop :: PrimType ty => CountOf ty -> UArray ty -> UArray ty
+drop :: CountOf ty -> UArray ty -> UArray ty
 drop n arr@(UArray start len backend)
     | n <= 0    = arr
-    | n >= len  = mempty
+    | n >= len  = empty
     | otherwise = UArray (start `offsetPlusE` n) (len - n) backend
 
-unsafeDrop :: PrimType ty => CountOf ty -> UArray ty -> UArray ty
+unsafeDrop :: CountOf ty -> UArray ty -> UArray ty
 unsafeDrop n (UArray start sz backend) = UArray (start `offsetPlusE` sz) (sz `sizeSub` n) backend
 
 -- | Split an array into two, with a count of at most N elements in the first one
 -- and the remaining in the other.
-splitAt :: PrimType ty => CountOf ty -> UArray ty -> (UArray ty, UArray ty)
+splitAt :: CountOf ty -> UArray ty -> (UArray ty, UArray ty)
 splitAt nbElems arr@(UArray start len backend)
-    | nbElems <= 0 = (mempty, arr)
-    | n == len     = (arr, mempty)
+    | nbElems <= 0 = (empty, arr)
+    | n == len     = (arr, empty)
     | otherwise    = (UArray start n backend, UArray (start `offsetPlusE` n) (len - n) backend)
   where
     n    = min nbElems len
@@ -395,17 +395,17 @@ countFromStart v sz@(CountOf sz')
   where len@(CountOf len') = length v
 
 -- | Take the N elements from the end of the array
-revTake :: PrimType ty => CountOf ty -> UArray ty -> UArray ty
+revTake :: CountOf ty -> UArray ty -> UArray ty
 revTake n v = drop (countFromStart v n) v
 
 -- | Drop the N elements from the end of the array
-revDrop :: PrimType ty => CountOf ty -> UArray ty -> UArray ty
+revDrop :: CountOf ty -> UArray ty -> UArray ty
 revDrop n v = take (countFromStart v n) v
 
 -- | Split an array at the N element from the end, and return
 -- the last N elements in the first part of the tuple, and whatever first
 -- elements remaining in the second
-revSplitAt :: PrimType ty => CountOf ty -> UArray ty -> (UArray ty, UArray ty)
+revSplitAt :: CountOf ty -> UArray ty -> (UArray ty, UArray ty)
 revSplitAt n v = (drop sz v, take sz v) where sz = countFromStart v n
 
 splitOn :: PrimType ty => (ty -> Bool) -> UArray ty -> [UArray ty]

--- a/Foundation/Array/Unboxed.hs
+++ b/Foundation/Array/Unboxed.hs
@@ -5,11 +5,10 @@
 -- Stability   : experimental
 -- Portability : portable
 --
--- A simple array abstraction that allow to use typed
--- array of bytes where the array is pinned in memory
--- to allow easy use with Foreign interfaces, ByteString
--- and always aligned to 64 bytes.
+-- An unboxed array of primitive types
 --
+-- All the cells in the array are in one chunk of contiguous
+-- memory.
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE ScopedTypeVariables #-}

--- a/Foundation/Array/Unboxed/ByteArray.hs
+++ b/Foundation/Array/Unboxed/ByteArray.hs
@@ -19,7 +19,7 @@ mutableByteArraySet mba val = do
     -- naive haskell way. TODO: call memset or a 32-bit/64-bit method
     forM_ [0..(sizeLastOffset len)] $ \i -> unsafeWrite mba i val
   where
-    len = mutableLengthSize mba
+    len = mutableLength mba
 
 {-
 mutableByteArraySetBetween :: PrimMonad prim => MUArray Word8 (PrimState prim) -> Word8 -> Offset Word8 -> CountOf Word8 -> prim ()

--- a/Foundation/Array/Unboxed/Mutable.hs
+++ b/Foundation/Array/Unboxed/Mutable.hs
@@ -210,9 +210,9 @@ copyToPtr :: forall ty prim . (PrimType ty, PrimMonad prim)
           -> prim ()
 copyToPtr (MUArrayMBA start sz ma) (Ptr p) = primitive $ \s1 ->
     case unsafeFreezeByteArray# ma s1 of
-        (# s2, ba #) -> (# compatCopyByteArrayToAddr# ba offset p szBytes s2, () #)
+        (# s2, ba #) -> (# compatCopyByteArrayToAddr# ba os p szBytes s2, () #)
   where
-    !(Offset (I# offset)) = offsetInBytes start
+    !(Offset (I# os)) = offsetInBytes start
     !(CountOf (I# szBytes)) = sizeInBytes sz
 copyToPtr (MUArrayAddr start sz fptr) dst =
     unsafePrimFromIO $ withFinalPtr fptr $ \ptr -> copyBytes dst (ptr `plusPtr` os) szBytes

--- a/Foundation/Array/Unboxed/Mutable.hs
+++ b/Foundation/Array/Unboxed/Mutable.hs
@@ -18,7 +18,9 @@ module Foundation.Array.Unboxed.Mutable
     -- * Property queries
     , sizeInMutableBytesOfContent
     , mutableLength
+    , mutableOffset
     , mutableSame
+    , onMutableBackend
     -- * Allocation & Copy
     , new
     , newPinned
@@ -171,7 +173,7 @@ copyFromPtr src@(Ptr src#) count marr
     | otherwise     = onMutableBackend copyNative copyPtr marr
   where
     arrSz = mutableLength marr
-    ofs = mutOffset marr
+    ofs = mutableOffset marr
 
     sz = primSizeInBytes (Proxy :: Proxy ty)
     !(CountOf bytes@(I# bytes#)) = sizeOfE sz count
@@ -194,8 +196,9 @@ copyToPtr marr dst@(Ptr dst#) = onMutableBackend copyNative copyPtr marr
     copyPtr fptr = unsafePrimFromIO $ withFinalPtr fptr $ \ptr ->
         copyBytes dst (ptr `plusPtr` os) szBytes
 
-    !(Offset os@(I# os#)) = offsetInBytes $ mutOffset marr
+    !(Offset os@(I# os#)) = offsetInBytes $ mutableOffset marr
     !(CountOf szBytes@(I# szBytes#)) = sizeInBytes $ mutableLength marr
 
-mutOffset (MUArrayMBA ofs _ _) = ofs
-mutOffset (MUArrayAddr ofs _ _) = ofs
+mutableOffset :: MUArray ty st -> Offset ty
+mutableOffset (MUArrayMBA ofs _ _) = ofs
+mutableOffset (MUArrayAddr ofs _ _) = ofs

--- a/Foundation/Array/Unboxed/Mutable.hs
+++ b/Foundation/Array/Unboxed/Mutable.hs
@@ -51,7 +51,7 @@ import           Foundation.Primitive.FinalPtr
 import           Foundation.Primitive.Exception
 import qualified Foundation.Primitive.Block.Mutable as MBLK
 import           Foundation.Primitive.Block         (MutableBlock(..))
-import           Foundation.Primitive.UArray.Base
+import           Foundation.Primitive.UArray.Base hiding (empty)
 import           Foundation.Numerical
 import           Foreign.Marshal.Utils (copyBytes)
 

--- a/Foundation/Collection.hs
+++ b/Foundation/Collection.hs
@@ -14,6 +14,7 @@ module Foundation.Collection
     , Element
     , InnerFunctor(..)
     , Foldable(..)
+    , Fold1able(..)
     , Mappable(..)
     , traverse_
     , mapM_

--- a/Foundation/Collection/Collection.hs
+++ b/Foundation/Collection/Collection.hs
@@ -146,8 +146,8 @@ instance Collection S.String where
     elem = S.elem
     minimum = Data.List.minimum . toList . getNonEmpty -- TODO faster implementation
     maximum = Data.List.maximum . toList . getNonEmpty -- TODO faster implementation
-    all p = Data.List.all p . toList
-    any p = Data.List.any p . toList
+    all = S.all
+    any = S.any
 
 instance Collection c => Collection (NonEmpty c) where
     null _ = False

--- a/Foundation/Collection/Sequential.hs
+++ b/Foundation/Collection/Sequential.hs
@@ -263,6 +263,7 @@ instance UV.PrimType ty => Sequential (UV.UArray ty) where
     sortBy = UV.sortBy
     singleton = fromList . (:[])
     replicate = UV.replicate
+    isPrefixOf = UV.isPrefixOf
 
 instance Sequential (BA.Array ty) where
     take = BA.take

--- a/Foundation/Primitive/Block.hs
+++ b/Foundation/Primitive/Block.hs
@@ -169,8 +169,12 @@ foldl' f initialAcc vec = loop 0 initialAcc
 {-# SPECIALIZE [2] foldl' :: (a -> Word8 -> a) -> a -> Block Word8 -> a #-}
 
 foldl1' :: PrimType ty => (ty -> ty -> ty) -> NonEmpty (Block ty) -> ty
-foldl1' f arr = let (initialAcc, rest) = splitAt 1 $ getNonEmpty arr
-               in foldl' f (unsafeIndex initialAcc 0) rest
+foldl1' f (NonEmpty arr) = loop 1 (unsafeIndex arr 0)
+  where
+    !len = length arr
+    loop !i !acc
+        | i .==# len = acc
+        | otherwise  = loop (i+1) (f acc (unsafeIndex arr i))
 
 foldr1 :: PrimType ty => (ty -> ty -> ty) -> NonEmpty (Block ty) -> ty
 foldr1 f arr = let (initialAcc, rest) = revSplitAt 1 $ getNonEmpty arr

--- a/Foundation/Primitive/Block.hs
+++ b/Foundation/Primitive/Block.hs
@@ -272,7 +272,6 @@ elem v blk = loop 0
         | i .==# len             = False
         | unsafeIndex blk i == v = True
         | otherwise              = loop (i+1)
-        | otherwise             = False
 {-# SPECIALIZE [2] elem :: Word8 -> Block Word8 -> Bool #-}
 
 all :: PrimType ty => (ty -> Bool) -> Block ty -> Bool

--- a/Foundation/Primitive/Block/Base.hs
+++ b/Foundation/Primitive/Block/Base.hs
@@ -150,7 +150,7 @@ equal a b
 equalMemcmp :: PrimMemoryComparable ty => Block ty -> Block ty -> Bool
 equalMemcmp b1@(Block a) b2@(Block b)
     | la /= lb  = False
-    | otherwise = unsafeDupablePerformIO (sysHsMemcmpBaBa a 0 b 0 (csizeOfSize la)) == 0
+    | otherwise = unsafeDupablePerformIO (sysHsMemcmpBaBa a 0 b 0 la) == 0
   where
     la = lengthBytes b1
     lb = lengthBytes b2
@@ -182,7 +182,7 @@ compareMemcmp b1@(Block a) b2@(Block b) =
   where
     la = lengthBytes b1
     lb = lengthBytes b2
-    sz = csizeOfSize $ min la lb
+    sz = min la lb
 {-# SPECIALIZE [3] compareMemcmp :: Block Word8 -> Block Word8 -> Ordering #-}
 
 -- | Append 2 blocks together by creating a new bigger block

--- a/Foundation/Primitive/Block/Base.hs
+++ b/Foundation/Primitive/Block/Base.hs
@@ -19,6 +19,7 @@ module Foundation.Primitive.Block.Base
     , length
     , lengthBytes
     -- * Other methods
+    , mutableEmpty
     , new
     , newPinned
     , touch
@@ -93,6 +94,11 @@ empty_ = runST $ primitive $ \s1 ->
     case newByteArray# 0# s1           of { (# s2, mba #) ->
     case unsafeFreezeByteArray# mba s2 of { (# s3, ba  #) ->
         (# s3, Block ba #) }}
+
+mutableEmpty :: PrimMonad prim => prim (MutableBlock ty (PrimState prim))
+mutableEmpty = primitive $ \s1 ->
+    case newByteArray# 0# s1 of { (# s2, mba #) ->
+        (# s2, MutableBlock mba #) }
 
 -- | Return the element at a specific index from an array without bounds checking.
 --

--- a/Foundation/Primitive/Block/Base.hs
+++ b/Foundation/Primitive/Block/Base.hs
@@ -74,10 +74,11 @@ instance PrimType ty => IsList (Block ty) where
 
 length :: forall ty . PrimType ty => Block ty -> CountOf ty
 length (Block ba) =
-    let !(CountOf (I# szBits)) = primSizeInBytes (Proxy :: Proxy ty)
-        !elems              = quotInt# (sizeofByteArray# ba) szBits
-     in CountOf (I# elems)
+    case primSizeInBytes (Proxy :: Proxy ty) of
+        CountOf 1           -> CountOf (I# (sizeofByteArray# ba))
+        CountOf (I# szBits) -> CountOf (I# (uncheckedIShiftRL# (sizeofByteArray# ba) szBits))
 {-# INLINE[1] length #-}
+{-# SPECIALIZE [2] length :: Block Word8 -> CountOf Word8 #-}
 
 lengthBytes :: Block ty -> CountOf Word8
 lengthBytes (Block ba) = CountOf (I# (sizeofByteArray# ba))

--- a/Foundation/Primitive/Block/Base.hs
+++ b/Foundation/Primitive/Block/Base.hs
@@ -74,9 +74,9 @@ instance PrimType ty => IsList (Block ty) where
 
 length :: forall ty . PrimType ty => Block ty -> CountOf ty
 length (Block ba) =
-    case primSizeInBytes (Proxy :: Proxy ty) of
-        CountOf 1           -> CountOf (I# (sizeofByteArray# ba))
-        CountOf (I# szBits) -> CountOf (I# (uncheckedIShiftRL# (sizeofByteArray# ba) szBits))
+    case primShiftToBytes (Proxy :: Proxy ty) of
+        0           -> CountOf (I# (sizeofByteArray# ba))
+        (I# szBits) -> CountOf (I# (uncheckedIShiftRL# (sizeofByteArray# ba) szBits))
 {-# INLINE[1] length #-}
 {-# SPECIALIZE [2] length :: Block Word8 -> CountOf Word8 #-}
 

--- a/Foundation/Primitive/Block/Mutable.hs
+++ b/Foundation/Primitive/Block/Mutable.hs
@@ -41,7 +41,7 @@ module Foundation.Primitive.Block.Mutable
     , mutableGetAddr
     , new
     , newPinned
-    , isPinned
+    , mutableEmpty
     , iterSet
     , read
     , write
@@ -80,13 +80,6 @@ mutableLengthSize (MutableBlock mba) =
 mutableLengthBytes :: MutableBlock ty st -> CountOf Word8
 mutableLengthBytes (MutableBlock mba) = CountOf (I# (sizeofMutableByteArray# mba))
 {-# INLINE[1] mutableLengthBytes #-}
-
--- | Return if a Mutable Block is pinned or not
-isPinned :: MutableBlock ty st -> Bool
-isPinned (MutableBlock mba) =
-    -- TODO use the exact value where the array become pinned (LARGE_OBJECT_THRESHOLD)
-    -- in 8.2, there's a primitive to know if an array in pinned
-    I# (sizeofMutableByteArray# mba) > 3000
 
 -- | Get the address of the context of the mutable block.
 --

--- a/Foundation/Primitive/FinalPtr.hs
+++ b/Foundation/Primitive/FinalPtr.hs
@@ -18,6 +18,7 @@ module Foundation.Primitive.FinalPtr
     , castFinalPtr
     , toFinalPtr
     , toFinalPtrForeign
+    , touchFinalPtr
     , withFinalPtr
     , withUnsafeFinalPtr
     , withFinalPtrNoTouch
@@ -86,6 +87,10 @@ withFinalPtr (FinalForeign fptr) f = do
     unsafePrimFromIO (touchForeignPtr fptr)
     pure r
 {-# INLINE withFinalPtr #-}
+
+touchFinalPtr :: PrimMonad prim => FinalPtr p -> prim ()
+touchFinalPtr (FinalPtr ptr) = primTouch ptr
+touchFinalPtr (FinalForeign fptr) = unsafePrimFromIO (touchForeignPtr fptr)
 
 -- | Unsafe version of 'withFinalPtr'
 withUnsafeFinalPtr :: PrimMonad prim => FinalPtr p -> (Ptr p -> prim a) -> a

--- a/Foundation/Primitive/Types.hs
+++ b/Foundation/Primitive/Types.hs
@@ -156,6 +156,9 @@ class Eq ty => PrimType ty where
     -- | get the size in bytes of a ty element
     primSizeInBytes :: Proxy ty -> Size8
 
+    -- | get the shift size
+    primShiftToBytes :: Proxy ty -> Int
+
     -----
     -- ByteArray section
     -----
@@ -204,9 +207,13 @@ sizeInt, sizeWord :: CountOf Word8
 #if WORD_SIZE_IN_BITS == 64
 sizeInt = CountOf 8
 sizeWord = CountOf 8
+shiftInt = 3
+shiftWord = 3
 #else
 sizeInt = CountOf 4
 sizeWord = CountOf 4
+shiftInt = 2
+shiftWord = 2
 #endif
 
 {-# SPECIALIZE [3] primBaUIndex :: ByteArray# -> Offset Word8 -> Word8 #-}
@@ -214,6 +221,8 @@ sizeWord = CountOf 4
 instance PrimType Int where
     primSizeInBytes _ = sizeInt
     {-# INLINE primSizeInBytes #-}
+    primShiftToBytes _ = shiftInt
+    {-# INLINE primShiftToBytes #-}
     primBaUIndex ba (Offset (I# n)) = I# (indexIntArray# ba n)
     {-# INLINE primBaUIndex #-}
     primMbaURead mba (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readIntArray# mba n s1 in (# s2, I# r #)
@@ -230,6 +239,8 @@ instance PrimType Int where
 instance PrimType Word where
     primSizeInBytes _ = sizeWord
     {-# INLINE primSizeInBytes #-}
+    primShiftToBytes _ = shiftWord
+    {-# INLINE primShiftToBytes #-}
     primBaUIndex ba (Offset (I# n)) = W# (indexWordArray# ba n)
     {-# INLINE primBaUIndex #-}
     primMbaURead mba (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readWordArray# mba n s1 in (# s2, W# r #)
@@ -246,6 +257,8 @@ instance PrimType Word where
 instance PrimType Word8 where
     primSizeInBytes _ = CountOf 1
     {-# INLINE primSizeInBytes #-}
+    primShiftToBytes _ = 0
+    {-# INLINE primShiftToBytes #-}
     primBaUIndex ba (Offset (I# n)) = W8# (indexWord8Array# ba n)
     {-# INLINE primBaUIndex #-}
     primMbaURead mba (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readWord8Array# mba n s1 in (# s2, W8# r #)
@@ -262,6 +275,8 @@ instance PrimType Word8 where
 instance PrimType Word16 where
     primSizeInBytes _ = CountOf 2
     {-# INLINE primSizeInBytes #-}
+    primShiftToBytes _ = 1
+    {-# INLINE primShiftToBytes #-}
     primBaUIndex ba (Offset (I# n)) = W16# (indexWord16Array# ba n)
     {-# INLINE primBaUIndex #-}
     primMbaURead mba (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readWord16Array# mba n s1 in (# s2, W16# r #)
@@ -277,6 +292,8 @@ instance PrimType Word16 where
 instance PrimType Word32 where
     primSizeInBytes _ = CountOf 4
     {-# INLINE primSizeInBytes #-}
+    primShiftToBytes _ = 2
+    {-# INLINE primShiftToBytes #-}
     primBaUIndex ba (Offset (I# n)) = W32# (indexWord32Array# ba n)
     {-# INLINE primBaUIndex #-}
     primMbaURead mba (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readWord32Array# mba n s1 in (# s2, W32# r #)
@@ -292,6 +309,8 @@ instance PrimType Word32 where
 instance PrimType Word64 where
     primSizeInBytes _ = CountOf 8
     {-# INLINE primSizeInBytes #-}
+    primShiftToBytes _ = 3
+    {-# INLINE primShiftToBytes #-}
     primBaUIndex ba (Offset (I# n)) = W64# (indexWord64Array# ba n)
     {-# INLINE primBaUIndex #-}
     primMbaURead mba (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readWord64Array# mba n s1 in (# s2, W64# r #)
@@ -307,6 +326,8 @@ instance PrimType Word64 where
 instance PrimType Int8 where
     primSizeInBytes _ = CountOf 1
     {-# INLINE primSizeInBytes #-}
+    primShiftToBytes _ = 0
+    {-# INLINE primShiftToBytes #-}
     primBaUIndex ba (Offset (I# n)) = I8# (indexInt8Array# ba n)
     {-# INLINE primBaUIndex #-}
     primMbaURead mba (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readInt8Array# mba n s1 in (# s2, I8# r #)
@@ -322,6 +343,8 @@ instance PrimType Int8 where
 instance PrimType Int16 where
     primSizeInBytes _ = CountOf 2
     {-# INLINE primSizeInBytes #-}
+    primShiftToBytes _ = 1
+    {-# INLINE primShiftToBytes #-}
     primBaUIndex ba (Offset (I# n)) = I16# (indexInt16Array# ba n)
     {-# INLINE primBaUIndex #-}
     primMbaURead mba (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readInt16Array# mba n s1 in (# s2, I16# r #)
@@ -337,6 +360,8 @@ instance PrimType Int16 where
 instance PrimType Int32 where
     primSizeInBytes _ = CountOf 4
     {-# INLINE primSizeInBytes #-}
+    primShiftToBytes _ = 2
+    {-# INLINE primShiftToBytes #-}
     primBaUIndex ba (Offset (I# n)) = I32# (indexInt32Array# ba n)
     {-# INLINE primBaUIndex #-}
     primMbaURead mba (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readInt32Array# mba n s1 in (# s2, I32# r #)
@@ -352,6 +377,8 @@ instance PrimType Int32 where
 instance PrimType Int64 where
     primSizeInBytes _ = CountOf 8
     {-# INLINE primSizeInBytes #-}
+    primShiftToBytes _ = 3
+    {-# INLINE primShiftToBytes #-}
     primBaUIndex ba (Offset (I# n)) = I64# (indexInt64Array# ba n)
     {-# INLINE primBaUIndex #-}
     primMbaURead mba (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readInt64Array# mba n s1 in (# s2, I64# r #)
@@ -368,6 +395,8 @@ instance PrimType Int64 where
 instance PrimType Float where
     primSizeInBytes _ = CountOf 4
     {-# INLINE primSizeInBytes #-}
+    primShiftToBytes _ = 2
+    {-# INLINE primShiftToBytes #-}
     primBaUIndex ba (Offset (I# n)) = F# (indexFloatArray# ba n)
     {-# INLINE primBaUIndex #-}
     primMbaURead mba (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readFloatArray# mba n s1 in (# s2, F# r #)
@@ -383,6 +412,8 @@ instance PrimType Float where
 instance PrimType Double where
     primSizeInBytes _ = CountOf 8
     {-# INLINE primSizeInBytes #-}
+    primShiftToBytes _ = 3
+    {-# INLINE primShiftToBytes #-}
     primBaUIndex ba (Offset (I# n)) = D# (indexDoubleArray# ba n)
     {-# INLINE primBaUIndex #-}
     primMbaURead mba (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readDoubleArray# mba n s1 in (# s2, D# r #)
@@ -399,6 +430,8 @@ instance PrimType Double where
 instance PrimType Char where
     primSizeInBytes _ = CountOf 4
     {-# INLINE primSizeInBytes #-}
+    primShiftToBytes _ = 2
+    {-# INLINE primShiftToBytes #-}
     primBaUIndex ba (Offset (I# n)) = C# (indexWideCharArray# ba n)
     {-# INLINE primBaUIndex #-}
     primMbaURead mba (Offset (I# n)) = primitive $ \s1 -> let (# s2, r #) = readWideCharArray# mba n s1 in (# s2, C# r #)
@@ -415,6 +448,8 @@ instance PrimType Char where
 instance PrimType CChar where
     primSizeInBytes _ = CountOf 1
     {-# INLINE primSizeInBytes #-}
+    primShiftToBytes _ = 0
+    {-# INLINE primShiftToBytes #-}
     primBaUIndex ba (Offset n) = CChar (primBaUIndex ba (Offset n))
     {-# INLINE primBaUIndex #-}
     primMbaURead mba (Offset n) = CChar <$> primMbaURead mba (Offset n)
@@ -430,6 +465,8 @@ instance PrimType CChar where
 instance PrimType CUChar where
     primSizeInBytes _ = CountOf 1
     {-# INLINE primSizeInBytes #-}
+    primShiftToBytes _ = 0
+    {-# INLINE primShiftToBytes #-}
     primBaUIndex ba (Offset n) = CUChar (primBaUIndex ba (Offset n :: Offset Word8))
     {-# INLINE primBaUIndex #-}
     primMbaURead mba (Offset n) = CUChar <$> primMbaURead mba (Offset n :: Offset Word8)
@@ -446,6 +483,8 @@ instance PrimType CUChar where
 instance PrimType a => PrimType (LE a) where
     primSizeInBytes _ = primSizeInBytes (Proxy :: Proxy a)
     {-# INLINE primSizeInBytes #-}
+    primShiftToBytes _ = primShiftToBytes (Proxy :: Proxy a)
+    {-# INLINE primShiftToBytes #-}
     primBaUIndex ba (Offset a) = LE $ primBaUIndex ba (Offset a)
     {-# INLINE primBaUIndex #-}
     primMbaURead ba (Offset a) = LE <$> primMbaURead ba (Offset a)
@@ -461,6 +500,8 @@ instance PrimType a => PrimType (LE a) where
 instance PrimType a => PrimType (BE a) where
     primSizeInBytes _ = primSizeInBytes (Proxy :: Proxy a)
     {-# INLINE primSizeInBytes #-}
+    primShiftToBytes _ = primShiftToBytes (Proxy :: Proxy a)
+    {-# INLINE primShiftToBytes #-}
     primBaUIndex ba (Offset a) = BE $ primBaUIndex ba (Offset a)
     {-# INLINE primBaUIndex #-}
     primMbaURead ba (Offset a) = BE <$> primMbaURead ba (Offset a)
@@ -501,7 +542,7 @@ instance PrimMemoryComparable a => PrimMemoryComparable (BE a) where
 -- | Cast a CountOf linked to type A (CountOf A) to a CountOf linked to type B (CountOf B)
 sizeRecast :: forall a b . (PrimType a, PrimType b) => CountOf a -> CountOf b
 sizeRecast sz = CountOf (bytes `Prelude.quot` szB)
-  where !szA          = primSizeInBytes (Proxy :: Proxy a)
+  where !szA             = primSizeInBytes (Proxy :: Proxy a)
         !(CountOf szB)   = primSizeInBytes (Proxy :: Proxy b)
         !(CountOf bytes) = sizeOfE szA sz
 {-# INLINE [1] sizeRecast #-}

--- a/Foundation/Primitive/Types.hs
+++ b/Foundation/Primitive/Types.hs
@@ -571,6 +571,7 @@ primOffsetRecast !ofs =
 {-# RULES "primOffsetRecast W8" [3] forall a . primOffsetRecast a = primOffsetRecastBytes a #-}
 
 primOffsetRecastBytes :: forall b . PrimType b => Offset Word8 -> Offset b
+primOffsetRecastBytes (Offset 0) = Offset 0
 primOffsetRecastBytes (Offset o) = Offset (szA `Prelude.quot` o)
   where !(CountOf szA) = primSizeInBytes (Proxy :: Proxy b)
 {-# INLINE [1] primOffsetRecastBytes #-}

--- a/Foundation/Primitive/Types.hs
+++ b/Foundation/Primitive/Types.hs
@@ -204,6 +204,7 @@ class Eq ty => PrimType ty where
                   -> prim ()
 
 sizeInt, sizeWord :: CountOf Word8
+shiftInt, shiftWord :: Int
 #if WORD_SIZE_IN_BITS == 64
 sizeInt = CountOf 8
 sizeWord = CountOf 8

--- a/Foundation/Primitive/Types/OffsetSize.hs
+++ b/Foundation/Primitive/Types/OffsetSize.hs
@@ -19,6 +19,8 @@ module Foundation.Primitive.Types.OffsetSize
     , offsetRecast
     , offsetCast
     , offsetSub
+    , offsetShiftL
+    , offsetShiftR
     , sizeCast
     , sizeLastOffset
     , sizeAsOffset
@@ -43,6 +45,7 @@ import GHC.Int
 import GHC.Prim
 import Foreign.C.Types
 import System.Posix.Types (CSsize (..))
+import Data.Bits
 import Foundation.Internal.Base
 import Foundation.Internal.Proxy
 import Foundation.Numerical.Primitives
@@ -117,6 +120,12 @@ offsetRecast :: Size8 -> Size8 -> Offset ty -> Offset ty2
 offsetRecast szTy (CountOf szTy2) ofs =
     let (Offset bytes) = offsetOfE szTy ofs
      in Offset (bytes `div` szTy2)
+
+offsetShiftR :: Int -> Offset ty -> Offset ty2
+offsetShiftR n (Offset o) = Offset (o `unsafeShiftR` n)
+
+offsetShiftL :: Int -> Offset ty -> Offset ty2
+offsetShiftL n (Offset o) = Offset (o `unsafeShiftL` n)
 
 offsetCast :: Proxy (a -> b) -> Offset a -> Offset b
 offsetCast _ (Offset o) = Offset o

--- a/Foundation/Primitive/Types/OffsetSize.hs
+++ b/Foundation/Primitive/Types/OffsetSize.hs
@@ -73,12 +73,8 @@ type Offset8 = Offset Word8
 -- considering that GHC/Haskell are mostly using this for offset.
 -- Trying to bring some sanity by a lightweight wrapping.
 newtype Offset ty = Offset Int
-    deriving (Show,Eq,Ord,Enum,Additive,Typeable)
+    deriving (Show,Eq,Ord,Enum,Additive,Typeable,Integral)
 
-instance Integral (Offset ty) where
-    fromInteger n
-        | n < 0     = error "CountOf: fromInteger: negative"
-        | otherwise = Offset . fromInteger $ n
 instance IsIntegral (Offset ty) where
     toInteger (Offset i) = toInteger i
 instance IsNatural (Offset ty) where
@@ -169,12 +165,8 @@ type Size8 = CountOf Word8
 --
 -- Same caveats as 'Offset' apply here.
 newtype CountOf ty = CountOf Int
-    deriving (Show,Eq,Ord,Enum,Typeable)
+    deriving (Show,Eq,Ord,Enum,Typeable,Integral)
 
-instance Integral (CountOf ty) where
-    fromInteger n
-        | n < 0     = error "CountOf: fromInteger: negative"
-        | otherwise = CountOf . fromInteger $ n
 instance IsIntegral (CountOf ty) where
     toInteger (CountOf i) = toInteger i
 instance IsNatural (CountOf ty) where

--- a/Foundation/Primitive/UArray/Addr.hs
+++ b/Foundation/Primitive/UArray/Addr.hs
@@ -10,6 +10,8 @@ module Foundation.Primitive.UArray.Addr
     , foldl
     , foldr
     , foldl1
+    , all
+    , any
     , filter
     , primIndex
     ) where
@@ -37,7 +39,7 @@ findIndexElem ty ba startIndex endIndex = loop startIndex
 {-# INLINE findIndexElem #-}
 
 findIndexPredicate :: PrimType ty => (ty -> Bool) -> Immutable -> Offset ty -> Offset ty -> Offset ty
-findIndexPredicate predicate ba startIndex endIndex = loop startIndex
+findIndexPredicate predicate ba !startIndex !endIndex = loop startIndex
   where
     loop i
         | i < endIndex && not found = loop (i+Offset 1)
@@ -46,7 +48,7 @@ findIndexPredicate predicate ba startIndex endIndex = loop startIndex
 {-# INLINE findIndexPredicate #-}
 
 foldl :: PrimType ty => (a -> ty -> a) -> a -> Immutable -> Offset ty -> Offset ty -> a
-foldl f !initialAcc ba startIndex endIndex = loop startIndex initialAcc
+foldl f !initialAcc ba !startIndex !endIndex = loop startIndex initialAcc
   where
     loop !i !acc
         | i == endIndex = acc
@@ -79,3 +81,21 @@ filter predicate dst src start end = loop azero start
         | otherwise   = loop d (s+Offset 1)
       where
         v = primIndex src s
+
+all :: PrimType ty => (ty -> Bool) -> Immutable -> Offset ty -> Offset ty -> Bool
+all predicate ba start end = loop start
+  where
+    loop !i
+        | i == end                   = True
+        | predicate (primIndex ba i) = loop (i+1)
+        | otherwise                  = False
+{-# INLINE all #-}
+
+any :: PrimType ty => (ty -> Bool) -> Immutable -> Offset ty -> Offset ty -> Bool
+any predicate ba start end = loop start
+  where
+    loop !i
+        | i == end                   = False
+        | predicate (primIndex ba i) = True
+        | otherwise                  = loop (i+1)
+{-# INLINE any #-}

--- a/Foundation/Primitive/UArray/Addr.hs
+++ b/Foundation/Primitive/UArray/Addr.hs
@@ -2,11 +2,16 @@
 {-# LANGUAGE MagicHash                  #-}
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE ExistentialQuantification  #-}
 {-# LANGUAGE CPP                        #-}
 module Foundation.Primitive.UArray.Addr
     ( findIndexElem
     , findIndexPredicate
+    , foldl
+    , foldr
+    , foldl1
     , filter
+    , primIndex
     ) where
 
 import           GHC.Types
@@ -39,6 +44,30 @@ findIndexPredicate predicate ba startIndex endIndex = loop startIndex
         | otherwise                 = i
       where found = predicate (primIndex ba i)
 {-# INLINE findIndexPredicate #-}
+
+foldl :: PrimType ty => (a -> ty -> a) -> a -> Immutable -> Offset ty -> Offset ty -> a
+foldl f !initialAcc ba startIndex endIndex = loop startIndex initialAcc
+  where
+    loop !i !acc
+        | i == endIndex = acc
+        | otherwise     = loop (i+1) (f acc (primIndex ba i))
+{-# INLINE foldl #-}
+
+foldr :: PrimType ty => (ty -> a -> a) -> a -> Immutable -> Offset ty -> Offset ty -> a
+foldr f !initialAcc ba startIndex endIndex = loop startIndex
+  where
+    loop !i
+        | i == endIndex = initialAcc
+        | otherwise     = primIndex ba i `f` loop (i+1)
+{-# INLINE foldr #-}
+
+foldl1 :: PrimType ty => (ty -> ty -> ty) -> Immutable -> Offset ty -> Offset ty -> ty
+foldl1 f ba startIndex endIndex = loop (startIndex+1) (primIndex ba startIndex)
+  where
+    loop !i !acc
+        | i == endIndex = acc
+        | otherwise     = loop (i+1) (f acc (primIndex ba i))
+{-# INLINE foldl1 #-}
 
 filter :: (PrimMonad prim, PrimType ty)
        => (ty -> Bool) -> MutableByteArray# (PrimState prim) -> Immutable -> Offset ty -> Offset ty -> prim (CountOf ty)

--- a/Foundation/Primitive/UArray/Addr.hs
+++ b/Foundation/Primitive/UArray/Addr.hs
@@ -32,8 +32,8 @@ primIndex = primAddrIndex
 findIndexElem :: PrimType ty => ty -> Immutable -> Offset ty -> Offset ty -> Offset ty
 findIndexElem ty ba startIndex endIndex = loop startIndex
   where
-    loop i
-        | i < endIndex && t /= ty = loop (i+Offset 1)
+    loop !i
+        | i < endIndex && t /= ty = loop (i+1)
         | otherwise               = i
       where t = primIndex ba i
 {-# INLINE findIndexElem #-}
@@ -41,8 +41,8 @@ findIndexElem ty ba startIndex endIndex = loop startIndex
 findIndexPredicate :: PrimType ty => (ty -> Bool) -> Immutable -> Offset ty -> Offset ty -> Offset ty
 findIndexPredicate predicate ba !startIndex !endIndex = loop startIndex
   where
-    loop i
-        | i < endIndex && not found = loop (i+Offset 1)
+    loop !i
+        | i < endIndex && not found = loop (i+1)
         | otherwise                 = i
       where found = predicate (primIndex ba i)
 {-# INLINE findIndexPredicate #-}

--- a/Foundation/Primitive/UArray/BA.hs
+++ b/Foundation/Primitive/UArray/BA.hs
@@ -31,8 +31,8 @@ primIndex = primBaIndex
 findIndexElem :: PrimType ty => ty -> Immutable -> Offset ty -> Offset ty -> Offset ty
 findIndexElem ty ba startIndex endIndex = loop startIndex
   where
-    loop i
-        | i < endIndex && t /= ty = loop (i+Offset 1)
+    loop !i
+        | i < endIndex && t /= ty = loop (i+1)
         | otherwise               = i
       where t = primIndex ba i
 {-# INLINE findIndexElem #-}
@@ -40,8 +40,8 @@ findIndexElem ty ba startIndex endIndex = loop startIndex
 findIndexPredicate :: PrimType ty => (ty -> Bool) -> Immutable -> Offset ty -> Offset ty -> Offset ty
 findIndexPredicate predicate ba !startIndex !endIndex = loop startIndex
   where
-    loop i
-        | i < endIndex && not found = loop (i+Offset 1)
+    loop !i
+        | i < endIndex && not found = loop (i+1)
         | otherwise                 = i
       where found = predicate (primIndex ba i)
 {-# INLINE findIndexPredicate #-}

--- a/Foundation/Primitive/UArray/BA.hs
+++ b/Foundation/Primitive/UArray/BA.hs
@@ -9,6 +9,8 @@ module Foundation.Primitive.UArray.BA
     , foldl
     , foldr
     , foldl1
+    , all
+    , any
     , filter
     , primIndex
     ) where
@@ -78,3 +80,21 @@ filter predicate dst src start end = loop azero start
         | otherwise   = loop d (s+Offset 1)
       where
         v = primIndex src s
+
+all :: PrimType ty => (ty -> Bool) -> Immutable -> Offset ty -> Offset ty -> Bool
+all predicate ba start end = loop start
+  where
+    loop !i
+        | i == end                   = True
+        | predicate (primIndex ba i) = loop (i+1)
+        | otherwise                  = False
+{-# INLINE all #-}
+
+any :: PrimType ty => (ty -> Bool) -> Immutable -> Offset ty -> Offset ty -> Bool
+any predicate ba start end = loop start
+  where
+    loop !i
+        | i == end                   = False
+        | predicate (primIndex ba i) = True
+        | otherwise                  = loop (i+1)
+{-# INLINE any #-}

--- a/Foundation/Primitive/UArray/Base.hs
+++ b/Foundation/Primitive/UArray/Base.hs
@@ -58,10 +58,10 @@ import           System.IO.Unsafe (unsafeDupablePerformIO)
 --
 -- Element in this array can be modified in place.
 data MUArray ty st =
-      MUVecMA {-# UNPACK #-} !(Offset ty)
+      MUArrayMBA {-# UNPACK #-} !(Offset ty)
               {-# UNPACK #-} !(CountOf ty)
                              (MutableByteArray# st)
-    | MUVecAddr {-# UNPACK #-} !(Offset ty)
+    | MUArrayAddr {-# UNPACK #-} !(Offset ty)
                 {-# UNPACK #-} !(CountOf ty)
                                !(FinalPtr ty)
 
@@ -71,10 +71,10 @@ data MUArray ty st =
 -- packed contiguous array in memory that can easily be passed
 -- to foreign interface
 data UArray ty =
-      UVecBA {-# UNPACK #-} !(Offset ty)
+      UArrayBA {-# UNPACK #-} !(Offset ty)
              {-# UNPACK #-} !(CountOf ty)
                             !ByteArray#
-    | UVecAddr {-# UNPACK #-} !(Offset ty)
+    | UArrayAddr {-# UNPACK #-} !(Offset ty)
                {-# UNPACK #-} !(CountOf ty)
                               !(FinalPtr ty)
     deriving (Typeable)
@@ -88,8 +88,8 @@ arrayType :: DataType
 arrayType = mkNoRepType "Foundation.UArray"
 
 instance NormalForm (UArray ty) where
-    toNormalForm (UVecBA _ _ !_) = ()
-    toNormalForm (UVecAddr {}) = ()
+    toNormalForm (UArrayBA _ _ !_) = ()
+    toNormalForm (UArrayAddr {}) = ()
 instance (PrimType ty, Show ty) => Show (UArray ty) where
     show v = show (toList v)
 instance (PrimType ty, Eq ty) => Eq (UArray ty) where
@@ -109,21 +109,21 @@ instance PrimType ty => IsList (UArray ty) where
     toList = vToList
 
 length :: UArray ty -> CountOf ty
-length (UVecAddr _ len _) = len
-length (UVecBA _ len _) = len
+length (UArrayAddr _ len _) = len
+length (UArrayBA _ len _) = len
 {-# INLINE[1] length #-}
 
 -- | Return if the array is pinned in memory
 --
 -- note that Foreign array are considered pinned
 isPinned :: UArray ty -> PinnedStatus
-isPinned (UVecAddr {})     = Pinned
-isPinned (UVecBA _ _ ba) = toPinnedStatus# (compatIsByteArrayPinned# ba)
+isPinned (UArrayAddr {})     = Pinned
+isPinned (UArrayBA _ _ ba) = toPinnedStatus# (compatIsByteArrayPinned# ba)
 
 -- | Return if a mutable array is pinned in memory
 isMutablePinned :: MUArray ty st -> PinnedStatus
-isMutablePinned (MUVecAddr {})    = Pinned
-isMutablePinned (MUVecMA _ _ mba) = toPinnedStatus# (compatIsMutableByteArrayPinned# mba)
+isMutablePinned (MUArrayAddr {})    = Pinned
+isMutablePinned (MUArrayMBA _ _ mba) = toPinnedStatus# (compatIsMutableByteArrayPinned# mba)
 
 -- | Create a new pinned mutable array of size @n.
 --
@@ -135,7 +135,7 @@ newPinned n = newFake n Proxy
   where newFake :: (PrimMonad prim, PrimType ty) => CountOf ty -> Proxy ty -> prim (MUArray ty (PrimState prim))
         newFake sz ty = primitive $ \s1 ->
             case newAlignedPinnedByteArray# bytes 8# s1 of
-                (# s2, mba #) -> (# s2, MUVecMA (Offset 0) sz mba #)
+                (# s2, mba #) -> (# s2, MUArrayMBA (Offset 0) sz mba #)
           where
                 !(CountOf (I# bytes)) = sizeOfE (primSizeInBytes ty) sz
         {-# INLINE newFake #-}
@@ -145,7 +145,7 @@ newUnpinned n = newFake n Proxy
   where newFake :: (PrimMonad prim, PrimType ty) => CountOf ty -> Proxy ty -> prim (MUArray ty (PrimState prim))
         newFake sz ty = primitive $ \s1 ->
             case newByteArray# bytes s1 of
-                (# s2, mba #) -> (# s2, MUVecMA (Offset 0) sz mba #)
+                (# s2, mba #) -> (# s2, MUArrayMBA (Offset 0) sz mba #)
           where
                 !(CountOf (I# bytes)) = sizeOfE (primSizeInBytes ty) sz
         {-# INLINE newFake #-}
@@ -157,8 +157,8 @@ newNative :: (PrimMonad prim, PrimType ty)
 newNative n f = do
     muvec <- new n
     case muvec of
-        (MUVecMA _ _ mba) -> f mba >>= \a -> pure (a, muvec)
-        MUVecAddr {}      -> error "internal error: unboxed new only supposed to allocate natively"
+        (MUArrayMBA _ _ mba) -> f mba >>= \a -> pure (a, muvec)
+        MUArrayAddr {}      -> error "internal error: unboxed new only supposed to allocate natively"
 
 -- | Create a new mutable array of size @n.
 --
@@ -183,8 +183,8 @@ new sz
 -- Reading from invalid memory can return unpredictable and invalid values.
 -- use 'read' if unsure.
 unsafeRead :: (PrimMonad prim, PrimType ty) => MUArray ty (PrimState prim) -> Offset ty -> prim ty
-unsafeRead (MUVecMA start _ mba) i = primMbaRead mba (start + i)
-unsafeRead (MUVecAddr start _ fptr) i = withFinalPtr fptr $ \(Ptr addr) -> primAddrRead addr (start + i)
+unsafeRead (MUArrayMBA start _ mba) i = primMbaRead mba (start + i)
+unsafeRead (MUArrayAddr start _ fptr) i = withFinalPtr fptr $ \(Ptr addr) -> primAddrRead addr (start + i)
 {-# INLINE unsafeRead #-}
 
 
@@ -193,8 +193,8 @@ unsafeRead (MUVecAddr start _ fptr) i = withFinalPtr fptr $ \(Ptr addr) -> primA
 -- Writing with invalid bounds will corrupt memory and your program will
 -- become unreliable. use 'write' if unsure.
 unsafeWrite :: (PrimMonad prim, PrimType ty) => MUArray ty (PrimState prim) -> Offset ty -> ty -> prim ()
-unsafeWrite (MUVecMA start _ mba)  i v = primMbaWrite mba (start+i) v
-unsafeWrite (MUVecAddr start _ fptr) i v = withFinalPtr fptr $ \(Ptr addr) -> primAddrWrite addr (start+i) v
+unsafeWrite (MUArrayMBA start _ mba)  i v = primMbaWrite mba (start+i) v
+unsafeWrite (MUArrayAddr start _ fptr) i v = withFinalPtr fptr $ \(Ptr addr) -> primAddrWrite addr (start+i) v
 {-# INLINE unsafeWrite #-}
 
 -- | Return the element at a specific index from an array without bounds checking.
@@ -202,36 +202,36 @@ unsafeWrite (MUVecAddr start _ fptr) i v = withFinalPtr fptr $ \(Ptr addr) -> pr
 -- Reading from invalid memory can return unpredictable and invalid values.
 -- use 'index' if unsure.
 unsafeIndex :: forall ty . PrimType ty => UArray ty -> Offset ty -> ty
-unsafeIndex (UVecBA start _ ba) n = primBaIndex ba (start + n)
-unsafeIndex (UVecAddr start _ fptr) n = withUnsafeFinalPtr fptr (\(Ptr addr) -> return (primAddrIndex addr (start+n)) :: IO ty)
+unsafeIndex (UArrayBA start _ ba) n = primBaIndex ba (start + n)
+unsafeIndex (UArrayAddr start _ fptr) n = withUnsafeFinalPtr fptr (\(Ptr addr) -> return (primAddrIndex addr (start+n)) :: IO ty)
 {-# INLINE unsafeIndex #-}
 
 unsafeIndexer :: (PrimMonad prim, PrimType ty) => UArray ty -> ((Offset ty -> ty) -> prim a) -> prim a
-unsafeIndexer (UVecBA start _ ba) f = f (\n -> primBaIndex ba (start + n))
-unsafeIndexer (UVecAddr start _ fptr) f = withFinalPtr fptr $ \(Ptr addr) -> f (\n -> primAddrIndex addr (start + n))
+unsafeIndexer (UArrayBA start _ ba) f = f (\n -> primBaIndex ba (start + n))
+unsafeIndexer (UArrayAddr start _ fptr) f = withFinalPtr fptr $ \(Ptr addr) -> f (\n -> primAddrIndex addr (start + n))
 {-# INLINE unsafeIndexer #-}
 
 -- | Freeze a mutable array into an array.
 --
 -- the MUArray must not be changed after freezing.
 unsafeFreeze :: PrimMonad prim => MUArray ty (PrimState prim) -> prim (UArray ty)
-unsafeFreeze (MUVecMA start len mba) = primitive $ \s1 ->
+unsafeFreeze (MUArrayMBA start len mba) = primitive $ \s1 ->
     case unsafeFreezeByteArray# mba s1 of
-        (# s2, ba #) -> (# s2, UVecBA start len ba #)
-unsafeFreeze (MUVecAddr start len fptr) = return $ UVecAddr start len fptr
+        (# s2, ba #) -> (# s2, UArrayBA start len ba #)
+unsafeFreeze (MUArrayAddr start len fptr) = return $ UArrayAddr start len fptr
 {-# INLINE unsafeFreeze #-}
 
 unsafeFreezeShrink :: (PrimType ty, PrimMonad prim) => MUArray ty (PrimState prim) -> CountOf ty -> prim (UArray ty)
-unsafeFreezeShrink (MUVecMA start _ mba) n = unsafeFreeze (MUVecMA start n mba)
-unsafeFreezeShrink (MUVecAddr start _ fptr) n = unsafeFreeze (MUVecAddr start n fptr)
+unsafeFreezeShrink (MUArrayMBA start _ mba) n = unsafeFreeze (MUArrayMBA start n mba)
+unsafeFreezeShrink (MUArrayAddr start _ fptr) n = unsafeFreeze (MUArrayAddr start n fptr)
 {-# INLINE unsafeFreezeShrink #-}
 
 -- | Thaw an immutable array.
 --
 -- The UArray must not be used after thawing.
 unsafeThaw :: (PrimType ty, PrimMonad prim) => UArray ty -> prim (MUArray ty (PrimState prim))
-unsafeThaw (UVecBA start len ba) = primitive $ \st -> (# st, MUVecMA start len (unsafeCoerce# ba) #)
-unsafeThaw (UVecAddr start len fptr) = return $ MUVecAddr start len fptr
+unsafeThaw (UArrayBA start len ba) = primitive $ \st -> (# st, MUArrayMBA start len (unsafeCoerce# ba) #)
+unsafeThaw (UArrayAddr start len fptr) = return $ MUArrayAddr start len fptr
 {-# INLINE unsafeThaw #-}
 
 
@@ -239,8 +239,8 @@ unsafeDewrap :: (ByteArray# -> Offset ty -> a)
              -> (Ptr ty -> Offset ty -> ST s a)
              -> UArray ty
              -> a
-unsafeDewrap _ g (UVecAddr start _ fptr) = withUnsafeFinalPtr fptr $ \ptr -> g ptr start
-unsafeDewrap f _ (UVecBA start _ ba)     = f ba start
+unsafeDewrap _ g (UArrayAddr start _ fptr) = withUnsafeFinalPtr fptr $ \ptr -> g ptr start
+unsafeDewrap f _ (UArrayBA start _ ba)     = f ba start
 {-# INLINE unsafeDewrap #-}
 
 unsafeDewrap2 :: (ByteArray# -> Offset ty -> ByteArray# -> Offset ty -> a)
@@ -250,11 +250,11 @@ unsafeDewrap2 :: (ByteArray# -> Offset ty -> ByteArray# -> Offset ty -> a)
               -> UArray ty
               -> UArray ty
               -> a
-unsafeDewrap2 f _ _ _ (UVecBA start1 _ ba1)     (UVecBA start2 _ ba2)     = f ba1 start1 ba2 start2
-unsafeDewrap2 _ f _ _ (UVecAddr start1 _ fptr1) (UVecAddr start2 _ fptr2) = withUnsafeFinalPtr fptr1 $ \ptr1 ->
+unsafeDewrap2 f _ _ _ (UArrayBA start1 _ ba1)     (UArrayBA start2 _ ba2)     = f ba1 start1 ba2 start2
+unsafeDewrap2 _ f _ _ (UArrayAddr start1 _ fptr1) (UArrayAddr start2 _ fptr2) = withUnsafeFinalPtr fptr1 $ \ptr1 ->
                                                                                   withFinalPtr fptr2 $ \ptr2 -> f ptr1 start1 ptr2 start2
-unsafeDewrap2 _ _ f _ (UVecBA start1 _ ba1)     (UVecAddr start2 _ fptr2) = withUnsafeFinalPtr fptr2 $ \ptr2 -> f ba1 start1 ptr2 start2
-unsafeDewrap2 _ _ _ f (UVecAddr start1 _ fptr1) (UVecBA start2 _ ba2)     = withUnsafeFinalPtr fptr1 $ \ptr1 -> f ptr1 start1 ba2 start2
+unsafeDewrap2 _ _ f _ (UArrayBA start1 _ ba1)     (UArrayAddr start2 _ fptr2) = withUnsafeFinalPtr fptr2 $ \ptr2 -> f ba1 start1 ptr2 start2
+unsafeDewrap2 _ _ _ f (UArrayAddr start1 _ fptr1) (UArrayBA start2 _ ba2)     = withUnsafeFinalPtr fptr1 $ \ptr1 -> f ptr1 start1 ba2 start2
 {-# INLINE [2] unsafeDewrap2 #-}
 
 pureST :: a -> ST s a
@@ -414,14 +414,14 @@ copyAt :: forall prim ty . (PrimMonad prim, PrimType ty)
        -> Offset ty                  -- ^ offset at source
        -> CountOf ty                    -- ^ number of elements to copy
        -> prim ()
-copyAt (MUVecMA dstStart _ dstMba) ed (MUVecMA srcStart _ srcBa) es n =
+copyAt (MUArrayMBA dstStart _ dstMba) ed (MUArrayMBA srcStart _ srcBa) es n =
     primitive $ \st -> (# copyMutableByteArray# srcBa os dstMba od nBytes st, () #)
   where
     !sz                 = primSizeInBytes (Proxy :: Proxy ty)
     !(Offset (I# os))   = offsetOfE sz (srcStart + es)
     !(Offset (I# od))   = offsetOfE sz (dstStart + ed)
     !(CountOf (I# nBytes)) = sizeOfE sz n
-copyAt (MUVecMA dstStart _ dstMba) ed (MUVecAddr srcStart _ srcFptr) es n =
+copyAt (MUArrayMBA dstStart _ dstMba) ed (MUArrayAddr srcStart _ srcFptr) es n =
     withFinalPtr srcFptr $ \srcPtr ->
         let !(Ptr srcAddr) = srcPtr `plusPtr` os
          in primitive $ \s -> (# compatCopyAddrToByteArray# srcAddr dstMba od nBytes s, () #)
@@ -450,14 +450,14 @@ unsafeCopyAtRO :: forall prim ty . (PrimMonad prim, PrimType ty)
                -> Offset ty                   -- ^ offset at source
                -> CountOf ty                     -- ^ number of elements to copy
                -> prim ()
-unsafeCopyAtRO (MUVecMA dstStart _ dstMba) ed (UVecBA srcStart _ srcBa) es n =
+unsafeCopyAtRO (MUArrayMBA dstStart _ dstMba) ed (UArrayBA srcStart _ srcBa) es n =
     primitive $ \st -> (# copyByteArray# srcBa os dstMba od nBytes st, () #)
   where
     sz = primSizeInBytes (Proxy :: Proxy ty)
     !(Offset (I# os))   = offsetOfE sz (srcStart+es)
     !(Offset (I# od))   = offsetOfE sz (dstStart+ed)
     !(CountOf (I# nBytes)) = sizeOfE sz n
-unsafeCopyAtRO (MUVecMA dstStart _ dstMba) ed (UVecAddr srcStart _ srcFptr) es n =
+unsafeCopyAtRO (MUArrayMBA dstStart _ dstMba) ed (UArrayAddr srcStart _ srcFptr) es n =
     withFinalPtr srcFptr $ \srcPtr ->
         let !(Ptr srcAddr) = srcPtr `plusPtr` os
          in primitive $ \s -> (# compatCopyAddrToByteArray# srcAddr dstMba od nBytes s, () #)
@@ -483,7 +483,7 @@ empty_ = runST $ primitive $ \s1 ->
         (# s3, BA0 ba #) }}
 
 empty :: UArray ty
-empty = UVecBA 0 0 ba where !(BA0 ba) = empty_
+empty = UArrayBA 0 0 ba where !(BA0 ba) = empty_
 
 -- | Append 2 arrays together by creating a new bigger array
 append :: PrimType ty => UArray ty -> UArray ty -> UArray ty

--- a/Foundation/Primitive/UArray/Base.hs
+++ b/Foundation/Primitive/UArray/Base.hs
@@ -129,7 +129,7 @@ offset (UArray ofs _ _) = ofs
 -- note that Foreign array are considered pinned
 isPinned :: UArray ty -> PinnedStatus
 isPinned (UArray _ _ (UArrayAddr {})) = Pinned
-isPinned (UArray _ _ (UArrayBA blk))  = BLK.isPinned blk -- toPinnedStatus# (compatIsByteArrayPinned# ba)
+isPinned (UArray _ _ (UArrayBA blk))  = BLK.isPinned blk
 
 -- | Return if a mutable array is pinned in memory
 isMutablePinned :: MUArray ty st -> PinnedStatus

--- a/Foundation/Primitive/UArray/Base.hs
+++ b/Foundation/Primitive/UArray/Base.hs
@@ -31,6 +31,7 @@ module Foundation.Primitive.UArray.Base
     , unsafeDewrap
     , unsafeDewrap2
     -- * Basic lowlevel functions
+    , empty
     , length
     , offset
     , ValidRange(..)

--- a/Foundation/Primitive/UArray/Base.hs
+++ b/Foundation/Primitive/UArray/Base.hs
@@ -32,6 +32,8 @@ module Foundation.Primitive.UArray.Base
     -- * Basic lowlevel functions
     , length
     , offset
+    , ValidRange(..)
+    , offsetsValidRange
     , equal
     , equalMemcmp
     , compare
@@ -123,6 +125,11 @@ length (UArray _ len _) = len
 offset :: UArray ty -> Offset ty
 offset (UArray ofs _ _) = ofs
 {-# INLINE[1] offset #-}
+
+data ValidRange ty = ValidRange {-# UNPACK #-} !(Offset ty) {-# UNPACK #-} !(Offset ty)
+
+offsetsValidRange :: UArray ty -> ValidRange ty
+offsetsValidRange (UArray ofs len _) = ValidRange ofs (ofs `offsetPlusE` len)
 
 -- | Return if the array is pinned in memory
 --

--- a/Foundation/Primitive/UArray/Base.hs
+++ b/Foundation/Primitive/UArray/Base.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE ViewPatterns #-}
 module Foundation.Primitive.UArray.Base
     ( MUArray(..)
     , UArray(..)

--- a/Foundation/Primitive/UTF8/Addr.hs
+++ b/Foundation/Primitive/UTF8/Addr.hs
@@ -14,6 +14,8 @@ module Foundation.Primitive.UTF8.Addr
     , prev
     , prevSkip
     , write
+    , all
+    , any
     -- temporary
     , primIndex
     , primRead
@@ -151,3 +153,23 @@ write mba !i !c
     toContinuation :: Word# -> Word#
     toContinuation w = or# (and# w 0x3f##) 0x80##
 {-# INLINE write #-}
+
+all :: (Char -> Bool) -> Immutable -> Offset Word8 -> Offset Word8 -> Bool
+all predicate ba start end = loop start
+  where
+    loop !idx
+        | idx == end  = True
+        | predicate c = loop idx'
+        | otherwise   = False
+      where (Step c idx') = next ba idx
+{-# INLINE all #-}
+
+any :: (Char -> Bool) -> Immutable -> Offset Word8 -> Offset Word8 -> Bool
+any predicate ba start end = loop start
+  where
+    loop !idx
+        | idx == end  = False
+        | predicate c = True
+        | otherwise   = loop idx'
+      where (Step c idx') = next ba idx
+{-# INLINE any #-}

--- a/Foundation/Primitive/UTF8/Addr.hs
+++ b/Foundation/Primitive/UTF8/Addr.hs
@@ -16,6 +16,7 @@ module Foundation.Primitive.UTF8.Addr
     , write
     , all
     , any
+    , foldr
     -- temporary
     , primIndex
     , primRead
@@ -173,3 +174,13 @@ any predicate ba start end = loop start
         | otherwise   = loop idx'
       where (Step c idx') = next ba idx
 {-# INLINE any #-}
+
+foldr :: Immutable -> Offset Word8 -> Offset Word8 -> (Char -> a -> a) -> a -> a
+foldr dat start end f acc = loop start
+  where
+    loop !i
+        | i == end  = acc
+        | otherwise =
+            let (Step c i') = next dat i
+             in c `f` loop i'
+{-# INLINE foldr #-}

--- a/Foundation/Primitive/UTF8/Addr.hs
+++ b/Foundation/Primitive/UTF8/Addr.hs
@@ -14,6 +14,7 @@ module Foundation.Primitive.UTF8.Addr
     , prev
     , prevSkip
     , write
+    , toList
     , all
     , any
     , foldr
@@ -27,7 +28,7 @@ import           GHC.Int
 import           GHC.Types
 import           GHC.Word
 import           GHC.Prim
-import           Foundation.Internal.Base
+import           Foundation.Internal.Base hiding (toList)
 import           Foundation.Internal.Primitive
 import           Foundation.Numerical
 import           Foundation.Primitive.Types.OffsetSize
@@ -154,6 +155,14 @@ write mba !i !c
     toContinuation :: Word# -> Word#
     toContinuation w = or# (and# w 0x3f##) 0x80##
 {-# INLINE write #-}
+
+toList :: Immutable -> Offset Word8 -> Offset Word8 -> [Char]
+toList ba !start !end = loop start
+  where
+    loop !idx
+        | idx == end = []
+        | otherwise  = c : loop idx'
+      where (Step c idx') = next ba idx
 
 all :: (Char -> Bool) -> Immutable -> Offset Word8 -> Offset Word8 -> Bool
 all predicate ba start end = loop start

--- a/Foundation/Primitive/UTF8/BA.hs
+++ b/Foundation/Primitive/UTF8/BA.hs
@@ -14,6 +14,7 @@ module Foundation.Primitive.UTF8.BA
     , prev
     , prevSkip
     , write
+    , toList
     , all
     , any
     , foldr
@@ -27,7 +28,7 @@ import           GHC.Int
 import           GHC.Types
 import           GHC.Word
 import           GHC.Prim
-import           Foundation.Internal.Base
+import           Foundation.Internal.Base hiding (toList)
 import           Foundation.Internal.Primitive
 import           Foundation.Numerical
 import           Foundation.Primitive.Types.OffsetSize
@@ -154,6 +155,14 @@ write mba !i !c
     toContinuation :: Word# -> Word#
     toContinuation w = or# (and# w 0x3f##) 0x80##
 {-# INLINE write #-}
+
+toList :: Immutable -> Offset Word8 -> Offset Word8 -> [Char]
+toList ba !start !end = loop start
+  where
+    loop !idx
+        | idx == end = []
+        | otherwise  = c : loop idx'
+      where (Step c idx') = next ba idx
 
 all :: (Char -> Bool) -> Immutable -> Offset Word8 -> Offset Word8 -> Bool
 all predicate ba start end = loop start

--- a/Foundation/Primitive/UTF8/BA.hs
+++ b/Foundation/Primitive/UTF8/BA.hs
@@ -153,3 +153,23 @@ write mba !i !c
     toContinuation :: Word# -> Word#
     toContinuation w = or# (and# w 0x3f##) 0x80##
 {-# INLINE write #-}
+
+all :: (Char -> Bool) -> Immutable -> Offset Word8 -> Offset Word8 -> Bool
+all predicate ba start end = loop start
+  where
+    loop !idx
+        | idx == end  = True
+        | predicate c = loop idx'
+        | otherwise   = False
+      where (Step c idx') = next ba idx
+{-# INLINE all #-}
+
+any :: (Char -> Bool) -> Immutable -> Offset Word8 -> Offset Word8 -> Bool
+any predicate ba start end = loop start
+  where
+    loop !idx
+        | idx == end  = False
+        | predicate c = True
+        | otherwise   = loop idx'
+      where (Step c idx') = next ba idx
+{-# INLINE any #-}

--- a/Foundation/Primitive/UTF8/BA.hs
+++ b/Foundation/Primitive/UTF8/BA.hs
@@ -16,6 +16,7 @@ module Foundation.Primitive.UTF8.BA
     , write
     , all
     , any
+    , foldr
     -- temporary
     , primIndex
     , primRead
@@ -173,3 +174,13 @@ any predicate ba start end = loop start
         | otherwise   = loop idx'
       where (Step c idx') = next ba idx
 {-# INLINE any #-}
+
+foldr :: Immutable -> Offset Word8 -> Offset Word8 -> (Char -> a -> a) -> a -> a
+foldr dat start end f acc = loop start
+  where
+    loop !i
+        | i == end  = acc
+        | otherwise =
+            let (Step c i') = next dat i
+             in c `f` loop i'
+{-# INLINE foldr #-}

--- a/Foundation/Primitive/UTF8/BA.hs
+++ b/Foundation/Primitive/UTF8/BA.hs
@@ -14,6 +14,8 @@ module Foundation.Primitive.UTF8.BA
     , prev
     , prevSkip
     , write
+    , all
+    , any
     -- temporary
     , primIndex
     , primRead

--- a/Foundation/Primitive/UTF8/BA.hs
+++ b/Foundation/Primitive/UTF8/BA.hs
@@ -18,8 +18,10 @@ module Foundation.Primitive.UTF8.BA
     , all
     , any
     , foldr
+    , length
     -- temporary
     , primIndex
+    , primIndex64
     , primRead
     , primWrite
     ) where
@@ -28,8 +30,10 @@ import           GHC.Int
 import           GHC.Types
 import           GHC.Word
 import           GHC.Prim
+import           Data.Bits
 import           Foundation.Internal.Base hiding (toList)
 import           Foundation.Internal.Primitive
+import           Foundation.Internal.Proxy
 import           Foundation.Numerical
 import           Foundation.Primitive.Types.OffsetSize
 import           Foundation.Primitive.Monad
@@ -50,6 +54,8 @@ primRead = primMbaRead
 primIndex :: Immutable -> Offset Word8 -> Word8
 primIndex = primBaIndex
 
+primIndex64 :: Immutable -> Offset Word64 -> Word64
+primIndex64 = primBaIndex
 
 nextAscii :: Immutable -> Offset Word8 -> StepASCII
 nextAscii ba n = StepASCII w
@@ -193,3 +199,46 @@ foldr dat start end f acc = loop start
             let (Step c i') = next dat i
              in c `f` loop i'
 {-# INLINE foldr #-}
+
+length :: Immutable -> Offset Word8 -> Offset Word8 -> CountOf Char
+length dat start end
+    | start == end = 0
+    | otherwise    = processStart 0 start
+  where
+    end64 :: Offset Word64
+    end64 = offsetInElements end
+
+    prx64 :: Proxy Word64
+    prx64 = Proxy
+
+    mask64_80 :: Word64
+    mask64_80 = 0x8080808080808080
+
+    processStart :: CountOf Char -> Offset Word8 -> CountOf Char
+    processStart !c !i
+        | i == end                = c
+        | offsetIsAligned prx64 i = processAligned c (offsetInElements i)
+        | otherwise               =
+            let h    = primIndex dat i
+                cont = (h .&. 0xc0) == 0x80
+                c'   = if cont then c else c+1
+             in processStart c' (i+1)
+    processAligned :: CountOf Char -> Offset Word64 -> CountOf Char
+    processAligned !c !i
+        | i >= end64 = processEnd c (offsetInBytes i)
+        | otherwise  =
+            let !h   = primIndex64 dat i
+                !h80 = h .&. mask64_80
+             in if h80 == 0
+                 then processAligned (c+8) (i+1)
+                 else let !nbAscii = if h80 == mask64_80 then 0 else CountOf (8 - popCount h80)
+                          !nbHigh  = CountOf $ popCount (h .&. (h80 `unsafeShiftR` 1))
+                       in processAligned (c + nbAscii + nbHigh) (i+1)
+    processEnd !c !i
+        | i == end  = c
+        | otherwise =
+            let h    = primIndex dat i
+                cont = (h .&. 0xc0) == 0x80
+                c'   = if cont then c else c+1
+             in processStart c' (i+1)
+{-# INLINE length #-}

--- a/Foundation/Primitive/UTF8/BA.hs
+++ b/Foundation/Primitive/UTF8/BA.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE BangPatterns               #-}
 {-# LANGUAGE MagicHash                  #-}
 {-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE UnboxedTuples              #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE CPP                        #-}
 module Foundation.Primitive.UTF8.BA
@@ -33,7 +32,7 @@ import           Foundation.Primitive.Monad
 import           Foundation.Primitive.Types
 import           Foundation.Primitive.UTF8.Helper
 import           Foundation.Primitive.UTF8.Table
-import           Foundation.Bits
+import           Foundation.Primitive.UTF8.Types
 
 type Immutable = ByteArray#
 type Mutable prim = MutableByteArray# (PrimState prim)
@@ -48,32 +47,31 @@ primIndex :: Immutable -> Offset Word8 -> Word8
 primIndex = primBaIndex
 
 
-nextAscii :: Immutable -> Offset Word8 -> (# Word8, Bool #)
-nextAscii ba n = (# w, not (testBit w 7) #)
+nextAscii :: Immutable -> Offset Word8 -> StepASCII
+nextAscii ba n = StepASCII w
   where
     !w = primIndex ba n
 {-# INLINE nextAscii #-}
 
 -- | nextAsciiBa specialized to get a digit between 0 and 9 (included)
-nextAsciiDigit :: Immutable -> Offset Word8 -> (# Word8, Bool #)
-nextAsciiDigit ba n = (# d, d < 0xa #)
-  where !d = primIndex ba n - 0x30
+nextAsciiDigit :: Immutable -> Offset Word8 -> StepDigit
+nextAsciiDigit ba n = StepDigit (primIndex ba n - 0x30)
 {-# INLINE nextAsciiDigit #-}
 
 expectAscii :: Immutable -> Offset Word8 -> Word8 -> Bool
 expectAscii ba n v = primIndex ba n == v
 {-# INLINE expectAscii #-}
 
-next :: Immutable -> Offset8 -> (# Char, Offset8 #)
+next :: Immutable -> Offset8 -> Step
 next ba n =
     case getNbBytes h of
-        0 -> (# toChar1 h, n + Offset 1 #)
-        1 -> (# toChar2 h (primIndex ba (n + Offset 1)) , n + Offset 2 #)
-        2 -> (# toChar3 h (primIndex ba (n + Offset 1))
-                          (primIndex ba (n + Offset 2)) , n + Offset 3 #)
-        3 -> (# toChar4 h (primIndex ba (n + Offset 1))
-                          (primIndex ba (n + Offset 2))
-                          (primIndex ba (n + Offset 3)) , n + Offset 4 #)
+        0 -> Step (toChar1 h) (n + Offset 1)
+        1 -> Step (toChar2 h (primIndex ba (n + Offset 1))) (n + Offset 2)
+        2 -> Step (toChar3 h (primIndex ba (n + Offset 1))
+                             (primIndex ba (n + Offset 2))) (n + Offset 3)
+        3 -> Step (toChar4 h (primIndex ba (n + Offset 1))
+                             (primIndex ba (n + Offset 2))
+                             (primIndex ba (n + Offset 3))) (n + Offset 4)
         r -> error ("next: internal error: invalid input: offset=" <> show n <> " table=" <> show r <> " h=" <> show h)
   where
     !h = primIndex ba n
@@ -81,11 +79,11 @@ next ba n =
 
 -- Given a non null offset, give the previous character and the offset of this character
 -- will fail bad if apply at the beginning of string or an empty string.
-prev :: Immutable -> Offset Word8 -> (# Char, Offset8 #)
+prev :: Immutable -> Offset Word8 -> StepBack
 prev ba offset =
     case primIndex ba prevOfs1 of
         (W8# v1) | isContinuation# v1 -> atLeast2 (maskContinuation# v1)
-                 | otherwise          -> (# toChar# v1, prevOfs1 #)
+                 | otherwise          -> StepBack (toChar# v1) prevOfs1
   where
     sz1 = CountOf 1
     !prevOfs1 = offset `offsetMinusE` sz1
@@ -95,14 +93,14 @@ prev ba offset =
     atLeast2 !v  =
         case primIndex ba prevOfs2 of
             (W8# v2) | isContinuation# v2 -> atLeast3 (or# (uncheckedShiftL# (maskContinuation# v2) 6#) v)
-                     | otherwise          -> (# toChar# (or# (uncheckedShiftL# (maskHeader2# v2) 6#) v), prevOfs2 #)
+                     | otherwise          -> StepBack (toChar# (or# (uncheckedShiftL# (maskHeader2# v2) 6#) v)) prevOfs2
     atLeast3 !v =
         case primIndex ba prevOfs3 of
             (W8# v3) | isContinuation# v3 -> atLeast4 (or# (uncheckedShiftL# (maskContinuation# v3) 12#) v)
-                     | otherwise          -> (# toChar# (or# (uncheckedShiftL# (maskHeader3# v3) 12#) v), prevOfs3 #)
+                     | otherwise          -> StepBack (toChar# (or# (uncheckedShiftL# (maskHeader3# v3) 12#) v)) prevOfs3
     atLeast4 !v =
         case primIndex ba prevOfs4 of
-            (W8# v4) -> (# toChar# (or# (uncheckedShiftL# (maskHeader4# v4) 18#) v), prevOfs4 #)
+            (W8# v4) -> StepBack (toChar# (or# (uncheckedShiftL# (maskHeader4# v4) 18#) v)) prevOfs4
 
 prevSkip :: Immutable -> Offset Word8 -> Offset Word8
 prevSkip ba offset = loop (offset `offsetMinusE` sz1)

--- a/Foundation/Primitive/UTF8/Base.hs
+++ b/Foundation/Primitive/UTF8/Base.hs
@@ -10,7 +10,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash                  #-}
 {-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE UnboxedTuples              #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE CPP                        #-}
 module Foundation.Primitive.UTF8.Base
@@ -22,13 +21,13 @@ import           GHC.Word
 import           GHC.Prim
 import           Foundation.Internal.Base
 import           Foundation.Numerical
-import           Foundation.Bits
 import           Foundation.Class.Bifunctor
 import           Foundation.Primitive.NormalForm
 import           Foundation.Primitive.Types.OffsetSize
 import           Foundation.Primitive.Monad
 import           Foundation.Primitive.FinalPtr
 import           Foundation.Primitive.UTF8.Helper
+import           Foundation.Primitive.UTF8.Types
 import qualified Foundation.Primitive.UTF8.BA       as PrimBA
 import qualified Foundation.Primitive.UTF8.Addr     as PrimAddr
 import           Foundation.Array.Unboxed           (UArray)
@@ -91,7 +90,7 @@ sToList s = loop 0
     loop idx
         | idx .==# nbBytes = []
         | otherwise        =
-            let (!c , !idx') = next s idx in c : loop idx'
+            let !(Step c idx') = next s idx in c : loop idx'
 
 {-# RULES
 "String sFromList" forall s .
@@ -120,27 +119,26 @@ sFromList l = runST (new bytes >>= startCopy)
         loop idx (c:xs) = write ms idx c >>= \idx' -> loop idx' xs
 {-# INLINE [0] sFromList #-}
 
-next :: String -> Offset8 -> (Char, Offset8)
+next :: String -> Offset8 -> Step
 next (String array) !n = Vec.onBackend nextNative nextAddr array
   where
     !start = Vec.offset array
-    reoffset !(# a, b #) = (a, b `offsetSub` start)
+    reoffset (Step a ofs) = Step a (ofs `offsetSub` start)
     nextNative ba        = reoffset (PrimBA.next ba (start + n))
     nextAddr _ (Ptr ptr) = pureST $ reoffset (PrimAddr.next ptr (start + n))
 
-prev :: String -> Offset8 -> (Char, Offset8)
+prev :: String -> Offset8 -> StepBack
 prev (String array) !n = Vec.onBackend prevNative prevAddr array
   where
     !start = Vec.offset array
-    reoffset !(# a, b #) = (a, b `offsetSub` start)
+    reoffset (StepBack a ofs) = StepBack a (ofs `offsetSub` start)
     prevNative ba        = reoffset (PrimBA.prev ba (start + n))
     prevAddr _ (Ptr ptr) = pureST $ reoffset (PrimAddr.prev ptr (start + n))
 
 -- A variant of 'next' when you want the next character
--- to be ASCII only. if Bool is False, then it's not ascii,
--- otherwise it is and the return Word8 is valid.
-nextAscii :: String -> Offset8 -> (# Word8, Bool #)
-nextAscii (String ba) n = (# w, not (testBit w 7) #)
+-- to be ASCII only.
+nextAscii :: String -> Offset8 -> StepASCII
+nextAscii (String ba) n = StepASCII w
   where
     !w = Vec.unsafeIndex ba n
 

--- a/Foundation/Primitive/UTF8/Base.hs
+++ b/Foundation/Primitive/UTF8/Base.hs
@@ -122,9 +122,9 @@ sFromList l = runST (new bytes >>= startCopy)
 next :: String -> Offset8 -> (# Char, Offset8 #)
 next (String array) n =
     case array of
-        Vec.UVecBA start _ ba     -> let (# c, o #) = PrimBA.next ba (start + n)
+        Vec.UArrayBA start _ ba     -> let (# c, o #) = PrimBA.next ba (start + n)
                                       in (# c, o `offsetSub` start #)
-        Vec.UVecAddr start _ fptr -> unt2 $ withUnsafeFinalPtr fptr $ \(Ptr ptr) -> pureST $ t2 start (PrimAddr.next ptr (start + n))
+        Vec.UArrayAddr start _ fptr -> unt2 $ withUnsafeFinalPtr fptr $ \(Ptr ptr) -> pureST $ t2 start (PrimAddr.next ptr (start + n))
   where
     pureST :: a -> ST s a
     pureST = pure
@@ -134,9 +134,9 @@ next (String array) n =
 prev :: String -> Offset8 -> (# Char, Offset8 #)
 prev (String array) n =
     case array of
-        Vec.UVecBA start _ ba     -> let (# c, o #) = PrimBA.prev ba (start + n)
+        Vec.UArrayBA start _ ba     -> let (# c, o #) = PrimBA.prev ba (start + n)
                                       in (# c, o `offsetSub` start #)
-        Vec.UVecAddr start _ fptr -> unt2 $ withUnsafeFinalPtr fptr $ \(Ptr ptr) -> pureST $ t2 start (PrimAddr.prev ptr (start + n))
+        Vec.UArrayAddr start _ fptr -> unt2 $ withUnsafeFinalPtr fptr $ \(Ptr ptr) -> pureST $ t2 start (PrimAddr.prev ptr (start + n))
   where
     pureST :: a -> ST s a
     pureST = pure
@@ -158,8 +158,8 @@ expectAscii (String ba) n v = Vec.unsafeIndex ba n == v
 write :: PrimMonad prim => MutableString (PrimState prim) -> Offset8 -> Char -> prim Offset8
 write (MutableString marray) ofs c =
     case marray of
-        MVec.MUVecMA start _ mba    -> PrimBA.write mba (start + ofs) c
-        MVec.MUVecAddr start _ fptr -> withFinalPtr fptr $ \(Ptr ptr) -> PrimAddr.write ptr (start + ofs) c
+        MVec.MUArrayMBA start _ mba    -> PrimBA.write mba (start + ofs) c
+        MVec.MUArrayAddr start _ fptr -> withFinalPtr fptr $ \(Ptr ptr) -> PrimAddr.write ptr (start + ofs) c
 
 -- | Allocate a MutableString of a specific size in bytes.
 new :: PrimMonad prim

--- a/Foundation/Primitive/UTF8/Helper.hs
+++ b/Foundation/Primitive/UTF8/Helper.hs
@@ -23,15 +23,6 @@ import           GHC.Prim
 import           GHC.Types
 import           GHC.Word
 
--- | Possible failure related to validating bytes of UTF8 sequences.
-data ValidationFailure = InvalidHeader
-                       | InvalidContinuation
-                       | MissingByte
-                       | BuildingFailure
-                       deriving (Show,Eq,Typeable)
-
-instance Exception ValidationFailure
-
 -- mask an UTF8 continuation byte (stripping the leading 10 and returning 6 valid bits)
 maskContinuation# :: Word# -> Word#
 maskContinuation# v = and# v 0x3f##

--- a/Foundation/Primitive/UTF8/Types.hs
+++ b/Foundation/Primitive/UTF8/Types.hs
@@ -1,0 +1,50 @@
+module Foundation.Primitive.UTF8.Types
+    (
+    -- * Stepper
+      Step(..)
+    , StepBack(..)
+    , StepASCII(..)
+    , StepDigit(..)
+    , isValidStepASCII
+    , isValidStepDigit
+    -- * Unicode Errors
+    , ValidationFailure(..)
+    ) where
+
+import           Foundation.Internal.Base
+import           Foundation.Primitive.Types.OffsetSize
+
+-- | Step when walking a String
+--
+-- this is a return value composed of :
+-- * the unicode code point read (Char) which need to be
+--   between 0 and 0x10ffff (inclusive)
+-- * The next offset to start reading the next unicode code point (or end)
+data Step = Step {-# UNPACK #-} !Char {-# UNPACK #-} !(Offset Word8)
+
+-- | Similar to Step but used when processing the string from the end.
+--
+-- The stepper is thus the previous character, and the offset of
+-- the beginning of the previous character
+data StepBack = StepBack {-# UNPACK #-} !Char {-# UNPACK #-} !(Offset Word8)
+
+-- | Step when processing digits. the value is between 0 and 9 to be valid
+newtype StepDigit = StepDigit Word8
+
+-- | Step when processing ASCII character
+newtype StepASCII = StepASCII Word8
+
+isValidStepASCII :: StepASCII -> Bool
+isValidStepASCII (StepASCII w) = w < 0x80
+
+isValidStepDigit :: StepDigit -> Bool
+isValidStepDigit (StepDigit w) = w < 0xa
+
+-- | Possible failure related to validating bytes of UTF8 sequences.
+data ValidationFailure = InvalidHeader
+                       | InvalidContinuation
+                       | MissingByte
+                       | BuildingFailure
+                       deriving (Show,Eq,Typeable)
+
+instance Exception ValidationFailure

--- a/Foundation/String/ASCII.hs
+++ b/Foundation/String/ASCII.hs
@@ -190,7 +190,7 @@ break predicate = bimap AsciiString AsciiString . Vec.break predicate . toBytes
 
 breakElem :: CUChar -> AsciiString -> (AsciiString, AsciiString)
 breakElem !el (AsciiString ba) =
-    let (# v1,v2 #) = Vec.splitElem el ba in (AsciiString v1, AsciiString v2)
+    bimap AsciiString AsciiString $ Vec.splitElem el ba
 {-# INLINE breakElem #-}
 
 intersperse :: CUChar -> AsciiString -> AsciiString

--- a/Foundation/String/ASCII.hs
+++ b/Foundation/String/ASCII.hs
@@ -190,7 +190,7 @@ break predicate = bimap AsciiString AsciiString . Vec.break predicate . toBytes
 
 breakElem :: CUChar -> AsciiString -> (AsciiString, AsciiString)
 breakElem !el (AsciiString ba) =
-    bimap AsciiString AsciiString $ Vec.splitElem el ba
+    bimap AsciiString AsciiString $ Vec.breakElem el ba
 {-# INLINE breakElem #-}
 
 intersperse :: CUChar -> AsciiString -> AsciiString

--- a/Foundation/String/ModifiedUTF8.hs
+++ b/Foundation/String/ModifiedUTF8.hs
@@ -46,7 +46,7 @@ accessBytes offset getAtIdx = (loop offset, pastEnd)
         | otherwise      = getAtIdx off : loop (off + 1)
 
 buildByteArray :: Addr# -> ST st (UArray Word8)
-buildByteArray addr = Vec.UVecAddr (Offset 0) (CountOf 100000) `fmap`
+buildByteArray addr = Vec.UArrayAddr (Offset 0) (CountOf 100000) `fmap`
     toFinalPtr (Ptr addr) (\_ -> return ())
 
 -- | assuming the given ByteArray is a valid modified UTF-8 sequence of bytes

--- a/Foundation/String/ModifiedUTF8.hs
+++ b/Foundation/String/ModifiedUTF8.hs
@@ -27,6 +27,7 @@ import           Control.Monad (mapM_)
 import           Foundation.Internal.Base
 import           Foundation.Primitive.Types.OffsetSize
 import qualified Foundation.Array.Unboxed as Vec
+import qualified Foundation.Primitive.UArray.Base as Vec
 import           Foundation.Array.Unboxed (UArray)
 import           Foundation.Numerical
 import           Foundation.Primitive.FinalPtr
@@ -46,7 +47,7 @@ accessBytes offset getAtIdx = (loop offset, pastEnd)
         | otherwise      = getAtIdx off : loop (off + 1)
 
 buildByteArray :: Addr# -> ST st (UArray Word8)
-buildByteArray addr = Vec.UArrayAddr (Offset 0) (CountOf 100000) `fmap`
+buildByteArray addr = Vec.UArray (Offset 0) (CountOf 100000) . Vec.UArrayAddr <$>
     toFinalPtr (Ptr addr) (\_ -> return ())
 
 -- | assuming the given ByteArray is a valid modified UTF-8 sequence of bytes

--- a/Foundation/String/UTF8.hs
+++ b/Foundation/String/UTF8.hs
@@ -761,8 +761,8 @@ filter :: (Char -> Bool) -> String -> String
 filter predicate (String arr) = runST $ do
     (finalSize, dst) <- newNative sz $ \mba ->
         case arr of
-            C.UVecBA start _ ba     -> BackendBA.copyFilter predicate sz mba ba start
-            C.UVecAddr start _ fptr -> withFinalPtr fptr $ \(Ptr addr) -> BackendAddr.copyFilter predicate sz mba addr start
+            C.UArrayBA start _ ba     -> BackendBA.copyFilter predicate sz mba ba start
+            C.UArrayAddr start _ fptr -> withFinalPtr fptr $ \(Ptr addr) -> BackendAddr.copyFilter predicate sz mba addr start
     freezeShrink finalSize dst
   where
     !sz = C.length arr

--- a/Foundation/String/UTF8.hs
+++ b/Foundation/String/UTF8.hs
@@ -110,7 +110,6 @@ import           Foundation.Boot.Builder
 import           Foundation.Primitive.UTF8.Table
 import           Foundation.Primitive.UTF8.Helper
 import           Foundation.Primitive.UTF8.Base
-import           Foundation.System.Bindings.Hs (sysHsUTF8LengthBa, sysHsUTF8LengthAddr)
 import           Foundation.Primitive.UTF8.Types
 import           Foundation.Primitive.UArray.Base as C (onBackendPrim, onBackend, offset, ValidRange(..), offsetsValidRange)
 import qualified Foundation.Primitive.UTF8.BA as PrimBA
@@ -572,9 +571,8 @@ length (String arr)
     | otherwise    = C.onBackend goVec (\_ -> pure . goAddr) arr
   where
     (C.ValidRange !start !end) = offsetsValidRange arr
-    goVec ma = sysHsUTF8LengthBa ma start end
-
-    goAddr (Ptr ptr) = sysHsUTF8LengthAddr ptr start end
+    goVec ma = PrimBA.length ma start end
+    goAddr (Ptr ptr) = PrimAddr.length ptr start end
 
 -- | Replicate a character @c@ @n@ times to create a string of length @n@
 replicate :: CountOf Char -> Char -> String

--- a/Foundation/String/UTF8.hs
+++ b/Foundation/String/UTF8.hs
@@ -1334,12 +1334,7 @@ lower = charMap toLower
 
 -- | Check whether the first string is a prefix of the second string.
 isPrefixOf :: String -> String -> Bool
-isPrefixOf (String needle) (String haystack)
-    | needleLen > hayLen = False
-    | otherwise          = needle == C.take needleLen haystack
-  where
-    needleLen = C.length needle
-    hayLen    = C.length haystack
+isPrefixOf (String needle) (String haystack) = C.isPrefixOf needle haystack
 
 -- | Check whether the first string is a suffix of the second string.
 isSuffixOf :: String -> String -> Bool

--- a/Foundation/String/UTF8.hs
+++ b/Foundation/String/UTF8.hs
@@ -464,7 +464,7 @@ breakElem !el s@(String ba)
     | sz == 0   = (mempty, mempty)
     | otherwise =
         case asUTF8Char el of
-            UTF8_1 w -> let (# v1,v2 #) = Vec.splitElem w ba in (String v1, String v2)
+            UTF8_1 w -> let !(v1,v2) = Vec.splitElem w ba in (String v1, String v2)
             _        -> runST $ Vec.unsafeIndexer ba go
   where
     sz = size s

--- a/Foundation/String/UTF8.hs
+++ b/Foundation/String/UTF8.hs
@@ -110,6 +110,7 @@ import           Foundation.Boot.Builder
 import           Foundation.Primitive.UTF8.Table
 import           Foundation.Primitive.UTF8.Helper
 import           Foundation.Primitive.UTF8.Base
+import           Foundation.System.Bindings.Hs (sysHsUTF8LengthBa, sysHsUTF8LengthAddr)
 import           Foundation.Primitive.UTF8.Types
 import           Foundation.Primitive.UArray.Base as C (onBackendPrim, onBackend, offset, ValidRange(..), offsetsValidRange)
 import qualified Foundation.Primitive.UTF8.BA as PrimBA
@@ -468,7 +469,7 @@ breakElem !el s@(String ba)
     | sz == 0   = (mempty, mempty)
     | otherwise =
         case asUTF8Char el of
-            UTF8_1 w -> let !(v1,v2) = Vec.splitElem w ba in (String v1, String v2)
+            UTF8_1 w -> let !(v1,v2) = Vec.breakElem w ba in (String v1, String v2)
             _        -> runST $ Vec.unsafeIndexer ba go
   where
     sz = size s

--- a/Foundation/String/UTF8.hs
+++ b/Foundation/String/UTF8.hs
@@ -412,7 +412,7 @@ splitOn predicate s
     loop prevIdx idx
         | idx == end = [sub s prevIdx idx]
         | otherwise =
-            let (# c, idx' #) = next s idx
+            let (!c, !idx') = next s idx
              in if predicate c
                     then sub s prevIdx idx : loop idx' idx'
                     else loop prevIdx idx'
@@ -541,7 +541,7 @@ intersperse sep src
             nextDstIdx' <- write dst nextDstIdx sep'
             return (nextSrcIdx, nextDstIdx')
       where
-        (# c, nextSrcIdx #) = next src' srcIdx
+        (c, nextSrcIdx) = next src' srcIdx
 
 -- | Allocate a new @String@ with a fill function that has access to the characters of
 --   the source @String@.
@@ -673,7 +673,7 @@ charMap f src
             | srcIdx == srcEnd = return (offsetAsSize dstIdx, srcIdx)
             | dstIdx == endDst = return (offsetAsSize dstIdx, srcIdx)
             | otherwise        =
-                let (# c, srcIdx' #) = next src srcIdx
+                let (c, srcIdx') = next src srcIdx
                     c' = f c -- the mapped char
                     !nbBytes = charToBytes (fromEnum c')
                  in -- check if we have room in the destination buffer
@@ -722,7 +722,7 @@ unsnoc :: String -> Maybe (String, Char)
 unsnoc s@(String arr)
     | sz == 0   = Nothing
     | otherwise =
-        let (# c, idx #) = prev s (sizeAsOffset sz)
+        let (c, idx) = prev s (sizeAsOffset sz)
          in Just (String $ Vec.take (offsetAsSize idx) arr, c)
   where
     sz = size s
@@ -734,7 +734,7 @@ uncons :: String -> Maybe (Char, String)
 uncons s@(String ba)
     | null s    = Nothing
     | otherwise =
-        let (# c, idx #) = next s azero
+        let (c, idx) = next s azero
          in Just (c, String $ Vec.drop (offsetAsSize idx) ba)
 
 -- | Look for a predicate in the String and return the matched character, if any.
@@ -746,7 +746,7 @@ find predicate s = loop (Offset 0)
     loop idx
         | idx == end = Nothing
         | otherwise =
-            let (# c, idx' #) = next s idx
+            let (c, idx') = next s idx
              in case predicate c of
                     True  -> Just c
                     False -> loop idx'
@@ -820,7 +820,7 @@ index :: String -> Offset Char -> Maybe Char
 index s n
     | ofs >= end = Nothing
     | otherwise  =
-        let (# c, _ #) = next s ofs
+        let (c, _) = next s ofs
          in Just c
   where
     !nbBytes = size s
@@ -837,7 +837,7 @@ findIndex predicate s = loop 0 0
     loop ofs idx
         | idx .==# sz = Nothing
         | otherwise   =
-            let (# c, idx' #) = next s idx
+            let (c, idx') = next s idx
              in case predicate c of
                     True  -> Just ofs
                     False -> loop (ofs+1) idx'

--- a/Foundation/String/UTF8/Addr.hs
+++ b/Foundation/String/UTF8/Addr.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE MagicHash                  #-}
 {-# LANGUAGE NoImplicitPrelude          #-}
 {-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE UnboxedTuples              #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE CPP                        #-}
 module Foundation.String.UTF8.Addr
@@ -20,6 +19,7 @@ import qualified Foundation.Primitive.UTF8.BA   as PrimBA
 import qualified Foundation.Primitive.UTF8.Addr as PrimBackend
 import           Foundation.Primitive.UTF8.Helper
 import           Foundation.Primitive.UTF8.Table
+import           Foundation.Primitive.UTF8.Types
 
 copyFilter :: (Char -> Bool)
            -> CountOf Word8
@@ -39,8 +39,8 @@ copyFilter predicate !sz dst src start = loop (Offset 0) start
                          | otherwise             -> loop d (s + Offset 1)
                     False ->
                         case PrimBackend.next src s of
-                            (# c, s' #) | predicate c -> PrimBA.write dst d c >>= \d' -> loop d' s'
-                                        | otherwise   -> loop d s'
+                            Step c s' | predicate c -> PrimBA.write dst d c >>= \d' -> loop d' s'
+                                      | otherwise   -> loop d s'
 
 validate :: Offset Word8
          -> PrimBackend.Immutable

--- a/Foundation/String/UTF8/BA.hs
+++ b/Foundation/String/UTF8/BA.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE MagicHash                  #-}
 {-# LANGUAGE NoImplicitPrelude          #-}
 {-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE UnboxedTuples              #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE CPP                        #-}
 module Foundation.String.UTF8.BA
@@ -20,6 +19,7 @@ import qualified Foundation.Primitive.UTF8.BA as PrimBA
 import qualified Foundation.Primitive.UTF8.BA as PrimBackend
 import           Foundation.Primitive.UTF8.Helper
 import           Foundation.Primitive.UTF8.Table
+import           Foundation.Primitive.UTF8.Types
 
 copyFilter :: (Char -> Bool)
            -> CountOf Word8
@@ -39,8 +39,8 @@ copyFilter predicate !sz dst src start = loop (Offset 0) start
                          | otherwise             -> loop d (s + Offset 1)
                     False ->
                         case PrimBackend.next src s of
-                            (# c, s' #) | predicate c -> PrimBA.write dst d c >>= \d' -> loop d' s'
-                                        | otherwise   -> loop d s'
+                            Step c s' | predicate c -> PrimBA.write dst d c >>= \d' -> loop d' s'
+                                      | otherwise   -> loop d s'
 
 validate :: Offset Word8
          -> PrimBackend.Immutable

--- a/Foundation/System/Bindings/Hs.hs
+++ b/Foundation/System/Bindings/Hs.hs
@@ -7,7 +7,6 @@ module Foundation.System.Bindings.Hs
 import GHC.IO
 import GHC.Prim
 import GHC.Word
-import Prelude (Char)
 import Foreign.C.Types
 import Foreign.Ptr
 import Foundation.Primitive.Types.OffsetSize
@@ -32,8 +31,8 @@ foreign import ccall unsafe "_foundation_mem_findbyte" sysHsMemFindByteBa ::
 foreign import ccall unsafe "_foundation_mem_findbyte" sysHsMemFindByteAddr ::
     Addr# -> Offset Word8 -> Offset Word8 -> Word8 -> Offset Word8
 
-foreign import ccall unsafe "foundation_utf8_length" sysHsUTF8LengthBa ::
-    ByteArray# -> Offset Word8 -> Offset Word8 -> CountOf Char
+--foreign import ccall unsafe "foundation_utf8_length" sysHsUTF8LengthBa ::
+--    ByteArray# -> Offset Word8 -> Offset Word8 -> CountOf Char
 
-foreign import ccall unsafe "foundation_utf8_length" sysHsUTF8LengthAddr ::
-    Addr# -> Offset Word8 -> Offset Word8 -> CountOf Char
+--foreign import ccall unsafe "foundation_utf8_length" sysHsUTF8LengthAddr ::
+--    Addr# -> Offset Word8 -> Offset Word8 -> CountOf Char

--- a/Foundation/System/Bindings/Hs.hs
+++ b/Foundation/System/Bindings/Hs.hs
@@ -6,19 +6,24 @@ module Foundation.System.Bindings.Hs
 
 import GHC.IO
 import GHC.Prim
+import GHC.Word
+import Prelude (Char)
 import Foreign.C.Types
 import Foreign.Ptr
+import Foundation.Primitive.Types.OffsetSize
 
 foreign import ccall unsafe "HsBase.h __hscore_get_errno" sysHsCoreGetErrno :: IO CInt
 
 foreign import ccall unsafe "_foundation_memcmp" sysHsMemcmpBaBa ::
-    ByteArray# -> CSize -> ByteArray# -> CSize -> CSize -> IO CInt
+    ByteArray# -> Offset Word8 -> ByteArray# -> Offset Word8 -> CountOf Word8 -> IO CInt
 
 foreign import ccall unsafe "_foundation_memcmp" sysHsMemcmpBaPtr ::
-    ByteArray# -> CSize -> Ptr a -> CSize -> CSize -> IO CInt
+    ByteArray# -> Offset Word8 -> Ptr a -> Offset Word8 -> CountOf Word8 -> IO CInt
 
 foreign import ccall unsafe "_foundation_memcmp" sysHsMemcmpPtrBa ::
-    Ptr a -> CSize -> ByteArray# -> CSize -> CSize -> IO CInt
+    Ptr a -> Offset Word8 -> ByteArray# -> Offset Word8 -> CountOf Word8 -> IO CInt
 
 foreign import ccall unsafe "_foundation_memcmp" sysHsMemcmpPtrPtr ::
-    Ptr a -> CSize -> Ptr b -> CSize -> CSize -> IO CInt
+    Ptr a -> Offset Word8 -> Ptr b -> Offset Word8 -> CountOf Word8 -> IO CInt
+
+foreign import ccall unsafe "_foundation_mem_findbyte" sysHsMemFindByteBa ::

--- a/Foundation/System/Bindings/Hs.hs
+++ b/Foundation/System/Bindings/Hs.hs
@@ -27,3 +27,7 @@ foreign import ccall unsafe "_foundation_memcmp" sysHsMemcmpPtrPtr ::
     Ptr a -> Offset Word8 -> Ptr b -> Offset Word8 -> CountOf Word8 -> IO CInt
 
 foreign import ccall unsafe "_foundation_mem_findbyte" sysHsMemFindByteBa ::
+    ByteArray# -> Offset Word8 -> Offset Word8 -> Word8 -> Offset Word8
+
+foreign import ccall unsafe "_foundation_mem_findbyte" sysHsMemFindByteAddr ::
+    Addr# -> Offset Word8 -> Offset Word8 -> Word8 -> Offset Word8

--- a/Foundation/System/Bindings/Hs.hs
+++ b/Foundation/System/Bindings/Hs.hs
@@ -31,3 +31,9 @@ foreign import ccall unsafe "_foundation_mem_findbyte" sysHsMemFindByteBa ::
 
 foreign import ccall unsafe "_foundation_mem_findbyte" sysHsMemFindByteAddr ::
     Addr# -> Offset Word8 -> Offset Word8 -> Word8 -> Offset Word8
+
+foreign import ccall unsafe "foundation_utf8_length" sysHsUTF8LengthBa ::
+    ByteArray# -> Offset Word8 -> Offset Word8 -> CountOf Char
+
+foreign import ccall unsafe "foundation_utf8_length" sysHsUTF8LengthAddr ::
+    Addr# -> Offset Word8 -> Offset Word8 -> CountOf Char

--- a/Foundation/Time/Types.hs
+++ b/Foundation/Time/Types.hs
@@ -23,6 +23,7 @@ newtype NanoSeconds = NanoSeconds Word64
 
 instance PrimType NanoSeconds where
     primSizeInBytes _        = primSizeInBytes (Proxy :: Proxy Word64)
+    primShiftToBytes _       = primShiftToBytes (Proxy :: Proxy Word64)
     primBaUIndex ba ofs      = primBaUIndex ba (coerce ofs)
     primMbaURead mba ofs     = primMbaURead mba (coerce ofs)
     primMbaUWrite mba ofs v  = primMbaUWrite mba (coerce ofs) (coerce v :: Word64)
@@ -36,6 +37,7 @@ newtype Seconds = Seconds Word64
 
 instance PrimType Seconds where
     primSizeInBytes _        = primSizeInBytes (Proxy :: Proxy Word64)
+    primShiftToBytes _       = primShiftToBytes (Proxy :: Proxy Word64)
     primBaUIndex ba ofs      = primBaUIndex ba (coerce ofs)
     primMbaURead mba ofs     = primMbaURead mba (coerce ofs)
     primMbaUWrite mba ofs v  = primMbaUWrite mba (coerce ofs) (coerce v :: Word64)

--- a/benchs/Fake/ByteString.hs
+++ b/benchs/Fake/ByteString.hs
@@ -9,6 +9,7 @@ module Fake.ByteString
     , reverse
     , filter
     , foldl'
+    , foldl1'
     , foldr
     , and
     , all
@@ -32,6 +33,8 @@ reverse     = undefined
 filter _    = undefined
 foldl' :: (Word8 -> a -> a) -> a -> ByteString -> a
 foldl' _ _ _ = undefined
+foldl1' :: (Word8 -> Word8 -> Word8) -> ByteString -> a
+foldl1' _ _ = undefined
 foldr :: (a -> Word8 -> a) -> a -> ByteString -> a
 foldr _ _ _ = undefined
 and _ _ = undefined

--- a/benchs/Fake/ByteString.hs
+++ b/benchs/Fake/ByteString.hs
@@ -16,6 +16,7 @@ module Fake.ByteString
     , any
     , readInt
     , readInteger
+    , unpack
     ) where
 
 import Prelude (undefined, Maybe(..))
@@ -40,6 +41,8 @@ foldr _ _ _ = undefined
 and _ _ = undefined
 all _ _ = undefined
 any _ _ = undefined
+unpack :: ByteString -> [Word8]
+unpack = undefined
 
 readInt :: ByteString -> Maybe (a,b)
 readInt _    = undefined

--- a/benchs/Fake/ByteString.hs
+++ b/benchs/Fake/ByteString.hs
@@ -18,6 +18,7 @@ module Fake.ByteString
     ) where
 
 import Prelude (undefined, Maybe(..))
+import Data.Word
 
 data ByteString = ByteString
 
@@ -29,7 +30,9 @@ break   _ _ = (undefined, undefined)
 takeWhile _ _ = undefined
 reverse     = undefined
 filter _    = undefined
+foldl' :: (Word8 -> a -> a) -> a -> ByteString -> a
 foldl' _ _ _ = undefined
+foldr :: (a -> Word8 -> a) -> a -> ByteString -> a
 foldr _ _ _ = undefined
 and _ _ = undefined
 all _ _ = undefined

--- a/benchs/Fake/Text.hs
+++ b/benchs/Fake/Text.hs
@@ -13,7 +13,7 @@ module Fake.Text
     , decodeUtf8
     ) where
 
-import Prelude (undefined, Either(..))
+import Prelude (undefined, Either(..), Char)
 
 data Text = Text
 

--- a/benchs/Fake/Text.hs
+++ b/benchs/Fake/Text.hs
@@ -1,6 +1,7 @@
 module Fake.Text
     ( Text
     , pack
+    , unpack
     , length
     , splitAt
     , take
@@ -17,6 +18,8 @@ import Prelude (undefined, Either(..))
 data Text = Text
 
 pack _      = Text
+unpack :: Text -> [Char]
+unpack _ = undefined
 length      = undefined
 splitAt _ _ = (undefined, undefined)
 take        = undefined

--- a/benchs/Fake/Vector.hs
+++ b/benchs/Fake/Vector.hs
@@ -1,6 +1,6 @@
-module Fake.ByteString
-    ( ByteString
-    , pack
+module Fake.Vector
+    ( Vector
+    , fromList
     , length
     , splitAt
     , take
@@ -13,15 +13,11 @@ module Fake.ByteString
     , and
     , all
     , any
-    , readInt
-    , readInteger
     ) where
 
-import Prelude (undefined, Maybe(..))
+data Vector ty = Vector
 
-data ByteString = ByteString
-
-pack _      = ByteString
+fromList _  = Vector
 length      = undefined
 splitAt _ _ = (undefined, undefined)
 take        = undefined
@@ -34,8 +30,3 @@ foldr _ _ _ = undefined
 and _ _ = undefined
 all _ _ = undefined
 any _ _ = undefined
-
-readInt :: ByteString -> Maybe (a,b)
-readInt _    = undefined
-readInteger :: ByteString -> Maybe (a,b)
-readInteger _ = undefined

--- a/benchs/Fake/Vector.hs
+++ b/benchs/Fake/Vector.hs
@@ -15,6 +15,8 @@ module Fake.Vector
     , any
     ) where
 
+import Prelude (undefined)
+
 data Vector ty = Vector
 
 fromList _  = Vector

--- a/benchs/Fake/Vector.hs
+++ b/benchs/Fake/Vector.hs
@@ -9,6 +9,7 @@ module Fake.Vector
     , reverse
     , filter
     , foldl'
+    , foldl1'
     , foldr
     , and
     , all
@@ -29,6 +30,8 @@ reverse     = undefined
 filter _    = undefined
 foldl' :: (ty -> a -> a) -> a -> Vector ty -> a
 foldl' _ _ _ = undefined
+foldl1' :: (ty -> ty -> ty) -> Vector ty -> a
+foldl1' _ _ = undefined
 foldr :: (a -> ty -> a) -> a -> Vector ty -> a
 foldr _ _ _ = undefined
 and _ _ = undefined

--- a/benchs/Fake/Vector.hs
+++ b/benchs/Fake/Vector.hs
@@ -27,7 +27,9 @@ break   _ _ = (undefined, undefined)
 takeWhile _ _ = undefined
 reverse     = undefined
 filter _    = undefined
+foldl' :: (ty -> a -> a) -> a -> Vector ty -> a
 foldl' _ _ _ = undefined
+foldr :: (a -> ty -> a) -> a -> Vector ty -> a
 foldr _ _ _ = undefined
 and _ _ = undefined
 all _ _ = undefined

--- a/benchs/Fake/Vector.hs
+++ b/benchs/Fake/Vector.hs
@@ -1,6 +1,7 @@
 module Fake.Vector
     ( Vector
     , fromList
+    , toList
     , length
     , splitAt
     , take
@@ -21,6 +22,8 @@ import Prelude (undefined)
 data Vector ty = Vector
 
 fromList _  = Vector
+toList :: Vector ty -> [ty]
+toList _ = undefined
 length      = undefined
 splitAt _ _ = (undefined, undefined)
 take        = undefined

--- a/benchs/Main.hs
+++ b/benchs/Main.hs
@@ -33,6 +33,7 @@ import qualified Fake.Vector as Vector
 
 benchsString = bgroup "String"
     [ benchLength
+    , benchUnpack
     , benchElem
     , benchTake
     , benchSplitAt
@@ -99,6 +100,9 @@ benchsString = bgroup "String"
 
     benchLength = bgroup "Length" $
         fmap (\(n, dat) -> bgroup n $ diffTextString length Text.length dat)
+            allDat
+    benchUnpack = bgroup "Unpack" $
+        fmap (\(n, dat) -> bgroup n $ diffTextString (length . toList) (length . Text.unpack) dat)
             allDat
     benchElem = bgroup "Elem" $
         fmap (\(n, dat) -> bgroup n $ diffTextString (elem '.') (Text.any (== '.')) dat)

--- a/benchs/Main.hs
+++ b/benchs/Main.hs
@@ -167,10 +167,11 @@ benchsByteArray = bgroup "ByteArray"
     , benchBreakElem
     , benchTakeWhile
     , benchFoldl
+    , benchFoldl1
+    , benchFoldr
     , benchReverse
     , benchFilter
     , benchAll
-    --, benchSplitAt
     ]
   where
     diffByteArray :: (UArray Word8 -> a)
@@ -229,6 +230,16 @@ benchsByteArray = bgroup "ByteArray"
     benchFoldl = bgroup "Foldl" $ fmap (\(n, dat) ->
             bgroup n $ diffByteArray (foldl' (+) 0) (foldl' (+) 0)
                                      (ByteString.foldl' (+) 0) (Vector.foldl' (+) 0) dat)
+                $ allDat
+
+    benchFoldl1 = bgroup "Foldl1" $ fmap (\(n, dat) ->
+            bgroup n $ diffByteArray (foldl1' (+) . nonEmpty_) (foldl1' (+) . nonEmpty_)
+                                     (ByteString.foldl1' (+)) (Vector.foldl1' (+)) dat)
+                $ allDat
+
+    benchFoldr = bgroup "Foldr" $ fmap (\(n, dat) ->
+            bgroup n $ diffByteArray (foldr (+) 1) (foldr (+) 1)
+                                     (ByteString.foldr (+) 1) (Vector.foldr (+) 1) dat)
                 $ allDat
 
     benchAll = bgroup "All" $ fmap (\(n, dat) ->

--- a/cbits/foundation_mem.c
+++ b/cbits/foundation_mem.c
@@ -1,6 +1,14 @@
 #include <string.h>
+#include <stdint.h>
+#include "foundation_prim.h"
 
-int _foundation_memcmp(const void *s1, size_t off1, const void *s2, size_t off2, size_t n)
+int _foundation_memcmp(const void *s1, FsOffset off1, const void *s2, FsOffset off2, FsCountOf n)
 {
 	return memcmp(s1 + off1, s2 + off2, n);
+}
+
+FsOffset _foundation_mem_findbyte(uint8_t * const arr, FsOffset startofs, FsOffset endofs, uint8_t ty)
+{
+    uint8_t *r = memchr(arr + startofs, ty, endofs - startofs);
+    return ((r == NULL) ? endofs : r - arr);
 }

--- a/cbits/foundation_prim.h
+++ b/cbits/foundation_prim.h
@@ -1,0 +1,8 @@
+#ifndef FOUNDATION_PRIM_H
+#define FOUNDATION_PRIM_H
+#include "Rts.h"
+
+typedef StgInt FsOffset;
+typedef StgInt FsCountOf;
+
+#endif

--- a/cbits/foundation_utf8.c
+++ b/cbits/foundation_utf8.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include "foundation_prim.h"
 
+#if 0
 static const uint64_t utf8_mask_80 = 0x8080808080808080ULL;
 static const uint64_t utf8_mask_40 = 0x4040404040404040ULL;
 
@@ -59,7 +60,7 @@ int foundation_utf8_validate(const uint8_t *c, size_t offset, size_t end)
         /* 2 bytes */
         else if (h < 0xE0) { if      (offset + 1 >= end) { goto fail2; }
             else if (IS_CONT(c[offset+1])) { offset += 2; }
-            else { goto fail1; } 
+            else { goto fail1; }
         }
         /* 3 bytes */
         else if (h < 0xF0) { if      (offset + 2 >= end) { goto fail2; }
@@ -81,3 +82,4 @@ fail1:
 fail2:
     return 2;
 }
+#endif

--- a/cbits/foundation_utf8.c
+++ b/cbits/foundation_utf8.c
@@ -1,0 +1,83 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include "foundation_prim.h"
+
+static const uint64_t utf8_mask_80 = 0x8080808080808080ULL;
+static const uint64_t utf8_mask_40 = 0x4040404040404040ULL;
+
+typedef unsigned long pu;
+#define POPCOUNT(x) __builtin_popcountl(x)
+#define ALIGNED8(p) ((((uintptr_t) (p)) & (sizeof(pu)-1)) == 0)
+
+FsCountOf foundation_utf8_length(uint8_t *p8, const FsOffset start_offset, const FsOffset end_offset)
+{
+    const uint8_t *end = p8 + end_offset;
+    FsCountOf n = 0;
+
+    p8 += start_offset;
+
+    while (!ALIGNED8(p8) && p8 < end) {
+        if ((*p8++ & 0xc0) != 0x80) { n++; }
+    }
+
+    /* process 8 bytes */
+    for (; (p8 + sizeof(pu)) <= end; p8 += sizeof(pu)) {
+        pu h   = *((pu *) p8);
+        pu h80 = h & utf8_mask_80;
+
+        /* only ASCII */
+        if (h80 == 0) {
+            n += sizeof(pu);
+            continue;
+        }
+
+        int nb_ascii = (h80 == utf8_mask_80) ? 0 : (8 - __builtin_popcountl(h80));
+        int nb_high = __builtin_popcountl( h & (h80 >> 1));
+        n += nb_ascii + nb_high;
+    }
+
+    while (p8 < end) {
+        if ((*p8++ & 0xc0) != 0x80) { n++; }
+    }
+
+    return n;
+}
+
+#define IS_CONT(x) ((x & 0xc0) == 0x80)
+
+int foundation_utf8_validate(const uint8_t *c, size_t offset, size_t end)
+{
+    while (offset < end) {
+        uint8_t h = c[offset];
+        if (!(h & 0x80)) {
+            offset++;
+            continue;
+        }
+
+        /* continuation */
+        if      (h < 0xC0) { goto fail1; }
+        /* 2 bytes */
+        else if (h < 0xE0) { if      (offset + 1 >= end) { goto fail2; }
+            else if (IS_CONT(c[offset+1])) { offset += 2; }
+            else { goto fail1; } 
+        }
+        /* 3 bytes */
+        else if (h < 0xF0) { if      (offset + 2 >= end) { goto fail2; }
+            else if (IS_CONT(c[offset+1]) && IS_CONT(c[offset+2])) { offset += 3; }
+            else { goto fail1; }
+        }
+
+        /* 4 bytes */
+        else if (h < 0xFE) { if      (offset + 3 >= end) { goto fail2; }
+            else if (IS_CONT(c[offset+1]) && IS_CONT(c[offset+2]) && IS_CONT(c[offset+3])) { offset += 4; }
+            else { goto fail1; }
+        }
+        /* invalid > 4 bytes */
+        else               { goto fail1; }
+    }
+    return 0;
+fail1:
+    return 1;
+fail2:
+    return 2;
+}

--- a/foundation.cabal
+++ b/foundation.cabal
@@ -192,6 +192,7 @@ library
                      Foundation.Primitive.UTF8.Base
                      Foundation.Primitive.UTF8.BA
                      Foundation.Primitive.UTF8.Addr
+                     Foundation.Primitive.UTF8.Types
                      Foundation.Primitive.UArray.Base
                      Foundation.Primitive.UArray.BA
                      Foundation.Primitive.UArray.Addr

--- a/foundation.cabal
+++ b/foundation.cabal
@@ -357,6 +357,7 @@ Benchmark bench
                      Sys
                      Fake.ByteString
                      Fake.Text
+                     Fake.Vector
   hs-source-dirs:    benchs
   default-language:  Haskell2010
   type:              exitcode-stdio-1.0

--- a/foundation.cabal
+++ b/foundation.cabal
@@ -224,6 +224,7 @@ library
                      cbits/foundation_network.c
                      cbits/foundation_mem.c
                      cbits/foundation_time.c
+                     cbits/foundation_utf8.c
                      cbits/foundation_rts.c
 
   if flag(experimental)


### PR DESCRIPTION
some new benchs, some uarray optimisation and a massive refactor of the UArray types from:

```haskell
data UArray = UArrayAddr Offset Count FinalPtr | UArrayBA Offset Count ByteArray#
```

to

```haskell
data UArray = UArray Offset Count (UArrayBackend ..)
```

UArrayBackend being defined for now as:

```haskell
data UArrayBackend = UArrayAddr FinalPtr | UarrayBA Block
```

thus starting to re-use the Block infrastructure and also permitting the (not finished) 8.2 unboxed sum types refactor of:

```haskell
data UArray = UArray Offset Count (# FinalPtr | Block #)
```