### PR TITLE
Improve quicksort with alternative partitioning scheme

### DIFF
--- a/basement/Basement/UArray.hs
+++ b/basement/Basement/UArray.hs
@@ -625,9 +625,10 @@ sortBy xford vec
                 p <- partition lo hi
                 qsort lo (pred p)
                 qsort (p+1) hi
-        pivotStrategy lo hi = do
-            pivot <- unsafeRead ma hi
-            pure (hi, pivot)
+        pivotStrategy (Offset low) (Offset high) = do
+            let mid = Offset $ (low + high) `div` 2
+            pivot <- unsafeRead ma mid
+            pure (mid, pivot)
         partition lo hi = do
             (p, pivot) <- pivotStrategy lo hi
             -- RETURN: index of pivot with [<pivot | pivot | >=pivot]

--- a/basement/Basement/UArray.hs
+++ b/basement/Basement/UArray.hs
@@ -633,10 +633,13 @@ sortBy xford vec
                         aj <- unsafeRead ma j
                         i' <- if ford aj pivot == GT
                                 then pure i
-                                else do
-                                    ai <- unsafeRead ma i
-                                    unsafeWrite ma j ai
-                                    unsafeWrite ma i aj
+                                else do 
+                                    if i == j 
+                                        then pure ()
+                                        else do
+                                            ai <- unsafeRead ma i
+                                            unsafeWrite ma j ai
+                                            unsafeWrite ma i aj
                                     pure $ i + 1
                         loop i' (j+1)
 

--- a/benchs/Array.hs
+++ b/benchs/Array.hs
@@ -7,7 +7,7 @@ import Criterion.Main
 import qualified Prelude as P
 
 main = do
-    rndInput <- getRandomBytes 10000
+    rndInput <- getRandomBytes (CountOf n)
     defaultMain [ bgroup "Uarray"
         [ bench "fromList [Word8]" $ whnf (fromList :: [Word8] -> UArray Word8) [1..255]
         , bench "fromList [Word16]" $ whnf (fromList :: [Word16] -> UArray Word16) [1..1024]
@@ -19,8 +19,9 @@ main = do
         ]
       ]
   where
+    n = 100000
     input, inputLong :: UArray Word8
     input = fromList ([1..255] <> [1..255])
-    inputLong = fromList . P.take 10000 . P.cycle $ [1..255]
+    inputLong = fromList . P.take n . P.cycle $ [1..255]
 
     sort = F.sortBy compare

--- a/benchs/Array.hs
+++ b/benchs/Array.hs
@@ -1,16 +1,26 @@
 module Main (main) where
 
 import Foundation
+import Foundation.Random
 import Foundation.Collection as F
 import Criterion.Main
+import qualified Prelude as P
 
-main = defaultMain
-    [ bgroup "Uarray"
+main = do
+    rndInput <- getRandomBytes 10000
+    defaultMain [ bgroup "Uarray"
         [ bench "fromList [Word8]" $ whnf (fromList :: [Word8] -> UArray Word8) [1..255]
         , bench "fromList [Word16]" $ whnf (fromList :: [Word16] -> UArray Word16) [1..1024]
         , bench "break" $ whnf (F.break (== 255)) input
+        , bench "sort random"  $ whnf sort rndInput
+        , bench "sort sorted"  $ whnf sort (sort rndInput)
+        , bench "sort reverse" $ whnf sort (reverse.sort $ rndInput)
+        , bench "sort cyclic"  $ whnf sort inputLong
         ]
-    ]
+      ]
   where
-    input :: UArray Word8
+    input, inputLong :: UArray Word8
     input = fromList ([1..255] <> [1..255])
+    inputLong = fromList . P.take 10000 . P.cycle $ [1..255]
+
+    sort = F.sortBy compare


### PR DESCRIPTION
The current quicksort partition made more swaps and memory access than neccessary.
Especially sorted arrays suffered quite a lot as a benchmark with 10k elements showed.
One improvement is to avoid swaps when the two array positions were actually the same.

The new partitioning uses two cursors to identify elements to be swapped, by scanning from the left and the right, rather than one linear scan from left to right. This reduces the worst-case number of swaps (per partitioning) from n to n/2. Moreover, the new approach avoids multiple reads of the same index position.

The mean execution time from the criterion benchmark are added in the individual commits.
In summary, the runtime reduced from about 18ms to about 9ms on random elements and from over 3 seconds to less than 10milliseconds on pre-sorted data. The latter reduction is certainly also because of using the central element as pivot. However, even without changing the pivot strategy (i.e. using the right most element as pivot) the execution time on sorted arrays reduced to about 39ms.