### PR TITLE
avoid duplicate inplaceSortBy code

### DIFF
--- a/basement/Basement/Alg/Foreign/Prim.hs
+++ b/basement/Basement/Alg/Foreign/Prim.hs
@@ -6,7 +6,6 @@ module Basement.Alg.Foreign.Prim
     , primIndex64
     , primRead
     , primWrite
-    , primReadWrite
     ) where
 
 import           GHC.Types
@@ -34,7 +33,3 @@ primRead = primAddrRead
 primWrite :: (PrimMonad prim, PrimType ty) => Mutable (PrimState prim) -> Offset ty -> ty -> prim ()
 primWrite = primAddrWrite
 {-# INLINE primWrite #-}
-
-primReadWrite :: (PrimMonad prim, PrimType ty) => Mutable (PrimState prim) -> ((Offset ty -> prim ty), (Offset ty -> ty -> prim ()))
-primReadWrite addr = (primAddrRead addr, primAddrWrite addr)
-{-# INLINE primReadWrite #-}

--- a/basement/Basement/Alg/Foreign/Prim.hs
+++ b/basement/Basement/Alg/Foreign/Prim.hs
@@ -6,6 +6,7 @@ module Basement.Alg.Foreign.Prim
     , primIndex64
     , primRead
     , primWrite
+    , primReadWrite
     ) where
 
 import           GHC.Types
@@ -33,3 +34,7 @@ primRead = primAddrRead
 primWrite :: (PrimMonad prim, PrimType ty) => Mutable (PrimState prim) -> Offset ty -> ty -> prim ()
 primWrite = primAddrWrite
 {-# INLINE primWrite #-}
+
+primReadWrite :: (PrimMonad prim, PrimType ty) => Mutable (primState prim) -> ((Offset ty -> prim ty), (Offset ty -> ty -> prim ()))
+primReadWrite addr = (primAddrRead addr, primAddrWrite addr)
+{-# INLINE primReadWrite #-}

--- a/basement/Basement/Alg/Foreign/Prim.hs
+++ b/basement/Basement/Alg/Foreign/Prim.hs
@@ -35,6 +35,6 @@ primWrite :: (PrimMonad prim, PrimType ty) => Mutable (PrimState prim) -> Offset
 primWrite = primAddrWrite
 {-# INLINE primWrite #-}
 
-primReadWrite :: (PrimMonad prim, PrimType ty) => Mutable (primState prim) -> ((Offset ty -> prim ty), (Offset ty -> ty -> prim ()))
+primReadWrite :: (PrimMonad prim, PrimType ty) => Mutable (PrimState prim) -> ((Offset ty -> prim ty), (Offset ty -> ty -> prim ()))
 primReadWrite addr = (primAddrRead addr, primAddrWrite addr)
 {-# INLINE primReadWrite #-}

--- a/basement/Basement/Alg/Foreign/PrimArray.hs
+++ b/basement/Basement/Alg/Foreign/PrimArray.hs
@@ -15,7 +15,6 @@ module Basement.Alg.Foreign.PrimArray
     , any
     , filter
     , primIndex
-    , inplaceSortBy
     ) where
 
 import           GHC.Types
@@ -123,57 +122,3 @@ any predicate ba start end = loop start
         | predicate (primIndex ba i) = True
         | otherwise                  = loop (i+1)
 {-# INLINE any #-}
-
-inplaceSortBy :: (PrimType ty, PrimMonad prim)
-              => (ty -> ty -> Ordering)
-              -> Mutable (PrimState prim)
-              -> Offset ty
-              -> Offset ty
-              -> prim ()
-inplaceSortBy ford ma start end = qsort start (end `offsetSub` 1)
-  where
-    qsort lo hi
-        | lo >= hi  = pure ()
-        | otherwise = do
-            p <- partition lo hi
-            qsort lo (pred p)
-            qsort (p+1) hi
-    pivotStrategy (Offset low) hi@(Offset high) = do
-        let mid = Offset $ (low + high) `div` 2
-        pivot <- primRead ma mid
-        primRead ma hi >>= primWrite ma mid
-        primWrite ma hi pivot -- move pivot @ pivotpos := hi
-        pure pivot
-    partition lo hi = do
-        pivot <- pivotStrategy lo hi
-        -- RETURN: index of pivot with [<pivot | pivot | >=pivot]
-        -- INVARIANT: i & j are valid array indices; pivotpos==hi
-        let go i j = do
-                -- INVARIANT: k <= pivotpos
-                let fw k = do ak <- primRead ma k
-                              if ford ak pivot == LT
-                                then fw (k+1)
-                                else pure (k, ak)
-                (i, ai) <- fw i -- POST: ai >= pivot
-                -- INVARIANT: k >= i
-                let bw k | k==i = pure (i, ai)
-                         | otherwise = do ak <- primRead ma k
-                                          if ford ak pivot /= LT
-                                            then bw (pred k)
-                                            else pure (k, ak)
-                (j, aj) <- bw j -- POST: i==j OR (aj<pivot AND j<pivotpos)
-                -- POST: ai>=pivot AND (i==j OR aj<pivot AND (j<pivotpos))
-                if i < j
-                    then do -- (ai>=p AND aj<p) AND (i<j<pivotpos)
-                        -- swap two non-pivot elements and proceed
-                        primWrite ma i aj
-                        primWrite ma j ai
-                        -- POST: (ai < pivot <= aj)
-                        go (i+1) (pred j)
-                    else do -- ai >= pivot
-                        -- complete partitioning by swapping pivot to the center
-                        primWrite ma hi ai
-                        primWrite ma i pivot
-                        pure i
-        go lo hi
-{-# INLINE inplaceSortBy #-}

--- a/basement/Basement/Alg/Native/Prim.hs
+++ b/basement/Basement/Alg/Native/Prim.hs
@@ -6,7 +6,6 @@ module Basement.Alg.Native.Prim
     , primIndex64
     , primRead
     , primWrite
-    , primReadWrite
     ) where
 
 import           GHC.Types
@@ -34,7 +33,3 @@ primRead = primMbaRead
 primWrite :: (PrimMonad prim, PrimType ty) => Mutable (PrimState prim) -> Offset ty -> ty -> prim ()
 primWrite = primMbaWrite
 {-# INLINE primWrite #-}
-
-primReadWrite :: (PrimMonad prim, PrimType ty) => MutableByteArray# (PrimState prim) -> ((Offset ty -> prim ty), (Offset ty -> ty -> prim ()))
-primReadWrite mba = (primMbaRead mba, primMbaWrite mba)
-{-# INLINE primReadWrite #-}

--- a/basement/Basement/Alg/Native/Prim.hs
+++ b/basement/Basement/Alg/Native/Prim.hs
@@ -6,6 +6,7 @@ module Basement.Alg.Native.Prim
     , primIndex64
     , primRead
     , primWrite
+    , primReadWrite
     ) where
 
 import           GHC.Types
@@ -33,3 +34,7 @@ primRead = primMbaRead
 primWrite :: (PrimMonad prim, PrimType ty) => Mutable (PrimState prim) -> Offset ty -> ty -> prim ()
 primWrite = primMbaWrite
 {-# INLINE primWrite #-}
+
+primReadWrite :: (PrimMonad prim, PrimType ty) => MutableByteArray# (PrimState prim) -> ((Offset ty -> prim ty), (Offset ty -> ty -> prim ()))
+primReadWrite mba = (primMbaRead mba, primMbaWrite mba)
+{-# INLINE primReadWrite #-}

--- a/basement/Basement/Algorithm.hs
+++ b/basement/Basement/Algorithm.hs
@@ -1,0 +1,69 @@
+module Basement.Algorithm
+    ( inplaceSortBy
+    ) where
+
+import           GHC.Types
+import           GHC.Prim
+import           Basement.Compat.Base
+import           Basement.Numerical.Additive
+import           Basement.Numerical.Multiplicative
+import           Basement.Types.OffsetSize
+import           Basement.PrimType
+import           Basement.Monad
+
+inplaceSortBy :: (PrimType ty, PrimMonad prim) 
+              => (ty -> ty -> Ordering)
+              -- ^ Function defining the ordering relationship
+              -> (Offset ty) -- ^ Offset to first element to sort
+              -> (CountOf ty) -- ^ Number of elements to sort
+              -> ((Offset ty -> prim ty), (Offset ty  -> ty -> prim ()))
+              -- ^ Pair of read and write actions for a given offset
+              -> prim ()
+inplaceSortBy ford start len (unsafeRead, unsafeWrite) 
+    = qsort start (start `offsetPlusE` len `offsetSub` 1)
+    where
+        qsort lo hi
+            | lo >= hi  = pure ()
+            | otherwise = do
+                p <- partition lo hi
+                qsort lo (pred p)
+                qsort (p+1) hi
+        pivotStrategy (Offset low) hi@(Offset high) = do
+            let mid = Offset $ (low + high) `div` 2
+            pivot <- unsafeRead mid
+            unsafeRead hi >>= unsafeWrite mid
+            unsafeWrite hi pivot -- move pivot @ pivotpos := hi
+            pure pivot
+        partition lo hi = do
+            pivot <- pivotStrategy lo hi
+            -- RETURN: index of pivot with [<pivot | pivot | >=pivot]
+            -- INVARIANT: i & j are valid array indices; pivotpos==hi
+            let go i j = do
+                    -- INVARIANT: k <= pivotpos
+                    let fw k = do ak <- unsafeRead k
+                                  if ford ak pivot == LT 
+                                    then fw (k+1)
+                                    else pure (k, ak)
+                    (i, ai) <- fw i -- POST: ai >= pivot
+                    -- INVARIANT: k >= i
+                    let bw k | k==i = pure (i, ai)
+                             | otherwise = do ak <- unsafeRead k
+                                              if ford ak pivot /= LT
+                                                then bw (pred k)
+                                                else pure (k, ak)
+                    (j, aj) <- bw j -- POST: i==j OR (aj<pivot AND j<pivotpos)
+                    -- POST: ai>=pivot AND (i==j OR aj<pivot AND (j<pivotpos))
+                    if i < j
+                        then do -- (ai>=p AND aj<p) AND (i<j<pivotpos)
+                            -- swap two non-pivot elements and proceed
+                            unsafeWrite i aj
+                            unsafeWrite j ai
+                            -- POST: (ai < pivot <= aj)
+                            go (i+1) (pred j)
+                        else do -- ai >= pivot 
+                            -- complete partitioning by swapping pivot to the center
+                            unsafeWrite hi ai 
+                            unsafeWrite i pivot
+                            pure i
+            go lo hi
+{-# INLINE inplaceSortBy #-}

--- a/basement/Basement/Algorithm.hs
+++ b/basement/Basement/Algorithm.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
 module Basement.Algorithm
     ( RandomAccess, read, write
     , inplaceSortBy
@@ -12,16 +13,16 @@ import           Basement.Types.OffsetSize
 import           Basement.PrimType
 import           Basement.Monad
 
-class RandomAccess a where
-    read  :: (PrimType ty, PrimMonad prim) => a (PrimState prim) -> (Offset ty) -> prim ty
-    write :: (PrimType ty, PrimMonad prim) => a (PrimState prim) -> (Offset ty) -> ty -> prim ()
+class RandomAccess a ty where
+    read  :: PrimMonad prim => a ty (PrimState prim) -> (Offset ty)       -> prim ty
+    write :: PrimMonad prim => a ty (PrimState prim) -> (Offset ty) -> ty -> prim ()
 
-inplaceSortBy :: (PrimType ty, PrimMonad prim, RandomAccess a) 
+inplaceSortBy :: (PrimMonad prim, RandomAccess a ty) 
               => (ty -> ty -> Ordering)
               -- ^ Function defining the ordering relationship
               -> (Offset ty) -- ^ Offset to first element to sort
               -> (CountOf ty) -- ^ Number of elements to sort
-              -> a (PrimState prim) -- ^ Data to be sorted
+              -> a ty (PrimState prim) -- ^ Data to be sorted
               -> prim ()
 inplaceSortBy ford start len mvec
     = qsort start (start `offsetPlusE` len `offsetSub` 1)

--- a/basement/Basement/Algorithm.hs
+++ b/basement/Basement/Algorithm.hs
@@ -13,16 +13,16 @@ import           Basement.Types.OffsetSize
 import           Basement.PrimType
 import           Basement.Monad
 
-class RandomAccess a ty where
-    read  :: PrimMonad prim => a ty (PrimState prim) -> (Offset ty)       -> prim ty
-    write :: PrimMonad prim => a ty (PrimState prim) -> (Offset ty) -> ty -> prim ()
+class RandomAccess container prim ty where
+    read  :: container -> (Offset ty)       -> prim ty
+    write :: container -> (Offset ty) -> ty -> prim ()
 
-inplaceSortBy :: (PrimMonad prim, RandomAccess a ty) 
+inplaceSortBy :: (PrimMonad prim, RandomAccess container prim ty) 
               => (ty -> ty -> Ordering)
               -- ^ Function defining the ordering relationship
               -> (Offset ty) -- ^ Offset to first element to sort
               -> (CountOf ty) -- ^ Number of elements to sort
-              -> a ty (PrimState prim) -- ^ Data to be sorted
+              -> container -- ^ Data to be sorted
               -> prim ()
 inplaceSortBy ford start len mvec
     = qsort start (start `offsetPlusE` len `offsetSub` 1)

--- a/basement/Basement/Block.hs
+++ b/basement/Basement/Block.hs
@@ -84,7 +84,8 @@ import qualified Basement.Alg.Native.PrimArray as Alg
 import qualified Basement.Alg.Native.Prim as Prim
 import qualified Basement.Algorithm as Algorithm
 
-instance PrimType ty => Algorithm.RandomAccess MutableBlock ty where
+instance (PrimMonad prim, st ~ PrimState prim, PrimType ty) 
+         => Algorithm.RandomAccess (MutableBlock ty st) prim ty where
     read (MutableBlock mba) = primMbaRead mba
     write (MutableBlock mba) = primMbaWrite mba
 

--- a/basement/Basement/Block.hs
+++ b/basement/Basement/Block.hs
@@ -14,6 +14,8 @@
 {-# LANGUAGE MagicHash           #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE UnboxedTuples       #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleInstances #-}
 module Basement.Block
     ( Block(..)
     , MutableBlock(..)
@@ -82,7 +84,7 @@ import qualified Basement.Alg.Native.PrimArray as Alg
 import qualified Basement.Alg.Native.Prim as Prim
 import qualified Basement.Algorithm as Algorithm
 
-instance Algorithm.RandomAccess (MutableBlock ty) where
+instance PrimType ty => Algorithm.RandomAccess MutableBlock ty where
     read (MutableBlock mba) = primMbaRead mba
     write (MutableBlock mba) = primMbaWrite mba
 

--- a/basement/Basement/Block.hs
+++ b/basement/Basement/Block.hs
@@ -82,6 +82,10 @@ import qualified Basement.Alg.Native.PrimArray as Alg
 import qualified Basement.Alg.Native.Prim as Prim
 import qualified Basement.Algorithm as Algorithm
 
+instance Algorithm.RandomAccess (MutableBlock ty) where
+    read (MutableBlock mba) = primMbaRead mba
+    write (MutableBlock mba) = primMbaWrite mba
+
 -- | Copy all the block content to the memory starting at the destination address
 unsafeCopyToPtr :: forall ty prim . PrimMonad prim
                 => Block ty -- ^ the source block to copy
@@ -357,7 +361,7 @@ sortBy ford vec
     | len == 0  = mempty
     | otherwise = runST $ do
         mblock@(MutableBlock mba) <- thaw vec
-        Algorithm.inplaceSortBy ford 0 len (Prim.primReadWrite mba)
+        Algorithm.inplaceSortBy ford 0 len mblock
         unsafeFreeze mblock
   where len = length vec
 {-# SPECIALIZE [2] sortBy :: (Word8 -> Word8 -> Ordering) -> Block Word8 -> Block Word8 #-}

--- a/basement/Basement/Block.hs
+++ b/basement/Basement/Block.hs
@@ -79,6 +79,8 @@ import           Basement.Block.Base
 import           Basement.Numerical.Additive
 import           Basement.Numerical.Subtractive
 import qualified Basement.Alg.Native.PrimArray as Alg
+import qualified Basement.Alg.Native.Prim as Prim
+import qualified Basement.Algorithm as Algorithm
 
 -- | Copy all the block content to the memory starting at the destination address
 unsafeCopyToPtr :: forall ty prim . PrimMonad prim
@@ -355,7 +357,7 @@ sortBy ford vec
     | len == 0  = mempty
     | otherwise = runST $ do
         mblock@(MutableBlock mba) <- thaw vec
-        Alg.inplaceSortBy ford mba 0 (sizeAsOffset len)
+        Algorithm.inplaceSortBy ford 0 len (Prim.primReadWrite mba)
         unsafeFreeze mblock
   where len = length vec
 {-# SPECIALIZE [2] sortBy :: (Word8 -> Word8 -> Ordering) -> Block Word8 -> Block Word8 #-}

--- a/basement/Basement/BoxedArray.hs
+++ b/basement/Basement/BoxedArray.hs
@@ -594,7 +594,8 @@ find predicate vec = loop 0
             let e = unsafeIndex vec i
              in if predicate e then Just e else loop (i+1)
 
-instance Algorithm.RandomAccess MArray ty where
+instance (PrimMonad prim, st ~ PrimState prim) 
+         => Algorithm.RandomAccess (MArray ty st) prim ty where
     read (MArray _ _ mba) = primMutableArrayRead mba
     write (MArray _ _ mba) = primMutableArrayWrite mba
 

--- a/basement/Basement/BoxedArray.hs
+++ b/basement/Basement/BoxedArray.hs
@@ -11,6 +11,8 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleInstances #-}
 module Basement.BoxedArray
     ( Array
     , MArray
@@ -77,6 +79,7 @@ import           Basement.Numerical.Subtractive
 import           Basement.NonEmpty
 import           Basement.Compat.Base
 import           Data.Proxy
+import qualified Basement.Algorithm as Algorithm
 import           Basement.Compat.MonadTrans
 import           Basement.Types.OffsetSize
 import           Basement.PrimType
@@ -591,6 +594,10 @@ find predicate vec = loop 0
             let e = unsafeIndex vec i
              in if predicate e then Just e else loop (i+1)
 
+instance Algorithm.RandomAccess MArray ty where
+    read (MArray _ _ mba) = primMutableArrayRead mba
+    write (MArray _ _ mba) = primMutableArrayWrite mba
+
 sortBy :: forall ty . (ty -> ty -> Ordering) -> Array ty -> Array ty
 sortBy xford vec
     | len == 0  = empty
@@ -598,35 +605,7 @@ sortBy xford vec
   where
     len = length vec
     doSort :: PrimMonad prim => (ty -> ty -> Ordering) -> MArray ty (PrimState prim) -> prim (Array ty)
-    doSort ford ma = qsort 0 (sizeLastOffset len) >> unsafeFreeze ma
-      where
-        qsort lo hi
-            | lo >= hi  = pure ()
-            | otherwise = do
-                p <- partition lo hi
-                qsort lo (pred p)
-                qsort (p+1) hi
-        partition lo hi = do
-            pivot <- unsafeRead ma hi
-            let loop i j
-                    | j == hi   = pure i
-                    | otherwise = do
-                        aj <- unsafeRead ma j
-                        i' <- if ford aj pivot == GT
-                                then pure i
-                                else do
-                                    ai <- unsafeRead ma i
-                                    unsafeWrite ma j ai
-                                    unsafeWrite ma i aj
-                                    pure $ i + 1
-                        loop i' (j+1)
-
-            i <- loop lo lo
-            ai  <- unsafeRead ma i
-            ahi <- unsafeRead ma hi
-            unsafeWrite ma hi ai
-            unsafeWrite ma i ahi
-            pure i
+    doSort ford ma = Algorithm.inplaceSortBy ford 0 len ma >> unsafeFreeze ma
 
 filter :: forall ty . (ty -> Bool) -> Array ty -> Array ty
 filter predicate vec = runST (new len >>= copyFilterFreeze predicate (unsafeIndex vec))

--- a/basement/Basement/UArray.hs
+++ b/basement/Basement/UArray.hs
@@ -131,8 +131,11 @@ import           Basement.MutableBuilder
 import           Basement.Bindings.Memory (sysHsMemFindByteBa, sysHsMemFindByteAddr)
 import qualified Basement.Compat.ExtList as List
 import qualified Basement.Base16 as Base16
+import qualified Basement.Alg.Native.Prim as PrimBA
 import qualified Basement.Alg.Native.PrimArray as PrimBA
+import qualified Basement.Alg.Foreign.Prim as PrimAddr
 import qualified Basement.Alg.Foreign.PrimArray as PrimAddr
+import qualified Basement.Algorithm as Algorithm
 
 -- | Copy every cells of an existing array to a new array
 copy :: PrimType ty => UArray ty -> UArray ty
@@ -651,13 +654,12 @@ sortBy ford vec = runST $ do
     unsafeFreeze mvec
   where
     !len = length vec
-    !end = 0 `offsetPlusE` len
     !start = offset vec
 
     goNative :: MutableByteArray# (PrimState (ST s)) -> ST s ()
-    goNative mba = PrimBA.inplaceSortBy ford mba start end
+    goNative mba = Algorithm.inplaceSortBy ford start len (PrimBA.primReadWrite mba)
     goAddr :: Ptr ty -> ST s ()
-    goAddr (Ptr addr) = PrimAddr.inplaceSortBy ford addr start end
+    goAddr (Ptr addr) = Algorithm.inplaceSortBy ford start len (PrimAddr.primReadWrite addr)
 {-# SPECIALIZE [3] sortBy :: (Word8 -> Word8 -> Ordering) -> UArray Word8 -> UArray Word8 #-}
 
 filter :: forall ty . PrimType ty => (ty -> Bool) -> UArray ty -> UArray ty

--- a/basement/Basement/UArray.hs
+++ b/basement/Basement/UArray.hs
@@ -13,6 +13,8 @@
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE Rank2Types #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleInstances #-}
 module Basement.UArray
     ( UArray(..)
     , PrimType(..)
@@ -139,7 +141,7 @@ import qualified Basement.Algorithm as Algorithm
 
 data PtrSt ty st = PtrSt Addr#
 
-instance Algorithm.RandomAccess (PtrSt ty) where
+instance PrimType ty => Algorithm.RandomAccess PtrSt ty where
     read (PtrSt addr) = PrimAddr.primRead addr
     write (PtrSt addr) = PrimAddr.primWrite addr
 

--- a/basement/basement.cabal
+++ b/basement/basement.cabal
@@ -90,6 +90,8 @@ library
 
                      Basement.Utils
 
+                     Basement.Algorithm
+
                      Basement.Alg.Native.Prim
                      Basement.Alg.Native.UTF8
                      Basement.Alg.Native.String

--- a/benchs/BenchUtil/RefData.hs
+++ b/benchs/BenchUtil/RefData.hs
@@ -11,10 +11,11 @@ module BenchUtil.RefData
     , rdBytes20
     , rdBytes200
     , rdBytes2000
+    , rdWord32
     ) where
 
-import Prelude (Char, cycle, take, ($))
-import Data.Word (Word8)
+import Prelude (Int, Char, cycle, take, ($))
+import Data.Word (Word8, Word32)
 
 rdLoremIpsum1 :: [Char]
 rdLoremIpsum1 = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam ornare dui vitae porta varius. In quis diam sed felis elementum ultricies non sit amet lorem. Nullam ut erat varius lectus scelerisque iaculis sed eu leo. Vivamus gravida interdum elit suscipit tempus. Quisque at mauris ac sapien consequat feugiat. In varius interdum rhoncus. Etiam hendrerit pharetra consectetur. Pellentesque laoreet, nisi quis feugiat rhoncus, nisi ipsum tincidunt nulla, vel fermentum mauris nisl sed felis. Sed ac convallis nibh. Donec rutrum finibus odio et rhoncus. Suspendisse pulvinar ex ac fermentum fermentum. Nam dui dui, lobortis sit amet sapien sed, gravida sagittis magna. Vestibulum nec egestas dui, non efficitur lectus. Fusce vitae mattis sem, nec dignissim nibh. Sed ac tincidunt metus."
@@ -42,3 +43,6 @@ rdBytes200 = take 200 $ cycle [1..255]
 
 rdBytes2000 :: [Word8]
 rdBytes2000 = take 2000 $ cycle [1..255]
+
+rdWord32 :: Int -> [Word32]
+rdWord32 n = Prelude.take n $ Prelude.cycle [1..255]

--- a/benchs/Main.hs
+++ b/benchs/Main.hs
@@ -177,6 +177,7 @@ benchsByteArray = bgroup "ByteArray"
     , benchFilter
     , benchAll
     , benchSort
+    , benchSort32
     ]
   where
     diffByteArray :: (UArray Word8 -> a)
@@ -275,6 +276,21 @@ benchsByteArray = bgroup "ByteArray"
             blockBench dat = sortBy compare dat
             uarrayBench :: UArray Word8 -> UArray Word8
             uarrayBench dat = sortBy compare dat
+    
+    benchSort32 = bgroup "Sort32" $ fmap (\n ->
+        bgroup (show n) $ 
+            [ bench "Array_W32" $ whnf arrayBench (fromList $ rdWord32 n)
+            , bench "UArray_W32" $ whnf uarrayBench (fromList $ rdWord32 n)
+            , bench "Block_W32" $ whnf blockBench (fromList $ rdWord32 n)
+            ]) [20, 200, 2000]
+      where
+            blockBench :: Block Word32 -> Block Word32
+            blockBench dat = sortBy compare dat
+            uarrayBench :: UArray Word32 -> UArray Word32
+            uarrayBench dat = sortBy compare dat
+            arrayBench :: Array Word32 -> Array Word32
+            arrayBench dat = sortBy compare dat
+
 
 --------------------------------------------------------------------------
 


### PR DESCRIPTION
By passing a pair of read & write actions to `inplaceSortBy` the algorithm becomes independent of the underlying representation (Native/Foreign), while still sorting the arrays with specialized code. The benchmark 'types/ByteArray/Sort' showed the same execution time (before and after the change). Hence, we can avoid the duplication of the sort logic. I guess the same idea could be applied to other functions in the `Basement.Alg.*` module. @vincenthz What do you think about that approach?

