### PR TITLE
Semigroup Monoid Prop fix

### DIFF
--- a/Foundation.hs
+++ b/Foundation.hs
@@ -101,6 +101,7 @@ module Foundation
     , Prelude.fromIntegral
     , Prelude.realToFrac
       -- ** Monoids
+    , Basement.Compat.Semigroup.Semigroup
     , Monoid (..)
     , (<>)
       -- ** Collection
@@ -186,6 +187,7 @@ import qualified Basement.Imports
 import           Basement.Environment (getArgs)
 import           Basement.Compat.NumLiteral
 import           Basement.Compat.Natural
+import qualified Basement.Compat.Semigroup
 
 import qualified Data.Maybe
 import qualified Data.Either

--- a/Foundation/Array/Bitmap.hs
+++ b/Foundation/Array/Bitmap.hs
@@ -33,6 +33,7 @@ import           Basement.UArray (UArray)
 import qualified Basement.UArray as A
 import           Basement.UArray.Mutable (MUArray)
 import           Basement.Compat.Bifunctor (first, second, bimap)
+import           Basement.Compat.Semigroup
 import           Basement.Exception
 import           Basement.Compat.Base
 import           Basement.Types.OffsetSize
@@ -63,6 +64,8 @@ instance Eq Bitmap where
     (==) = equal
 instance Ord Bitmap where
     compare = vCompare
+instance Semigroup Bitmap where
+    (<>) = append
 instance Monoid Bitmap where
     mempty  = empty
     mappend = append

--- a/Foundation/Array/Chunked/Unboxed.hs
+++ b/Foundation/Array/Chunked/Unboxed.hs
@@ -24,6 +24,7 @@ import           Basement.Exception
 import           Basement.UArray (UArray)
 import qualified Basement.UArray as U
 import           Basement.Compat.Bifunctor
+import           Basement.Compat.Semigroup
 import           Basement.Compat.Base
 import           Basement.Types.OffsetSize
 import           Basement.PrimType
@@ -42,6 +43,8 @@ instance PrimType ty => Eq (ChunkedUArray ty) where
 instance NormalForm (ChunkedUArray ty) where
     toNormalForm (ChunkedUArray spine) = toNormalForm spine
 
+instance Semigroup (ChunkedUArray a) where
+    (<>) = append
 instance Monoid (ChunkedUArray a) where
     mempty  = empty
     mappend = append

--- a/Foundation/List/DList.hs
+++ b/Foundation/List/DList.hs
@@ -12,8 +12,9 @@ module Foundation.List.DList
     ) where
 
 import Basement.Compat.Base
-import Foundation.Collection
+import Basement.Compat.Semigroup
 import Basement.Compat.Bifunctor
+import Foundation.Collection
 
 newtype DList a = DList { unDList :: [a] -> [a] }
   deriving (Typeable)
@@ -29,9 +30,11 @@ instance Show a => Show (DList a) where
 
 instance IsList (DList a) where
     type Item (DList a) = a
-    fromList = DList . (<>)
+    fromList = DList . (Basement.Compat.Semigroup.<>)
     toList = flip unDList []
 
+instance Semigroup (DList a) where
+    (<>) dl1 dl2 = DList $ unDList dl1 . unDList dl2
 instance Monoid (DList a) where
     mempty = DList id
     mappend dl1 dl2 = DList $ unDList dl1 . unDList dl2

--- a/Foundation/String/Builder.hs
+++ b/Foundation/String/Builder.hs
@@ -17,7 +17,7 @@ module Foundation.String.Builder
     ) where
 
 import           Basement.Compat.Base
---import           Basement.Compat.Semigroup
+import           Basement.Compat.Semigroup
 import           Basement.String                (String)
 import qualified Basement.String as S
 
@@ -26,9 +26,8 @@ data Builder = E String | T [Builder]
 instance IsString Builder where
     fromString = E . fromString
 
---instance Semigroup Builder where
---    (<>) = append
-
+instance Semigroup Builder where
+    (<>) = append
 instance Monoid Builder where
     mempty = empty
     mappend = append

--- a/Foundation/VFS/FilePath.hs
+++ b/Foundation/VFS/FilePath.hs
@@ -184,9 +184,11 @@ hasContigueSeparators [_] = False
 hasContigueSeparators (x1:x2:xs) =
     (isSeparator x1 && x1 == x2) || hasContigueSeparators xs
 
+instance Semigroup FileName where
+    (<>) (FileName a) (FileName b) = FileName $ a `mappend` b
 instance Monoid FileName where
-      mempty = FileName mempty
-      mappend (FileName a) (FileName b) = FileName $ a `mappend` b
+    mempty = FileName mempty
+    mappend (FileName a) (FileName b) = FileName $ a `mappend` b
 
 instance Path FilePath where
     type PathEnt FilePath = FileName

--- a/Foundation/VFS/FilePath.hs
+++ b/Foundation/VFS/FilePath.hs
@@ -35,6 +35,7 @@ module Foundation.VFS.FilePath
     ) where
 
 import Basement.Compat.Base
+import Basement.Compat.Semigroup
 import Foundation.Collection
 import Foundation.Array
 import Foundation.String (Encoding(..), ValidationFailure, toBytes, fromBytes, String)

--- a/basement/Basement/Block/Base.hs
+++ b/basement/Basement/Block/Base.hs
@@ -34,6 +34,7 @@ import qualified Data.List
 import           Basement.Compat.Base
 import           Data.Proxy
 import           Basement.Compat.Primitive
+import           Basement.Compat.Semigroup
 import           Basement.Bindings.Memory (sysHsMemcmpBaBa)
 import           Basement.Types.OffsetSize
 import           Basement.Monad
@@ -63,6 +64,8 @@ instance (PrimType ty, Eq ty) => Eq (Block ty) where
 instance (PrimType ty, Ord ty) => Ord (Block ty) where
     compare = internalCompare
 
+instance PrimType ty => Semigroup (Block ty) where
+    (<>) = append
 instance PrimType ty => Monoid (Block ty) where
     mempty  = empty
     mappend = append

--- a/basement/Basement/BoxedArray.hs
+++ b/basement/Basement/BoxedArray.hs
@@ -84,6 +84,7 @@ import           Basement.NonEmpty
 import           Basement.Compat.Base
 import qualified Basement.Alg.Mutable as MutAlg
 import           Basement.Compat.MonadTrans
+import           Basement.Compat.Semigroup
 import           Basement.Types.OffsetSize
 import           Basement.PrimType
 import           Basement.NormalForm
@@ -125,6 +126,8 @@ data MArray a st = MArray {-# UNPACK #-} !(Offset a)
 instance Functor Array where
     fmap = map
 
+instance Semigroup (Array a) where
+    (<>) = append
 instance Monoid (Array a) where
     mempty  = empty
     mappend = append

--- a/basement/Basement/Compat/Semigroup.hs
+++ b/basement/Basement/Compat/Semigroup.hs
@@ -91,6 +91,9 @@ instance Semigroup a => Semigroup (Maybe a) where
     EQ -> Nothing
     GT -> Just (stimes n a)
 
+instance Semigroup [a] where
+    (<>) = (++)
+
 instance Semigroup (Either a b) where
   Left _ <> b = b
   a      <> _ = a

--- a/basement/Basement/Imports.hs
+++ b/basement/Basement/Imports.hs
@@ -6,6 +6,7 @@
 -- Portability : portable
 --
 -- re-export of all the base prelude and basic primitive stuffs
+{-# LANGUAGE CPP #-}
 module Basement.Imports
     ( (Prelude.$)
     , (Prelude.$!)
@@ -68,7 +69,13 @@ module Basement.Imports
     , Data.Data.DataType
     , Data.Typeable.Typeable
     , Data.Monoid.Monoid (..)
+#if MIN_VERSION_base(4,10,0)
+    -- , (Basement.Compat.Semigroup.<>)
+    , Basement.Compat.Semigroup.Semigroup(..)
+#else
     , (Data.Monoid.<>)
+    , Basement.Compat.Semigroup.Semigroup
+#endif
     , Control.Exception.Exception
     , Control.Exception.throw
     , Control.Exception.throwIO
@@ -88,6 +95,7 @@ import qualified Data.Int
 import qualified Basement.Compat.IsList
 import qualified Basement.Compat.Natural
 import qualified Basement.Compat.NumLiteral
+import qualified Basement.Compat.Semigroup
 import qualified Basement.UArray
 import qualified Basement.BoxedArray
 import qualified Basement.UTF8.Base

--- a/basement/Basement/Types/AsciiString.hs
+++ b/basement/Basement/Types/AsciiString.hs
@@ -22,6 +22,7 @@ module Basement.Types.AsciiString
     ) where
 
 import           Basement.Compat.Base
+import           Basement.Compat.Semigroup
 import           Basement.Types.Char7
 import           Basement.UArray.Base
 import qualified Basement.Types.Char7 as Char7
@@ -29,7 +30,7 @@ import qualified Basement.UArray as A (all, unsafeRecast)
 
 -- | Opaque packed array of characters in the ASCII encoding
 newtype AsciiString = AsciiString { toBytes :: UArray Char7 }
-    deriving (Typeable, Monoid, Eq, Ord)
+    deriving (Typeable, Semigroup, Monoid, Eq, Ord)
 
 newtype MutableAsciiString st = MutableAsciiString (MUArray Char7 st)
     deriving (Typeable)

--- a/basement/Basement/Types/OffsetSize.hs
+++ b/basement/Basement/Types/OffsetSize.hs
@@ -47,6 +47,7 @@ import Foreign.C.Types
 import System.Posix.Types (CSsize (..))
 import Data.Bits
 import Basement.Compat.Base
+import Basement.Compat.Semigroup
 import Data.Proxy
 import Basement.Numerical.Number
 import Basement.Numerical.Additive
@@ -192,6 +193,9 @@ instance Subtractive (CountOf ty) where
     type Difference (CountOf ty) = Maybe (CountOf ty)
     (CountOf a) - (CountOf b) | a >= b    = Just . CountOf $ a - b
                               | otherwise = Nothing
+
+instance Semigroup (CountOf ty) where
+    (<>) = (+)
 
 instance Monoid (CountOf ty) where
     mempty = azero

--- a/basement/Basement/UArray/Base.hs
+++ b/basement/Basement/UArray/Base.hs
@@ -57,6 +57,7 @@ import           Basement.Compat.Primitive
 import           Basement.Monad
 import           Basement.PrimType
 import           Basement.Compat.Base
+import           Basement.Compat.Semigroup
 import qualified Basement.Runtime as Runtime
 import           Data.Proxy
 import qualified Basement.Compat.ExtList as List
@@ -112,6 +113,8 @@ instance (PrimType ty, Ord ty) => Ord (UArray ty) where
     {-# SPECIALIZE instance Ord (UArray Word8) #-}
     compare = vCompare
 
+instance PrimType ty => Semigroup (UArray ty) where
+    (<>) = append
 instance PrimType ty => Monoid (UArray ty) where
     mempty  = empty
     mappend = append

--- a/basement/Basement/UTF8/Base.hs
+++ b/basement/Basement/UTF8/Base.hs
@@ -42,10 +42,11 @@ import           GHC.CString                        (unpackCString#, unpackCStri
 
 import           Data.Data
 import           Basement.Compat.ExtList as List
+import           Basement.Compat.Semigroup (Semigroup)
 
 -- | Opaque packed array of characters in the UTF8 encoding
 newtype String = String (UArray Word8)
-    deriving (Typeable, Monoid, Eq, Ord)
+    deriving (Typeable, Semigroup, Monoid, Eq, Ord)
 
 -- | Mutable String Buffer.
 --

--- a/programs/Time.hs
+++ b/programs/Time.hs
@@ -28,6 +28,8 @@ data Monotonic = Monotonic
     , notMonotonic :: Sum Word
     } deriving (Show,Eq)
 
+instance Semigroup Monotonic where
+    (<>) =
 instance Monoid Monotonic where
     mempty = Monotonic mempty mempty mempty
     mappend m1 m2 = Monotonic { maxDiff      = maxDiff m1 `mappend` maxDiff m2


### PR DESCRIPTION
Adds the final missing Base.Compat.Semigroup import to Foundation.VFS.FilePath to make it compile with HEAD (GHC with Semigroup Monoid Proposal)