### PR TITLE
Improve String & Conduit lines

### DIFF
--- a/Foundation/Array/Unboxed.hs
+++ b/Foundation/Array/Unboxed.hs
@@ -361,7 +361,7 @@ drop n arr@(UArray start len backend)
     | otherwise = UArray (start `offsetPlusE` n) (len - n) backend
 
 unsafeDrop :: CountOf ty -> UArray ty -> UArray ty
-unsafeDrop n (UArray start sz backend) = UArray (start `offsetPlusE` sz) (sz `sizeSub` n) backend
+unsafeDrop n (UArray start sz backend) = UArray (start `offsetPlusE` n) (sz `sizeSub` n) backend
 
 -- | Split an array into two, with a count of at most N elements in the first one
 -- and the remaining in the other.

--- a/Foundation/Conduit/Textual.hs
+++ b/Foundation/Conduit/Textual.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 module Foundation.Conduit.Textual
     ( lines
     , words
@@ -19,22 +20,27 @@ import           Data.Char (isSpace)
 -- This is very similar to Prelude lines except
 -- it work directly on Conduit
 --
--- Note that if the newline character is not coming,
+-- Note that if the newline character is not ever appearing in the stream,
 -- this function will keep accumulating data until OOM
+--
+-- TODO: make a size-limited function
 lines :: Monad m => Conduit String String m ()
-lines = await >>= maybe (finish []) (go [])
+lines = await >>= maybe (finish []) (go False [])
   where
     mconcatRev = mconcat . reverse
 
     finish l = if null l then return () else yield (mconcatRev l)
 
-    go prevs nextBuf =
-        case S.uncons next' of
-            Just (_, rest') -> yield (mconcatRev (line : prevs)) >> go mempty rest'
-            Nothing         ->
+    go prevCR prevs nextBuf = do
+        case S.breakLine nextBuf of
+            Right (line, next)
+                | S.null line && prevCR -> yield (mconcatRev (line : stripCRFromHead prevs)) >> go False mempty next
+                | otherwise             -> yield (mconcatRev (line : prevs)) >> go False mempty next
+            Left lastCR ->
                 let nextCurrent = nextBuf : prevs
-                 in await >>= maybe (finish nextCurrent) (go nextCurrent)
-      where (line, next') = S.breakElem '\n' nextBuf
+                 in await >>= maybe (finish nextCurrent) (go lastCR nextCurrent)
+    stripCRFromHead []     = []
+    stripCRFromHead (x:xs) = S.revDrop 1 x:xs
 
 words :: Monad m => Conduit String String m ()
 words = await >>= maybe (finish []) (go [])

--- a/Foundation/Conduit/Textual.hs
+++ b/Foundation/Conduit/Textual.hs
@@ -5,7 +5,7 @@ module Foundation.Conduit.Textual
     , toBytes
     ) where
 
-import           Foundation.Internal.Base hiding (throw)
+import           Foundation.Primitive.Imports hiding (throw)
 import           Foundation.Array.Unboxed (UArray)
 import           Foundation.String (String)
 import           Foundation.Collection

--- a/Foundation/Primitive/Block.hs
+++ b/Foundation/Primitive/Block.hs
@@ -175,6 +175,7 @@ foldl1' f (NonEmpty arr) = loop 1 (unsafeIndex arr 0)
     loop !i !acc
         | i .==# len = acc
         | otherwise  = loop (i+1) (f acc (unsafeIndex arr i))
+{-# SPECIALIZE [3] foldl1' :: (Word8 -> Word8 -> Word8) -> NonEmpty (Block Word8) -> Word8 #-}
 
 foldr1 :: PrimType ty => (ty -> ty -> ty) -> NonEmpty (Block ty) -> ty
 foldr1 f arr = let (initialAcc, rest) = revSplitAt 1 $ getNonEmpty arr

--- a/Foundation/String.hs
+++ b/Foundation/String.hs
@@ -37,6 +37,7 @@ module Foundation.String
     , toBase64
     , toBase64URL
     , toBase64OpenBSD
+    , breakLine
     ) where
 
 import Foundation.String.UTF8

--- a/Foundation/String/UTF8.hs
+++ b/Foundation/String/UTF8.hs
@@ -985,9 +985,15 @@ toBytes ISO_8859_1 (String bytes) = toEncoderBytes Encoder.ISO_8859_1 bytes
 toBytes UTF16      (String bytes) = toEncoderBytes Encoder.UTF16      bytes
 toBytes UTF32      (String bytes) = toEncoderBytes Encoder.UTF32      bytes
 
--- | Split lines in a string using newline as separation
+-- | Split lines in a string using newline as separation.
+--
+-- Note that carriage return preceding a newline are also strip for
+-- maximum compatibility between Windows and Unix system.
 lines :: String -> [String]
-lines = fmap fromList . Prelude.lines . toList
+lines s =
+    case breakLine s of
+        Left _         -> [s]
+        Right (line,r) -> line : lines r
 
 -- | Split words in a string using spaces as separation
 --

--- a/Foundation/String/UTF8.hs
+++ b/Foundation/String/UTF8.hs
@@ -52,6 +52,7 @@ module Foundation.String.UTF8
     , span
     , break
     , breakElem
+    , breakLine
     , dropWhile
     , singleton
     , charMap
@@ -485,6 +486,15 @@ breakElem !el s@(String ba)
                 case el == c of
                     True  -> return $ splitIndex idx s
                     False -> loop idx'
+
+-- | Same as break but cut on a line feed with an optional carriage return.
+--
+-- This is the same operation as 'breakElem LF' dropping the last character of the
+-- string if it's a CR.
+--
+-- Also for efficiency reason (streaming), it returns if the last character was a CR character.
+breakLine :: String -> Either Bool (String, String)
+breakLine (String arr) = bimap String String <$> Vec.breakLine arr
 
 -- | Apply a @predicate@ to the string to return the longest prefix that satisfy the predicate and
 -- the remaining

--- a/tests/Test/Foundation/String.hs
+++ b/tests/Test/Foundation/String.hs
@@ -96,6 +96,22 @@ testStringCases =
             , testCase "30 31 E2 82 0C" $ expectFromBytesErr UTF8 ("01", Just InvalidContinuation, 2) (fromList [0x30,0x31,0xE2,0x82,0x0c])
             ]
         ]
+    , testGroup "Lines"
+        [ testCase "Hello<LF>Foundation" $
+            (breakLine "Hello\nFoundation" @?= Right ("Hello", "Foundation"))
+        , testCase "Hello<CRLF>Foundation" $
+            (breakLine "Hello\r\nFoundation" @?= Right ("Hello", "Foundation"))
+        , testCase "Hello<LF>Foundation" $
+            (breakLine (drop 5 "Hello\nFoundation\nSomething") @?= Right ("", "Foundation\nSomething"))
+        , testCase "Hello<CR>" $
+            (breakLine "Hello\r" @?= Left True)
+        , testCase "CR" $
+            (breakLine "\r" @?= Left True)
+        , testCase "LF" $
+            (breakLine "\n" @?= Right ("", ""))
+        , testCase "empty" $
+            (breakLine "" @?= Left False)
+        ]
     ]
 
 testAsciiStringCases :: [TestTree]


### PR DESCRIPTION
remove CR preceding LR by default. fix #331.

related to #332 too