### PR TITLE
Use CApiFFI for variadic fcntl 

### DIFF
--- a/Foundation/System/Bindings/Posix.hsc
+++ b/Foundation/System/Bindings/Posix.hsc
@@ -17,6 +17,7 @@ module Foundation.System.Bindings.Posix
 
 import Basement.Compat.Base
 import Foreign.C.Types
+import Foreign.Ptr (nullPtr)
 import Data.Bits
 import Foundation.System.Bindings.PosixDef
 
@@ -349,9 +350,10 @@ foreign import ccall unsafe "close"
     sysPosixClose :: CFd -> IO CInt
 
 foreign import ccall unsafe "fcntl"
-    sysPosixFnctlNoArg :: CFd -> CInt -> IO CInt
-foreign import ccall unsafe "fcntl"
     sysPosixFnctlPtr :: CFd -> CInt -> Ptr a -> IO CInt
+
+sysPosixFnctlNoArg :: CFd -> CInt -> IO CInt
+sysPoxixFnctlNoArg fd cmd = sysPosixFnctlPtr fd cmd nullPtr
 
 foreign import ccall unsafe "ftruncate"
     sysPosixFtruncate :: CFd -> COff -> IO CInt

--- a/Foundation/System/Bindings/Posix.hsc
+++ b/Foundation/System/Bindings/Posix.hsc
@@ -350,10 +350,9 @@ foreign import ccall unsafe "close"
     sysPosixClose :: CFd -> IO CInt
 
 foreign import capi "fcntl.h fcntl"
-    sysPosixFnctlPtr :: CFd -> CInt -> Ptr a -> IO CInt
-
-foreign import capi "fcntl.h fcntl"
     sysPosixFnctlNoArg :: CFd -> CInt -> IO CInt
+foreign import capi "fcntl.h fcntl"
+    sysPosixFnctlPtr :: CFd -> CInt -> Ptr a -> IO CInt
 
 foreign import ccall unsafe "ftruncate"
     sysPosixFtruncate :: CFd -> COff -> IO CInt

--- a/Foundation/System/Bindings/Posix.hsc
+++ b/Foundation/System/Bindings/Posix.hsc
@@ -353,7 +353,7 @@ foreign import ccall unsafe "fcntl"
     sysPosixFnctlPtr :: CFd -> CInt -> Ptr a -> IO CInt
 
 sysPosixFnctlNoArg :: CFd -> CInt -> IO CInt
-sysPoxixFnctlNoArg fd cmd = sysPosixFnctlPtr fd cmd nullPtr
+sysPosixFnctlNoArg fd cmd = sysPosixFnctlPtr fd cmd nullPtr
 
 foreign import ccall unsafe "ftruncate"
     sysPosixFtruncate :: CFd -> COff -> IO CInt

--- a/Foundation/System/Bindings/Posix.hsc
+++ b/Foundation/System/Bindings/Posix.hsc
@@ -11,13 +11,13 @@
 -- Functions defined by the POSIX standards
 --
 -----------------------------------------------------------------------------
+{-# LANGUAGE CApiFFI #-}
 {-# OPTIONS_HADDOCK hide #-}
 module Foundation.System.Bindings.Posix
    where
 
 import Basement.Compat.Base
 import Foreign.C.Types
-import Foreign.Ptr (nullPtr)
 import Data.Bits
 import Foundation.System.Bindings.PosixDef
 
@@ -349,11 +349,11 @@ foreign import ccall unsafe "openat"
 foreign import ccall unsafe "close"
     sysPosixClose :: CFd -> IO CInt
 
-foreign import ccall unsafe "fcntl"
+foreign import capi "fcntl.h fcntl"
     sysPosixFnctlPtr :: CFd -> CInt -> Ptr a -> IO CInt
 
-sysPosixFnctlNoArg :: CFd -> CInt -> IO CInt
-sysPosixFnctlNoArg fd cmd = sysPosixFnctlPtr fd cmd nullPtr
+foreign import capi "fcntl.h fcntl"
+    sysPosixFnctlNoArg :: CFd -> CInt -> IO CInt
 
 foreign import ccall unsafe "ftruncate"
     sysPosixFtruncate :: CFd -> COff -> IO CInt


### PR DESCRIPTION
This came up when using the alternative `-llvmng` backend. Which started to complain about two functions `fcntl` that had different signatures. While I assume full responsibility for all llvmng bugs, it was suggested by @geekosaur, to rather use the CApiFFI extension to import variadic `fcntl` as multiple functions with different numbers of arguments.