### PR TITLE
test-suite: depend on template-haskell

### DIFF
--- a/foundation.cabal
+++ b/foundation.cabal
@@ -235,6 +235,7 @@ test-suite check-foundation
   build-depends:     base >= 3 && < 5
                    , basement
                    , foundation
+                   , template-haskell
   ghc-options:       -Wall -fno-warn-orphans -fno-warn-missing-signatures
   default-language:  Haskell2010
   if impl(ghc >= 8.0)


### PR DESCRIPTION
Tests seems to use TH:

```
$ git grep TemplateHaskell
tests/Test/Foundation/Misc.hs:{-# LANGUAGE TemplateHaskell #-}
```

Otherwise darwin compilation fails with:

```
Linking dist/build/check-foundation/check-foundation ...
running tests
Running 1 test suites...
Test suite check-foundation: RUNNING...
dyld: Library not loaded: @rpath/libHStemplate-haskell-2.11.1.0-ghc8.0.2.dylib
  Referenced from: /private/tmp/nix-build-foundation-0.0.15.drv-0/foundation-0.0.15/dist/build/check-foundation/check-foundation
  Reason: image not found
Test suite check-foundation: FAIL
Test suite logged to: dist/test/foundation-0.0.15-check-foundation.log
0 of 1 test suites (0 of 1 test cases) passed.
builder for ‘/nix/store/hm5hdkapi57ri0bv3vrr5xmq4mll2gns-foundation-0.0.15.drv’ failed with exit code 1
```