### PR TITLE
Avoid touch, use with, fixes #399

### DIFF
--- a/Foundation/Foreign/MemoryMap/Windows.hs
+++ b/Foundation/Foreign/MemoryMap/Windows.hs
@@ -9,7 +9,6 @@ import Control.Exception hiding (handle)
 
 import Basement.Compat.Base
 import Basement.Types.OffsetSize
-import Basement.FinalPtr
 import Foundation.VFS
 import Foundation.Foreign.MemoryMap.Types
 

--- a/Foundation/Time/StopWatch.hs
+++ b/Foundation/Time/StopWatch.hs
@@ -53,13 +53,12 @@ initPrecise = unsafePerformIO $ integralDownsize <$> queryPerformanceFrequency
 initPrecise :: (Word64, Word64)
 initPrecise = unsafePerformIO $ do
     mti <- newPinned (sizeOfCSize size_MachTimebaseInfo)
-    p   <- mutableGetAddr mti
-    sysMacos_timebase_info (castPtr p)
-    let p32 = castPtr p :: Ptr Word32
-    !n <- peek (p32 `ptrPlus` ofs_MachTimebaseInfo_numer)
-    !d <- peek (p32 `ptrPlus` ofs_MachTimebaseInfo_denom)
-    mutableTouch mti
-    pure (integralUpsize n, integralUpsize d)
+    mutableWithAddr mti $ \p -> do
+        sysMacos_timebase_info (castPtr p)
+        let p32 = castPtr p :: Ptr Word32
+        !n <- peek (p32 `ptrPlus` ofs_MachTimebaseInfo_numer)
+        !d <- peek (p32 `ptrPlus` ofs_MachTimebaseInfo_denom)
+        pure (integralUpsize n, integralUpsize d)
 {-# NOINLINE initPrecise #-}
 #endif
 
@@ -70,15 +69,15 @@ startPrecise :: IO StopWatchPrecise
 startPrecise = do
 #if defined(mingw32_HOST_OS)
     blk <- newPinned 16
-    p   <- mutableGetAddr blk
-    _ <- c_QueryPerformanceCounter (castPtr p `ptrPlus` 8)
+    _ <- mutableWithAddr blk $ \p ->
+        c_QueryPerformanceCounter (castPtr p `ptrPlus` 8)
     pure (StopWatchPrecise blk)
 #elif defined(darwin_HOST_OS)
     StopWatchPrecise <$> sysMacos_absolute_time
 #else
     blk <- newPinned (sizeOfCSize (size_CTimeSpec + size_CTimeSpec))
-    p   <- mutableGetAddr blk
-    _err1 <- sysTimeClockGetTime sysTime_CLOCK_MONOTONIC (castPtr p `ptrPlusCSz` size_CTimeSpec)
+    _err1 <- mutableWithAddr blk $ \p -> do
+        sysTimeClockGetTime sysTime_CLOCK_MONOTONIC (castPtr p `ptrPlusCSz` size_CTimeSpec)
     pure (StopWatchPrecise blk)
 #endif
 
@@ -86,28 +85,26 @@ startPrecise = do
 stopPrecise :: StopWatchPrecise -> IO NanoSeconds
 stopPrecise (StopWatchPrecise blk) = do
 #if defined(mingw32_HOST_OS)
-    p <- mutableGetAddr blk
-    _ <- c_QueryPerformanceCounter (castPtr p)
-    let p64 = castPtr p :: Ptr Word64
-    end   <- peek p64
-    start <- peek (p64 `ptrPlus` 8)
-    mutableTouch blk
-    pure $ NanoSeconds ((end - start) * secondInNano `div` initPrecise)
+    mutableWithAddr blk $ \p -> do
+        _ <- c_QueryPerformanceCounter (castPtr p)
+        let p64 = castPtr p :: Ptr Word64
+        end   <- peek p64
+        start <- peek (p64 `ptrPlus` 8)
+        pure $ NanoSeconds ((end - start) * secondInNano `div` initPrecise)
 #elif defined(darwin_HOST_OS)
     end <- sysMacos_absolute_time
     pure $ NanoSeconds $ case initPrecise of
         (1,1)         -> end - blk
         (numer,denom) -> ((end - blk) * numer) `div` denom
 #else
-    p <- mutableGetAddr blk
-    _err1 <- sysTimeClockGetTime sysTime_CLOCK_MONOTONIC (castPtr p)
-    let p64 = castPtr p :: Ptr Word64
-    endSec    <- peek p64
-    startSec  <- peek (p64 `ptrPlusCSz` size_CTimeSpec)
-    endNSec   <- peek (p64 `ptrPlus` ofs_CTimeSpec_NanoSeconds)
-    startNSec <- peek (p64 `ptrPlus` (sizeAsOffset (sizeOfCSize size_CTimeSpec) + ofs_CTimeSpec_NanoSeconds))
-    mutableTouch blk
-    pure $ NanoSeconds $ (endSec * secondInNano + endNSec) - (startSec * secondInNano + startNSec)
+    mutableWithAddr blk $ \p -> do
+        _err1 <- sysTimeClockGetTime sysTime_CLOCK_MONOTONIC (castPtr p)
+        let p64 = castPtr p :: Ptr Word64
+        endSec    <- peek p64
+        startSec  <- peek (p64 `ptrPlusCSz` size_CTimeSpec)
+        endNSec   <- peek (p64 `ptrPlus` ofs_CTimeSpec_NanoSeconds)
+        startNSec <- peek (p64 `ptrPlus` (sizeAsOffset (sizeOfCSize size_CTimeSpec) + ofs_CTimeSpec_NanoSeconds))
+        pure $ NanoSeconds $ (endSec * secondInNano + endNSec) - (startSec * secondInNano + startNSec)
 #endif
 
 secondInNano :: Word64

--- a/basement/Basement/Block/Base.hs
+++ b/basement/Basement/Block/Base.hs
@@ -22,7 +22,6 @@ module Basement.Block.Base
     , mutableEmpty
     , new
     , newPinned
-    , touch
     , withPtr
     , mutableWithPtr
     ) where
@@ -347,9 +346,6 @@ withPtr (Block ba) f = do
     res <- f addr
     unsafePrimFromIO $ primitive $ \s -> case touch# ba s of { s2 -> (# s2, () #) }
     return res
-
-touch :: PrimMonad prim => Block ty -> prim ()
-touch (Block ba) = unsafePrimFromIO $ primitive $ \s -> case touch# ba s of { s2 -> (# s2, () #) }
 
 -- | Use the 'Ptr' to a mutable block in a safer construct
 --

--- a/basement/Basement/Block/Base.hs
+++ b/basement/Basement/Block/Base.hs
@@ -23,7 +23,7 @@ module Basement.Block.Base
     , new
     , newPinned
     , touch
-    , mutableTouch
+    , mutableWithPtr
     ) where
 
 import           GHC.Prim
@@ -340,3 +340,25 @@ touch (Block ba) = unsafePrimFromIO $ primitive $ \s -> case touch# ba s of { s2
 mutableTouch :: PrimMonad prim => MutableBlock ty (PrimState prim) -> prim ()
 mutableTouch (MutableBlock mba) = unsafePrimFromIO $ primitive $ \s -> case touch# mba s of { s2 -> (# s2, () #) }
 
+-- | Get the address of the context of the mutable block.
+--
+-- if the block is not pinned, this is a _dangerous_ operation
+--
+-- Note that if nothing is holding the block, the GC can garbage collect the block
+-- and thus the address is dangling on the memory. use 'mutableWithPtr' to prevent
+-- this problem by construction
+mutableGetAddr :: PrimMonad prim => MutableBlock ty (PrimState prim) -> prim (Ptr ty)
+mutableGetAddr (MutableBlock mba) = primitive $ \s1 ->
+    case unsafeFreezeByteArray# mba s1 of
+        (# s2, ba #) -> (# s2, Ptr (byteArrayContents# ba) #)
+
+-- | Get the address of the mutable block in a safer construct
+--
+-- if the block is not pinned, this is a _dangerous_ operation
+mutableWithPtr :: PrimMonad prim
+                => MutableBlock ty (PrimState prim)
+                -> (Ptr ty -> prim a)
+                -> prim a
+mutableWithPtr mb f = do
+    addr <- mutableGetAddr mb
+    f addr <* mutableTouch mb

--- a/basement/Basement/Block/Mutable.hs
+++ b/basement/Basement/Block/Mutable.hs
@@ -40,7 +40,6 @@ module Basement.Block.Mutable
     , mutableLengthSize
     , mutableLengthBytes
     , mutableWithPtr
-    , mutableTouch
     , new
     , newPinned
     , mutableEmpty

--- a/basement/Basement/Block/Mutable.hs
+++ b/basement/Basement/Block/Mutable.hs
@@ -39,7 +39,6 @@ module Basement.Block.Mutable
     , MutableBlock(..)
     , mutableLengthSize
     , mutableLengthBytes
-    , mutableGetAddr
     , mutableWithAddr
     , mutableTouch
     , new

--- a/basement/Basement/Block/Mutable.hs
+++ b/basement/Basement/Block/Mutable.hs
@@ -82,29 +82,6 @@ mutableLengthBytes :: MutableBlock ty st -> CountOf Word8
 mutableLengthBytes (MutableBlock mba) = CountOf (I# (sizeofMutableByteArray# mba))
 {-# INLINE[1] mutableLengthBytes #-}
 
--- | Get the address of the context of the mutable block.
---
--- if the block is not pinned, this is a _dangerous_ operation
---
--- Note that if nothing is holding the block, the GC can garbage collect the block
--- and thus the address is dangling on the memory. use 'mutableWithPtr' to prevent
--- this problem by construction
-mutableGetAddr :: PrimMonad prim => MutableBlock ty (PrimState prim) -> prim (Ptr ty)
-mutableGetAddr (MutableBlock mba) = primitive $ \s1 ->
-    case unsafeFreezeByteArray# mba s1 of
-        (# s2, ba #) -> (# s2, Ptr (byteArrayContents# ba) #)
-
--- | Get the address of the mutable block in a safer construct
---
--- if the block is not pinned, this is a _dangerous_ operation
-mutableWithPtr :: PrimMonad prim
-                => MutableBlock ty (PrimState prim)
-                -> (Ptr ty -> prim a)
-                -> prim a
-mutableWithPtr mb f = do
-    addr <- mutableGetAddr mb
-    f addr <* mutableTouch mb
-
 -- | Set all mutable block element to a value
 iterSet :: (PrimType ty, PrimMonad prim)
         => (Offset ty -> ty)

--- a/basement/Basement/Block/Mutable.hs
+++ b/basement/Basement/Block/Mutable.hs
@@ -39,7 +39,7 @@ module Basement.Block.Mutable
     , MutableBlock(..)
     , mutableLengthSize
     , mutableLengthBytes
-    , mutableWithAddr
+    , mutableWithPtr
     , mutableTouch
     , new
     , newPinned
@@ -88,7 +88,7 @@ mutableLengthBytes (MutableBlock mba) = CountOf (I# (sizeofMutableByteArray# mba
 -- if the block is not pinned, this is a _dangerous_ operation
 --
 -- Note that if nothing is holding the block, the GC can garbage collect the block
--- and thus the address is dangling on the memory. use 'mutableWithAddr' to prevent
+-- and thus the address is dangling on the memory. use 'mutableWithPtr' to prevent
 -- this problem by construction
 mutableGetAddr :: PrimMonad prim => MutableBlock ty (PrimState prim) -> prim (Ptr ty)
 mutableGetAddr (MutableBlock mba) = primitive $ \s1 ->
@@ -98,11 +98,11 @@ mutableGetAddr (MutableBlock mba) = primitive $ \s1 ->
 -- | Get the address of the mutable block in a safer construct
 --
 -- if the block is not pinned, this is a _dangerous_ operation
-mutableWithAddr :: PrimMonad prim
+mutableWithPtr :: PrimMonad prim
                 => MutableBlock ty (PrimState prim)
                 -> (Ptr ty -> prim a)
                 -> prim a
-mutableWithAddr mb f = do
+mutableWithPtr mb f = do
     addr <- mutableGetAddr mb
     f addr <* mutableTouch mb
 

--- a/basement/Basement/String.hs
+++ b/basement/Basement/String.hs
@@ -98,7 +98,7 @@ import           Basement.UArray           (UArray)
 import qualified Basement.UArray           as Vec
 import qualified Basement.UArray           as C
 import qualified Basement.UArray.Mutable   as MVec
-import           Basement.Block.Mutable (MutableBlock(..))
+import           Basement.Block.Mutable (Block(..), MutableBlock(..))
 import           Basement.Compat.Bifunctor
 import           Basement.Compat.Base
 import           Basement.Compat.Natural
@@ -471,8 +471,8 @@ breakEnd predicate s@(String arr)
   where
     k = C.onBackend goVec (\_ -> pure . goAddr) arr
     (C.ValidRange !start !end) = offsetsValidRange arr
-    goVec ba = let k = BackendBA.revFindIndexPredicate predicate ba start end
-                in if k == end then end else PrimBA.nextSkip ba k
+    goVec (Block ba) = let k = BackendBA.revFindIndexPredicate predicate ba start end
+                        in if k == end then end else PrimBA.nextSkip ba k
     goAddr (Ptr addr) =
         let k = BackendAddr.revFindIndexPredicate predicate addr start end
          in if k == end then end else PrimAddr.nextSkip addr k
@@ -604,7 +604,7 @@ length (String arr)
     | otherwise    = C.onBackend goVec (\_ -> pure . goAddr) arr
   where
     (C.ValidRange !start !end) = offsetsValidRange arr
-    goVec ma = PrimBA.length ma start end
+    goVec (Block ma) = PrimBA.length ma start end
     goAddr (Ptr ptr) = PrimAddr.length ptr start end
 
 -- | Replicate a character @c@ @n@ times to create a string of length @n@
@@ -1391,17 +1391,17 @@ stripSuffix (String prefix) (String arr)
     | otherwise               = Nothing
 
 all :: (Char -> Bool) -> String -> Bool
-all predicate (String arr) = C.onBackend goNative (\_ -> pure . goAddr) arr
+all predicate (String arr) = C.onBackend goBA (\_ -> pure . goAddr) arr
   where
     !(C.ValidRange start end) = C.offsetsValidRange arr
-    goNative ba = PrimBA.all predicate ba start end
+    goBA (Block ba)   = PrimBA.all predicate ba start end
     goAddr (Ptr addr) = PrimAddr.all predicate addr start end
 
 any :: (Char -> Bool) -> String -> Bool
-any predicate (String arr) = C.onBackend goNative (\_ -> pure . goAddr) arr
+any predicate (String arr) = C.onBackend goBA (\_ -> pure . goAddr) arr
   where
     !(C.ValidRange start end) = C.offsetsValidRange arr
-    goNative ba = PrimBA.any predicate ba start end
+    goBA (Block ba)   = PrimBA.any predicate ba start end
     goAddr (Ptr addr) = PrimAddr.any predicate addr start end
 
 -- | Transform string @src@ to base64 binary representation.

--- a/basement/Basement/String.hs
+++ b/basement/Basement/String.hs
@@ -785,7 +785,7 @@ sortBy sortF s = fromList $ Data.List.sortBy sortF $ toList s -- FIXME for tests
 filter :: (Char -> Bool) -> String -> String
 filter predicate (String arr) = runST $ do
     (finalSize, dst) <- newNative sz $ \(MutableBlock mba) ->
-        C.onBackendPrim (\ba -> BackendBA.copyFilter predicate sz mba ba start)
+        C.onBackendPrim (\(Block ba) -> BackendBA.copyFilter predicate sz mba ba start)
                         (\fptr -> withFinalPtr fptr $ \(Ptr addr) -> BackendAddr.copyFilter predicate sz mba addr start)
                         arr
     freezeShrink finalSize dst

--- a/basement/Basement/UArray.hs
+++ b/basement/Basement/UArray.hs
@@ -125,7 +125,7 @@ import           Basement.Exception
 import           Basement.UArray.Base
 import           Basement.Block (Block(..), MutableBlock(..))
 import qualified Basement.Block as BLK
-import qualified Basement.Block.Base as BLK (touch, unsafeWrite)
+import qualified Basement.Block.Base as BLK (withPtr, unsafeWrite)
 import           Basement.UArray.Mutable hiding (sub, copyToPtr)
 import           Basement.Numerical.Additive
 import           Basement.Numerical.Subtractive
@@ -293,7 +293,7 @@ withPtr :: forall ty prim a . (PrimMonad prim, PrimType ty)
         -> prim a
 withPtr a f
     | isPinned a == Pinned =
-        onBackendPrim (\(Block ba) -> f (Ptr (byteArrayContents# ba) `plusPtr` os) <* BLK.touch (Block ba))
+        onBackendPrim (\blk  -> BLK.withPtr  blk  $ \ptr -> f (ptr `plusPtr` os))
                       (\fptr -> withFinalPtr fptr $ \ptr -> f (ptr `plusPtr` os))
                       a
     | otherwise = do

--- a/basement/Basement/UArray.hs
+++ b/basement/Basement/UArray.hs
@@ -639,8 +639,8 @@ sortBy ford vec = runST $ do
     !end = 0 `offsetPlusE` len
     !start = offset vec
 
-    goNative :: MutableByteArray# (PrimState (ST s)) -> ST s ()
-    goNative mba = PrimBA.inplaceSortBy ford mba start end
+    goNative :: MutableBlock ty (PrimState (ST s)) -> ST s ()
+    goNative (MutableBlock mba) = PrimBA.inplaceSortBy ford mba start end
     goAddr :: Ptr ty -> ST s ()
     goAddr (Ptr addr) = PrimAddr.inplaceSortBy ford addr start end
 {-# SPECIALIZE [3] sortBy :: (Word8 -> Word8 -> Ordering) -> UArray Word8 -> UArray Word8 #-}

--- a/basement/Basement/UArray/Base.hs
+++ b/basement/Basement/UArray/Base.hs
@@ -266,12 +266,12 @@ onBackend _    onAddr (UArray _ _ (UArrayAddr fptr)) = withUnsafeFinalPtr fptr (
 {-# INLINE onBackend #-}
 
 onBackendPrim :: PrimMonad prim
-              => (ByteArray# -> prim a)
+              => (Block ty -> prim a)
               -> (FinalPtr ty -> prim a)
               -> UArray ty
               -> prim a
-onBackendPrim onBa _      (UArray _ _ (UArrayBA (Block ba))) = onBa ba
-onBackendPrim _    onAddr (UArray _ _ (UArrayAddr fptr))     = onAddr fptr
+onBackendPrim onBa _      (UArray _ _ (UArrayBA ba))     = onBa ba
+onBackendPrim _    onAddr (UArray _ _ (UArrayAddr fptr)) = onAddr fptr
 {-# INLINE onBackendPrim #-}
 
 onMutableBackend :: PrimMonad prim

--- a/basement/Basement/UArray/Base.hs
+++ b/basement/Basement/UArray/Base.hs
@@ -44,7 +44,6 @@ module Basement.UArray.Base
     , compare
     , copyAt
     , unsafeCopyAtRO
-    , touch
     , toBlock
     -- * temporary
     , pureST
@@ -66,7 +65,6 @@ import           Basement.FinalPtr
 import           Basement.NormalForm
 import           Basement.Block (MutableBlock(..), Block(..))
 import qualified Basement.Block as BLK
-import qualified Basement.Block.Base as BLK (touch)
 import qualified Basement.Block.Mutable as MBLK
 import           Basement.Numerical.Additive
 import           Basement.Bindings.Memory
@@ -591,10 +589,6 @@ concat l  =
         unsafeCopyAtRO r i x (Offset 0) lx
         doCopy r (i `offsetPlusE` lx) xs
       where lx = length x
-
-touch :: PrimMonad prim => UArray ty -> prim ()
-touch (UArray _ _ (UArrayBA blk))    = BLK.touch blk
-touch (UArray _ _ (UArrayAddr fptr)) = touchFinalPtr fptr
 
 -- | Create a Block from a UArray.
 --

--- a/basement/Basement/UArray/Base.hs
+++ b/basement/Basement/UArray/Base.hs
@@ -257,12 +257,12 @@ copy :: PrimType ty => UArray ty -> UArray ty
 copy array = runST (thaw array >>= unsafeFreeze)
 
 
-onBackend :: (ByteArray# -> a)
+onBackend :: (Block ty -> a)
           -> (FinalPtr ty -> Ptr ty -> ST s a)
           -> UArray ty
           -> a
-onBackend onBa _      (UArray _ _ (UArrayBA (Block ba))) = onBa ba
-onBackend _    onAddr (UArray _ _ (UArrayAddr fptr))     = withUnsafeFinalPtr fptr (onAddr fptr)
+onBackend onBa _      (UArray _ _ (UArrayBA ba))     = onBa ba
+onBackend _    onAddr (UArray _ _ (UArrayAddr fptr)) = withUnsafeFinalPtr fptr (onAddr fptr)
 {-# INLINE onBackend #-}
 
 onBackendPrim :: PrimMonad prim

--- a/basement/Basement/UArray/Base.hs
+++ b/basement/Basement/UArray/Base.hs
@@ -275,11 +275,11 @@ onBackendPrim _    onAddr (UArray _ _ (UArrayAddr fptr)) = onAddr fptr
 {-# INLINE onBackendPrim #-}
 
 onMutableBackend :: PrimMonad prim
-                 => (MutableByteArray# (PrimState prim) -> prim a)
+                 => (MutableBlock ty (PrimState prim) -> prim a)
                  -> (FinalPtr ty -> prim a)
                  -> MUArray ty (PrimState prim)
                  -> prim a
-onMutableBackend onMba _      (MUArray _ _ (MUArrayMBA (MutableBlock mba)))   = onMba mba
+onMutableBackend onMba _      (MUArray _ _ (MUArrayMBA mba))   = onMba mba
 onMutableBackend _     onAddr (MUArray _ _ (MUArrayAddr fptr)) = onAddr fptr
 {-# INLINE onMutableBackend #-}
 

--- a/basement/Basement/UArray/Mutable.hs
+++ b/basement/Basement/UArray/Mutable.hs
@@ -168,7 +168,7 @@ copyFromPtr src@(Ptr src#) count marr
     !(CountOf bytes@(I# bytes#)) = sizeOfE sz count
     !(Offset od@(I# od#)) = offsetOfE sz ofs
 
-    copyNative mba = primitive $ \st -> (# copyAddrToByteArray# src# mba od# bytes# st, () #)
+    copyNative (MutableBlock mba) = primitive $ \st -> (# copyAddrToByteArray# src# mba od# bytes# st, () #)
     copyPtr fptr = withFinalPtr fptr $ \dst ->
         unsafePrimFromIO $ copyBytes (dst `plusPtr` od) src bytes
 
@@ -179,7 +179,7 @@ copyToPtr :: forall ty prim . (PrimType ty, PrimMonad prim)
           -> prim ()
 copyToPtr marr dst@(Ptr dst#) = onMutableBackend copyNative copyPtr marr
   where
-    copyNative mba = primitive $ \s1 ->
+    copyNative (MutableBlock mba) = primitive $ \s1 ->
         case unsafeFreezeByteArray# mba s1 of
             (# s2, ba #) -> (# compatCopyByteArrayToAddr# ba os# dst# szBytes# s2, () #)
     copyPtr fptr = unsafePrimFromIO $ withFinalPtr fptr $ \ptr ->

--- a/basement/Basement/UArray/Mutable.hs
+++ b/basement/Basement/UArray/Mutable.hs
@@ -125,7 +125,7 @@ withMutablePtrHint _ _ (MUArray start _ (MUArrayAddr fptr))  f =
     sz           = primSizeInBytes (Proxy :: Proxy ty)
     !(Offset os) = offsetOfE sz start
 withMutablePtrHint skipCopy skipCopyBack vec@(MUArray start vecSz (MUArrayMBA mb)) f
-    | BLK.isMutablePinned mb == Pinned = MBLK.mutableWithAddr mb (\ptr -> f (ptr `plusPtr` os))
+    | BLK.isMutablePinned mb == Pinned = MBLK.mutableWithPtr mb (\ptr -> f (ptr `plusPtr` os))
     | otherwise                        = do
         trampoline <- newPinned vecSz
         if not skipCopy

--- a/basement/Basement/UTF8/Base.hs
+++ b/basement/Basement/UTF8/Base.hs
@@ -176,7 +176,7 @@ expectAscii (String ba) n v = Vec.unsafeIndex ba n == v
 
 write :: PrimMonad prim => MutableString (PrimState prim) -> Offset8 -> Char -> prim Offset8
 write (MutableString marray) ofs c =
-    MVec.onMutableBackend (\mba -> PrimBA.write mba (start + ofs) c)
+    MVec.onMutableBackend (\(BLK.MutableBlock mba) -> PrimBA.write mba (start + ofs) c)
                           (\fptr -> withFinalPtr fptr $ \(Ptr ptr) -> PrimAddr.write ptr (start + ofs) c)
                           marray
   where start = MVec.mutableOffset marray

--- a/basement/Basement/UTF8/Base.hs
+++ b/basement/Basement/UTF8/Base.hs
@@ -148,20 +148,20 @@ sFromList l = runST (new bytes >>= startCopy)
 {-# INLINE [0] sFromList #-}
 
 next :: String -> Offset8 -> Step
-next (String array) !n = Vec.onBackend nextNative nextAddr array
+next (String array) !n = Vec.onBackend nextBA nextAddr array
   where
     !start = Vec.offset array
     reoffset (Step a ofs) = Step a (ofs `offsetSub` start)
-    nextNative ba        = reoffset (PrimBA.next ba (start + n))
-    nextAddr _ (Ptr ptr) = pureST $ reoffset (PrimAddr.next ptr (start + n))
+    nextBA (BLK.Block ba) = reoffset (PrimBA.next ba (start + n))
+    nextAddr _ (Ptr ptr)  = pureST $ reoffset (PrimAddr.next ptr (start + n))
 
 prev :: String -> Offset8 -> StepBack
-prev (String array) !n = Vec.onBackend prevNative prevAddr array
+prev (String array) !n = Vec.onBackend prevBA prevAddr array
   where
     !start = Vec.offset array
     reoffset (StepBack a ofs) = StepBack a (ofs `offsetSub` start)
-    prevNative ba        = reoffset (PrimBA.prev ba (start + n))
-    prevAddr _ (Ptr ptr) = pureST $ reoffset (PrimAddr.prev ptr (start + n))
+    prevBA (BLK.Block ba) = reoffset (PrimBA.prev ba (start + n))
+    prevAddr _ (Ptr ptr)  = pureST $ reoffset (PrimAddr.prev ptr (start + n))
 
 -- A variant of 'next' when you want the next character
 -- to be ASCII only.


### PR DESCRIPTION
The main purpose of this change is to avoid the do something unsafe and touch pattern, and instead move to using `withFoo`, even for the low-level pieces. In the process I think it fixes bugs in Stopwatch, but mostly it's about static guarantees in more places.

At the same time I changed onBacked to use `Block ty` rathern than `ByteArrayContents#` as this lets you use the `with` functions on safer types, and also preserves type information for longer. It also provides a nice symmetry with the `Ptr` - a newtype phantom type over `Addr#`.