### PR TITLE
Add TypeInType language pragma to Basement.Error

### DIFF
--- a/basement/Basement/Error.hs
+++ b/basement/Basement/Error.hs
@@ -3,6 +3,9 @@
 {-# LANGUAGE ImplicitParams #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE CPP #-}
+#if __GLASGOW_HASKELL__ >= 800
+{-# LANGUAGE TypeInType #-}
+#endif
 module Basement.Error
     ( error
     ) where


### PR DESCRIPTION
This was required to compile on ghc head.

Haven't tested it on any other ghcs.

Feel free to close if you don't want this at this time.