### PR TITLE
Adjust includes in foundation_random.c to work with both libc and musl

### DIFF
--- a/cbits/foundation_random.c
+++ b/cbits/foundation_random.c
@@ -10,8 +10,7 @@
 
 #if defined(FOUNDATION_SYSTEM_LINUX)
 #include <sys/syscall.h>
-#include <linux/types.h>
-#include <linux/random.h>
+#include <sys/types.h>
 #include <unistd.h>
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE


### PR DESCRIPTION
This fixes #393

Test process was to set Stack resolver to lts-9.2, then build with "--docker", thereby using the default (libc) fpco linux image. Then the build was repeated using a musl-based docker image produced with the following Dockerfile:

FROM alpine:latest
RUN apk add ghc musl-dev shadow

Both builds succeeded.