### PR TITLE
Difference of count returns maybe

### DIFF
--- a/Foundation/Array/Chunked/Unboxed.hs
+++ b/Foundation/Array/Chunked/Unboxed.hs
@@ -231,10 +231,14 @@ splitAt n c@(ChunkedUArray spine)
                     )
 
 revTake :: PrimType ty => CountOf ty -> ChunkedUArray ty -> ChunkedUArray ty
-revTake n c = drop (length c - n) c
+revTake n c = case length c - n of
+    Nothing -> c
+    Just elems -> drop elems c
 
 revDrop :: PrimType ty => CountOf ty -> ChunkedUArray ty -> ChunkedUArray ty
-revDrop n c = take (length c - n) c
+revDrop n c = case length c - n of
+    Nothing -> empty
+    Just keepElems -> take keepElems c
 
 -- TODO: Improve implementation.
 splitOn :: PrimType ty => (ty -> Bool) -> ChunkedUArray ty -> [ChunkedUArray ty]

--- a/Foundation/Array/Unboxed.hs
+++ b/Foundation/Array/Unboxed.hs
@@ -413,9 +413,8 @@ breakLine :: UArray Word8 -> Either Bool (UArray Word8, UArray Word8)
 breakLine arr@(UArray start len backend)
     | end == start = Left False
     | k2 == end    = Left (k1 /= k2)
-    | k2 == start  = Right (empty, if k2 + 1 == end then empty else unsafeDrop 1 arr)
-    | otherwise    = Right ( unsafeTake (offsetAsSize k1 `sizeSub` offsetAsSize start) arr
-                           , if k2+1 == end then empty else UArray (k2+1) (len `sizeSub` (offsetAsSize (k2+1) `sizeSub` offsetAsSize start)) backend)
+    | otherwise    = let newArray start' len' = if len' == 0 then empty else UArray start' len' backend
+                      in Right (newArray start (k1-start), newArray (k2+1) (end - (k2+1)))
   where
     !end = start `offsetPlusE` len
     -- return (offset of CR, offset of LF, whether the last element was a carriage return

--- a/Foundation/Array/Unboxed.hs
+++ b/Foundation/Array/Unboxed.hs
@@ -423,11 +423,11 @@ breakLine arr@(UArray start len backend)
     carriageReturn = 0xd
     goBa ba =
         let k = sysHsMemFindByteBa ba start end lineFeed
-            cr = if k > start then PrimBA.primIndex ba (k `offsetSub` 1) == carriageReturn else False
+            cr = k > start && PrimBA.primIndex ba (k `offsetSub` 1) == carriageReturn
          in (if cr then k `offsetSub` 1 else k, k)
     goAddr _ (Ptr addr) =
         let k = sysHsMemFindByteAddr addr start end lineFeed
-            cr = if k > start then PrimAddr.primIndex addr (k `offsetSub` 1) == carriageReturn else False
+            cr = k > start && PrimAddr.primIndex addr (k `offsetSub` 1) == carriageReturn
          in (if cr then k `offsetSub` 1 else k, k)
 
 -- inverse a CountOf that is specified from the end (e.g. take n elements from the end)

--- a/Foundation/Array/Unboxed/Mutable.hs
+++ b/Foundation/Array/Unboxed/Mutable.hs
@@ -101,11 +101,12 @@ sub :: (PrimMonad prim, PrimType ty)
     -> prim (MUArray ty (PrimState prim))
 sub (MUArray start sz back) dropElems' takeElems
     | takeElems <= 0 = empty
-    | resultEmpty    = empty
-    | otherwise      = pure $ MUArray (start `offsetPlusE` dropElems) (min (CountOf takeElems) (sz - dropElems)) back
+    | Just keepElems <- sz - dropElems, keepElems > 0 
+                     = pure $ MUArray (start `offsetPlusE` dropElems) (min (CountOf takeElems) keepElems) back
+    | otherwise      = empty
   where
     dropElems = max 0 (CountOf dropElems')
-    resultEmpty = dropElems >= sz
+
 
 -- | return the numbers of elements in a mutable array
 mutableLength :: PrimType ty => MUArray ty st -> CountOf ty

--- a/Foundation/Check/Main.hs
+++ b/Foundation/Check/Main.hs
@@ -231,7 +231,7 @@ pushGroup name list = do
     whenGroupOnly $ if groupHasSubGroup list then displayCurrent name else return ()
     withState $ \s -> ((), s { testPath = push (testPath s) name, indent = indent s + 2 })
     results <- mapM test list
-    withState $ \s -> ((), s { testPath = pop (testPath s), indent = indent s - 2 })
+    withState $ \s -> ((), s { testPath = pop (testPath s), indent = indent s `sizeSub` 2 })
     let totFail = sum $ fmap nbFail results
         tot = sum $ fmap nbTests results
     whenGroupOnly $ case (groupHasSubGroup list, totFail) of

--- a/Foundation/Collection/Sequential.hs
+++ b/Foundation/Collection/Sequential.hs
@@ -178,19 +178,11 @@ class (IsList c, Item c ~ Element c, Monoid c, Collection c) => Sequential c whe
     -- | Takes two collections and returns True iff the first collection is an infix of the second.
     isInfixOf :: Eq (Element c) => c -> c -> Bool
     default isInfixOf :: Eq c => c -> c -> Bool
-    isInfixOf c1 c2
-        | len1 > len2  = False
-        | otherwise    = loop 0
-      where
-        endofs = len2 - len1
-        len1 = length c1
-        len2 = length c2
-
-        loop i
-            | i == endofs = c1 == c2Sub
-            | c1 == c2Sub = True
-            | otherwise   = loop (succ i)
-          where c2Sub = take len1 $ drop i c2
+    isInfixOf c1 c2 = loop (len2 - len1) c2
+      where len1 = length c1
+            len2 = length c2
+            loop (Just cnt) c2' = c1 == take len1 c2' || loop (cnt - 1) (drop 1 c2')
+            loop Nothing    _   = False
 
     -- | Try to strip a prefix from a collection
     stripPrefix :: Eq (Element c) => c -> c -> Maybe c

--- a/Foundation/Parser.hs
+++ b/Foundation/Parser.hs
@@ -226,7 +226,7 @@ failure _ _ _ = ParseFailed
 success :: ParserSource input => input -> Offset (Element input) -> NoMore -> r -> Result input r
 success buf off _ = ParseOk rest
   where
-    !rest = subChunk buf off (length buf - offsetAsSize off)
+    !rest = subChunk buf off (length buf `sizeSub` offsetAsSize off)
 {-# INLINE success #-}
 
 -- | parse only the given input
@@ -360,12 +360,11 @@ take n = Parser $ \buf off nm err ok ->
     let lenI = sizeAsOffset (length buf) - off
      in if endOfParserSource buf off && n > 0
        then err buf off nm $ NotEnough n
-       else if n <= lenI
-         then let t = subChunk buf off n
-               in ok buf (off + sizeAsOffset n) nm t
-         else let h = subChunk buf off lenI
-               in runParser_ (take $ n - lenI) buf (sizeAsOffset lenI) nm err $
-                    \buf' off' nm' t -> ok buf' off' nm' (h <> t)
+       else case n - lenI of
+              Just s | s > 0 -> let h = subChunk buf off lenI
+                                 in runParser_ (take s) buf (sizeAsOffset lenI) nm err $
+                                      \buf' off' nm' t -> ok buf' off' nm' (h <> t)
+              _              -> ok buf (off + sizeAsOffset n) nm (subChunk buf off n)
 
 takeWhile :: ( ParserSource input, Sequential (Chunk input)
              )
@@ -408,9 +407,9 @@ skip n = Parser $ \buf off nm err ok ->
     let lenI = sizeAsOffset (length buf) - off
      in if endOfParserSource buf off && n > 0
        then err buf off nm $ NotEnough n
-       else if n <= lenI
-         then ok buf (off + sizeAsOffset n) nm ()
-         else runParser_ (skip $ n - lenI) buf (sizeAsOffset lenI) nm err ok
+       else case n - lenI of
+              Just s | s > 0 -> runParser_ (skip s) buf (sizeAsOffset lenI) nm err ok
+              _              -> ok buf (off + sizeAsOffset n) nm ()
 
 skipWhile :: ( ParserSource input, Sequential (Chunk input)
              )

--- a/Foundation/Primitive/Types/OffsetSize.hs
+++ b/Foundation/Primitive/Types/OffsetSize.hs
@@ -186,8 +186,9 @@ instance Additive (CountOf ty) where
     (+) (CountOf a) (CountOf b) = CountOf (a+b)
 
 instance Subtractive (CountOf ty) where
-    type Difference (CountOf ty) = CountOf ty
-    (CountOf a) - (CountOf b) = CountOf (a-b)
+    type Difference (CountOf ty) = Maybe (CountOf ty)
+    (CountOf a) - (CountOf b) | a >= b    = Just . CountOf $ a - b
+                              | otherwise = Nothing
 
 instance Monoid (CountOf ty) where
     mempty = azero

--- a/Foundation/Primitive/Types/OffsetSize.hs
+++ b/Foundation/Primitive/Types/OffsetSize.hs
@@ -141,7 +141,7 @@ sizeCast _ (CountOf sz) = CountOf sz
 -- use the safer (-) version if unsure.
 sizeSub :: CountOf a -> CountOf a -> CountOf a
 sizeSub (CountOf m) (CountOf n)
-    | m > n     = CountOf diff
+    | diff >= 0 = CountOf diff
     | otherwise = error "sizeSub negative size"
   where
     diff = m - n

--- a/Foundation/String/ASCII.hs
+++ b/Foundation/String/ASCII.hs
@@ -160,14 +160,19 @@ splitAt n = bimap AsciiString AsciiString . Vec.splitAt n . toBytes
 -- we can process the string from the end using a skipPrev instead of getting the length
 
 revTake :: CountOf CUChar -> AsciiString -> AsciiString
-revTake nbElems v = drop (length v - nbElems) v
+revTake nbElems v = case length v - nbElems of
+    Nothing        -> v
+    Just dropElems -> drop dropElems v
 
 revDrop :: CountOf CUChar -> AsciiString -> AsciiString
-revDrop nbElems v = take (length v - nbElems) v
+revDrop nbElems v = case length v - nbElems of
+    Nothing        -> fromList []
+    Just keepElems -> take keepElems v
 
 revSplitAt :: CountOf CUChar -> AsciiString -> (AsciiString, AsciiString)
-revSplitAt n v = (drop idx v, take idx v)
-  where idx = length v - n
+revSplitAt n v =  case length v - n of
+   Nothing  -> (v         , fromList [])
+   Just idx -> (drop idx v, take idx v)
 
 -- | Split on the input string using the predicate as separator
 --

--- a/tests/Test/Checks/Property/Collection.hs
+++ b/tests/Test/Checks/Property/Collection.hs
@@ -278,6 +278,12 @@ testSequentialProperties proxy genElement = Group "Sequential"
         , Property "collection + empty" $ withElements $ \l1 ->
             isPrefixOf (fromListP proxy []) (fromListP proxy l1) === isPrefixOf [] l1
         ]
+    , Group "isInfixOf"
+        [ Property "b isInfixOf 'a b c'" $ with3Elements $ \(a, b, c) -> 
+            isInfixOf (toCol b) (toCol a <> toCol b <> toCol c)
+        , Property "the reverse is typically not an infix" $ withElements $ \a' ->
+            let a = toCol a'; rev = reverse a in isInfixOf rev a === (a == rev)
+        ]
     ]
 {-
     , testProperty "imap" $ \(CharMap (LUString u) i) ->
@@ -285,11 +291,13 @@ testSequentialProperties proxy genElement = Group "Sequential"
     ]
 -}
   where
+    toCol = fromListP proxy 
     toList2 (x,y) = (toList x, toList y)
     toListFirst (x,y) = (toList x, y)
     toListSecond (x,y) = (x, toList y)
     withElements f = forAll (generateListOfElement genElement) f
     with2Elements f = forAll ((,) <$> generateListOfElement genElement <*> generateListOfElement genElement) f
+    with3Elements f = forAll ((,,) <$> generateListOfElement genElement <*> generateListOfElement genElement <*> generateListOfElement genElement) f
     withElements2 f = forAll ((,) <$> generateListOfElement genElement <*> arbitrary) f
     withElements3 f = forAll ((,,) <$> generateListOfElement genElement <*> arbitrary <*> arbitrary) f
     withElements2E f = forAll ((,) <$> generateListOfElement genElement <*> genElement) f

--- a/tests/Test/Foundation/Collection.hs
+++ b/tests/Test/Foundation/Collection.hs
@@ -242,6 +242,12 @@ testSequentialOps proxy genElement = testGroup "Sequential"
         , testProperty "collection + empty" $ withElements $ \l1 ->
             isPrefixOf (fromListP proxy []) (fromListP proxy l1) === isPrefixOf [] l1
         ]
+    , testGroup "isInfixOf"
+        [ testProperty "b isInfixOf 'a b c'" $ with3Elements $ \(a, b, c) -> 
+            isInfixOf (toCol b) (toCol a <> toCol b <> toCol c)
+        , testProperty "the reverse is typically not an infix" $ withElements $ \a' ->
+            let a = toCol a'; rev = reverse a in isInfixOf rev a === (a == rev)
+        ]
     ]
 {-
     , testProperty "imap" $ \(CharMap (LUString u) i) ->
@@ -249,11 +255,13 @@ testSequentialOps proxy genElement = testGroup "Sequential"
     ]
 -}
   where
+    toCol = fromListP proxy
     toList2 (x,y) = (toList x, toList y)
     toListFirst (x,y) = (toList x, y)
     toListSecond (x,y) = (x, toList y)
     withElements f = forAll (generateListOfElement genElement) f
     with2Elements f = forAll ((,) <$> generateListOfElement genElement <*> generateListOfElement genElement) f
+    with3Elements f = forAll ((,,) <$> generateListOfElement genElement <*> generateListOfElement genElement <*> generateListOfElement genElement) f
     withElements2 f = forAll ((,) <$> generateListOfElement genElement <*> (CountOf <$> arbitrary)) f
     withElements3 f = forAll ((,,) <$> generateListOfElement genElement <*> (CountOf <$> arbitrary) <*> (CountOf <$> arbitrary)) f
     withElements2E f = forAll ((,) <$> generateListOfElement genElement <*> genElement) f

--- a/tests/Test/Foundation/Storable.hs
+++ b/tests/Test/Foundation/Storable.hs
@@ -125,14 +125,11 @@ data SomeWhereInArray a = SomeWhereInArray a Int Int
 instance (StorableFixed a, Arbitrary a) => Arbitrary (SomeWhereInArray a) where
     arbitrary = do
         a  <- arbitrary
-        let p = toProxy a
-            (CountOf minsz) = size p + (alignment p - size p)
+        let p = Proxy :: Proxy a
+            Just (CountOf minsz) = (size p + alignment p - size p)
         sz <- choose (minsz, 512)
         o  <- choose (0, sz - minsz)
         return $ SomeWhereInArray a sz o
-      where
-        toProxy :: a -> Proxy a
-        toProxy _ = Proxy
 
 testPropertyStorableFixedPeekOff :: (StorableFixed a, Foreign.Storable.Storable a, Arbitrary a, Eq a, Show a)
                          => Proxy a


### PR DESCRIPTION
I completed my work on #293 that I started at ZuriHac 2017 and I'm looking forward to your feedback.

The difference type for `CountOf` has been changed to `Maybe CountOf`. All affected uses of difference of CountOf now handle the Just/Noting cases explicitly or fallback on 'sizeSub' in case that the difference is known to be non-negative from the context. 

Hopefully, my assumption is correct that the difference of two equal `CountOf`s should result in `Just (CountOf 0)`. In fact, the existing implementation of `sizeSub` threw an error in that case, which probably was a bug, wasn't it? This has been corrected as well.

A test for the `isInfixOf` has been added as this function was not covered by tests yet.
Moreover, I think that the function `sub` in Array.Unboxed.Mutable.hs is not covered by test yet, but I was unsure where a test should be added.

Moreover, I wonder if the difference of `Offset`s should also return a `Maybe CountOf` (in Primitive.Types.OffsetSize.hs)? The current implementation ` (Offset a) - (Offset b) = CountOf (a-b)` might actually violate the non-negativity constraint of CountOf. Changing this would likely affect similar amount of places as the changes made so far. What do you think?

Finally, `offsetSub (Offset m) (Offset n) = Offset (m - n)` currently returns `Offset`. Shouldn't that return `CountOf` instead of `Offset`?