### PR TITLE
Touch the bytearray after the action in uarray's withPtr when pinned

### DIFF
--- a/Foundation/Time/StopWatch.hs
+++ b/Foundation/Time/StopWatch.hs
@@ -58,7 +58,7 @@ initPrecise = unsafePerformIO $ do
     let p32 = castPtr p :: Ptr Word32
     !n <- peek (p32 `ptrPlus` ofs_MachTimebaseInfo_numer)
     !d <- peek (p32 `ptrPlus` ofs_MachTimebaseInfo_denom)
-    -- touch mti ..
+    mutableTouch mti
     pure (integralUpsize n, integralUpsize d)
 {-# NOINLINE initPrecise #-}
 #endif
@@ -91,6 +91,7 @@ stopPrecise (StopWatchPrecise blk) = do
     let p64 = castPtr p :: Ptr Word64
     end   <- peek p64
     start <- peek (p64 `ptrPlus` 8)
+    mutableTouch blk
     pure $ NanoSeconds ((end - start) * secondInNano `div` initPrecise)
 #elif defined(darwin_HOST_OS)
     end <- sysMacos_absolute_time
@@ -105,6 +106,7 @@ stopPrecise (StopWatchPrecise blk) = do
     startSec  <- peek (p64 `ptrPlusCSz` size_CTimeSpec)
     endNSec   <- peek (p64 `ptrPlus` ofs_CTimeSpec_NanoSeconds)
     startNSec <- peek (p64 `ptrPlus` (sizeAsOffset (sizeOfCSize size_CTimeSpec) + ofs_CTimeSpec_NanoSeconds))
+    mutableTouch blk
     pure $ NanoSeconds $ (endSec * secondInNano + endNSec) - (startSec * secondInNano + startNSec)
 #endif
 

--- a/basement/Basement/String.hs
+++ b/basement/Basement/String.hs
@@ -98,6 +98,7 @@ import           Basement.UArray           (UArray)
 import qualified Basement.UArray           as Vec
 import qualified Basement.UArray           as C
 import qualified Basement.UArray.Mutable   as MVec
+import           Basement.Block.Mutable (MutableBlock(..))
 import           Basement.Compat.Bifunctor
 import           Basement.Compat.Base
 import           Basement.Compat.Natural
@@ -783,7 +784,7 @@ sortBy sortF s = fromList $ Data.List.sortBy sortF $ toList s -- FIXME for tests
 -- | Filter characters of a string using the predicate
 filter :: (Char -> Bool) -> String -> String
 filter predicate (String arr) = runST $ do
-    (finalSize, dst) <- newNative sz $ \mba ->
+    (finalSize, dst) <- newNative sz $ \(MutableBlock mba) ->
         C.onBackendPrim (\ba -> BackendBA.copyFilter predicate sz mba ba start)
                         (\fptr -> withFinalPtr fptr $ \(Ptr addr) -> BackendAddr.copyFilter predicate sz mba addr start)
                         arr

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,5 @@
 resolver: nightly-2017-07-31
 packages:
 - '.'
-- basement/
+- location: basement/
+  extra-dep: true


### PR DESCRIPTION
After the bytearrayContent#, there's potentially nothing holding
the bytearray, so the GC could in rare race decide to get rid of it
before its address is used by f.

fix #397 