### PR TITLE
added text and examples to bifunctor documentation

### DIFF
--- a/basement/Basement/Compat/Bifunctor.hs
+++ b/basement/Basement/Compat/Bifunctor.hs
@@ -5,11 +5,19 @@
 -- Stability   : experimental
 -- Portability : portable
 --
+-- A bifunctor is a type constructor that takes 
+-- two type arguments and is a functor in /both/ arguments. That
+-- is, unlike with 'Functor', a type constructor such as 'Either' 
+-- does not need to be partially applied for a 'Bifunctor' 
+-- instance, and the methods in this class permit mapping 
+-- functions over the 'Left' value or the 'Right' value,
+-- or both at the same time. 
+--
 -- Formally, the class 'Bifunctor' represents a bifunctor
 -- from @Hask@ -> @Hask@.
 --
--- Intuitively it is a bifunctor where both the first and second
--- arguments are covariant.
+-- Intuitively it is a bifunctor where both the first and second 
+-- arguments are covariant. 
 --
 -- You can define a 'Bifunctor' by either defining 'bimap' or by
 -- defining both 'first' and 'second'.
@@ -35,12 +43,28 @@ class Bifunctor p where
     -- | Map over both arguments at the same time.
     --
     -- @'bimap' f g ≡ 'first' f '.' 'second' g@
+    --
+    --==== Examples:
+    -- >>> bimap toUpper (+1) ('j', 3)
+    -- ('J',4)
+    -- 
+    -- >>> bimap toUpper (+1) (Left 'j')
+    -- Left 'J'
+    -- 
+    -- >>> bimap toUpper (+1) (Right 3)
+    -- Right 4
     bimap :: (a -> b) -> (c -> d) -> p a c -> p b d
     bimap f g = first f P.. second g
 
     -- | Map covariantly over the first argument.
     --
     -- @'first' f ≡ 'bimap' f 'id'@
+    --==== Examples:
+    -- >>> first toUpper ('j', 3)
+    -- ('J',3)
+    --
+    -- >>> first toUpper (Left 'j')
+    -- Left 'J'
     first :: (a -> b) -> p a c -> p b c
     first f = bimap f P.id
 


### PR DESCRIPTION
I just thought it'd be nice to have more explanation and examples of bifunctor in the documentation; I PRd `base` with the same changes, so they will stay the same. I'm not sure if that was a priority or not.