### PR TITLE
Minor formatting fix for tables in docs

### DIFF
--- a/docs/porting.md
+++ b/docs/porting.md
@@ -26,7 +26,7 @@
 ## Formats
 
 | Name | Haskell package | Foundation module | Status |
-| ------------ | ------------- | ------------ |
+| ------------ | ------------- | ------------ | ------------ |
 | JSON | aeson, json | | Not-Started |
 | YAML | yaml | | Not-Started |
 | CSV  | cassava, csv | | Not-Started |
@@ -46,6 +46,8 @@
 | QuickCheck   | Foundation.Check      | Started |
 | tasty        | Foundation.Check.Main | Started |
 
-# Benchmarks
+## Benchmarks
 
+| Haskell package | Foundation module | Status |
+| ------------ | ------------- | ------------ |
 | Criterion    | Foundation.Timing     | Started |


### PR DESCRIPTION
These tables were missing a tiny bit of formatting. One heading was a level higher than the others.