### PR TITLE
Add better implementation of Builder

### DIFF
--- a/Foundation/Check.hs
+++ b/Foundation/Check.hs
@@ -37,6 +37,7 @@ module Foundation.Check
     ) where
 
 import           Basement.Imports
+import           Basement.Cast (cast)
 import           Basement.IntegralConv
 import           Basement.Types.OffsetSize
 import           Foundation.Check.Gen
@@ -80,7 +81,7 @@ iterateProperty limit genParams genRngIter prop = iterProp 1
                                       | otherwise -> return (PropertySuccess, iter)
         where
           iterW64 :: Word64
-          iterW64 = let (CountOf iter') = iter in integralCast (integralUpsize iter' :: Int64)
+          iterW64 = let (CountOf iter') = iter in cast (integralUpsize iter' :: Int64)
 
           -- TODO revisit to let through timeout and other exception like ctrl-c or thread killing.
           toResult :: IO (PropertyResult, Bool)

--- a/Foundation/Check/Arbitrary.hs
+++ b/Foundation/Check/Arbitrary.hs
@@ -14,6 +14,7 @@ module Foundation.Check.Arbitrary
 import           Basement.Imports
 import           Foundation.Primitive
 import           Basement.Nat
+import           Basement.Cast (cast)
 import           Basement.IntegralConv
 import           Basement.Bounded
 import           Basement.Types.OffsetSize
@@ -81,11 +82,11 @@ instance Arbitrary Bool where
 
 instance Arbitrary String where
     arbitrary = genWithParams $ \params ->
-        fromList <$> (genMax (genMaxSizeString params) >>= \i -> replicateM (integralCast i) arbitrary)
+        fromList <$> (genMax (genMaxSizeString params) >>= \i -> replicateM (cast i) arbitrary)
 
 instance Arbitrary AsciiString where
     arbitrary = genWithParams $ \params ->
-        fromList <$> (genMax (genMaxSizeString params) >>= \i -> replicateM (integralCast i) arbitrary)
+        fromList <$> (genMax (genMaxSizeString params) >>= \i -> replicateM (cast i) arbitrary)
 
 instance Arbitrary Float where
     arbitrary = arbitraryF32
@@ -116,7 +117,7 @@ instance (Arbitrary a, Arbitrary b, Arbitrary c, Arbitrary d, Arbitrary e, Arbit
 
 instance Arbitrary a => Arbitrary [a] where
     arbitrary = genWithParams $ \params ->
-        fromList <$> (genMax (genMaxSizeArray params) >>= \i -> replicateM (integralCast i) arbitrary)
+        fromList <$> (genMax (genMaxSizeArray params) >>= \i -> replicateM (cast i) arbitrary)
 #if __GLASGOW_HASKELL__ >= 710
 instance (Arbitrary a, KnownNat n, NatWithinBound Int n) => Arbitrary (ListN.ListN n a) where
     arbitrary = ListN.replicateM arbitrary
@@ -153,7 +154,7 @@ arbitraryWord64 :: Gen Word64
 arbitraryWord64 = genWithRng getRandomWord64
 
 arbitraryInt64 :: Gen Int64
-arbitraryInt64 = integralCast <$> arbitraryWord64
+arbitraryInt64 = cast <$> arbitraryWord64
 
 arbitraryF64 :: Gen Double
 arbitraryF64 = genWithRng getRandomF64
@@ -163,7 +164,7 @@ arbitraryF32 = genWithRng getRandomF32
 
 arbitraryUArrayOf :: (PrimType ty, Arbitrary ty) => Word -> Gen (UArray ty)
 arbitraryUArrayOf size = between (0, size) >>=
-    \sz -> fromList <$> replicateM (integralCast sz) arbitrary
+    \sz -> fromList <$> replicateM (cast sz) arbitrary
 
 -- | Call one of the generator weighted
 frequency :: NonEmpty [(Word, Gen a)] -> Gen a

--- a/Foundation/Check/Main.hs
+++ b/Foundation/Check/Main.hs
@@ -17,6 +17,7 @@ module Foundation.Check.Main
 
 import           Basement.Imports
 import           Basement.IntegralConv
+import           Basement.Cast (cast)
 import           Basement.Bounded
 import           Basement.Types.OffsetSize
 import qualified Basement.Terminal.ANSI as ANSI
@@ -285,7 +286,7 @@ testProperty name prop = do
     params <- getGenParams . config <$> get
     maxTests <- numTests . config <$> get
 
-    (res,nb) <- liftIO $ iterateProperty (CountOf $ integralDownsize (integralCast maxTests :: Int64)) params rngIt prop
+    (res,nb) <- liftIO $ iterateProperty (CountOf $ integralDownsize (cast maxTests :: Int64)) params rngIt prop
     case res of
         PropertyFailed {} -> failed
         PropertySuccess   -> passed

--- a/Foundation/Hashing/Hashable.hs
+++ b/Foundation/Hashing/Hashable.hs
@@ -13,6 +13,7 @@ module Foundation.Hashing.Hashable
     ) where
 
 import           Basement.Imports
+import           Basement.Cast (cast)
 import           Basement.Compat.Natural
 import           Basement.Types.Word128
 import           Basement.Types.Word256
@@ -58,13 +59,13 @@ instance Hashable Natural where
             let b = integralDownsize (w :: Natural) :: Word8
              in loop (w `div` 256) (hashMix8 b acc)
 instance Hashable Int8 where
-    hashMix w = hashMix8 (integralCast w)
+    hashMix w = hashMix8 (cast w)
 instance Hashable Int16 where
-    hashMix w = hashMix16 (integralCast w)
+    hashMix w = hashMix16 (cast w)
 instance Hashable Int32 where
-    hashMix w = hashMix32 (integralCast w)
+    hashMix w = hashMix32 (cast w)
 instance Hashable Int64 where
-    hashMix w = hashMix64 (integralCast w)
+    hashMix w = hashMix64 (cast w)
 instance Hashable Integer where
     hashMix i iacc
         | i == 0    = hashMix8 0 iacc

--- a/Foundation/Hashing/SipHash.hs
+++ b/Foundation/Hashing/SipHash.hs
@@ -21,6 +21,7 @@ import           Data.Bits
 import           Basement.Compat.Base
 import           Basement.Types.OffsetSize
 import           Basement.PrimType
+import           Basement.Cast (cast)
 import           Basement.IntegralConv
 import           Foundation.Hashing.Hasher
 import qualified Basement.UArray as A
@@ -175,7 +176,7 @@ finish !c !d (Sip ist incremental (CountOf len)) = finalize d $
         SipIncremental7 acc -> process c ist (lenMask .|. acc)
   where
     lenMask = (wlen .&. 0xff) .<<. 56
-    wlen = integralCast (integralUpsize len :: Int64) :: Word64
+    wlen = cast (integralUpsize len :: Int64) :: Word64
 
 -- | same as 'hash', except also specifies the number of sipround iterations for compression (C) and digest (D).
 mixBa :: PrimType a => Int -> UArray a -> Sip -> Sip
@@ -202,7 +203,7 @@ mixBa !c !array (Sip initSt initIncr currentLen) =
                         .|. to64 0  (primBaIndex ba (ofs + Offset 7))
                 in loop8 (process c st v) SipIncremental0 (start + Offset 8) l8
         loop8 !st !incr !ofs !l = loop1 st incr ofs l
-        loop1 !st !incr !ofs !l = case l - 1 of 
+        loop1 !st !incr !ofs !l = case l - 1 of
             Nothing -> Sip st incr (currentLen + totalLen)
             Just l1 -> let (!st', !incr') = mix8Prim c (primBaIndex ba ofs) st incr
                         in loop1 st' incr' (ofs + Offset 1) l1

--- a/Foundation/Primitive.hs
+++ b/Foundation/Primitive.hs
@@ -19,7 +19,6 @@ module Foundation.Primitive
     -- * Integral convertion
     , IntegralUpsize(..)
     , IntegralDownsize(..)
-    , IntegralCast(..)
 
     -- * Evaluation
     , NormalForm(..)

--- a/Foundation/String/Builder.hs
+++ b/Foundation/String/Builder.hs
@@ -10,46 +10,7 @@
 -- So, in the spirit of getting started and to be able to start using
 -- the API, we don't wait for the fast implementation.
 module Foundation.String.Builder
-    ( Builder
-    , emit
-    , emitChar
-    , toString
+    ( module Basement.String.Builder
     ) where
 
-import           Basement.Compat.Base
-import           Basement.Compat.Semigroup
-import           Basement.String                (String)
-import qualified Basement.String as S
-
-data Builder = E String | T [Builder]
-
-instance IsString Builder where
-    fromString = E . fromString
-
-instance Semigroup Builder where
-    (<>) = append
-instance Monoid Builder where
-    mempty = empty
-    mappend = append
-    mconcat = concat
-
-empty :: Builder
-empty = T []
-
-emit :: String -> Builder
-emit s = E s
-
-emitChar :: Char -> Builder
-emitChar c = E (S.singleton c)
-
-toString :: Builder -> String
-toString = mconcat . flatten
-  where
-    flatten (E s) = [s]
-    flatten (T l) = mconcat $ fmap flatten l
-
-append :: Builder -> Builder -> Builder
-append a b = T [a,b]
-
-concat :: [Builder] -> Builder
-concat = T
+import Basement.String.Builder

--- a/Foundation/String/Builder.hs
+++ b/Foundation/String/Builder.hs
@@ -5,12 +5,20 @@
 --
 -- String Builder
 --
--- This is extremely bad implementation of a builder implementation
--- but provide a very similar API to the future fast implementation;
--- So, in the spirit of getting started and to be able to start using
--- the API, we don't wait for the fast implementation.
 module Foundation.String.Builder
     ( module Basement.String.Builder
+    , toString
     ) where
 
 import Basement.String.Builder
+import Basement.String (String)
+import GHC.ST
+
+-- | run the builder and return a `String`
+--
+-- alias to `runUnsafe`
+--
+-- This function is not safe, prefer `run`.
+--
+toString :: Builder -> String
+toString builder = runST (runUnsafe builder)

--- a/Foundation/Timing.hs
+++ b/Foundation/Timing.hs
@@ -13,8 +13,8 @@ module Foundation.Timing
     , measure
     ) where
 
-import           Basement.Imports
-import           Basement.IntegralConv
+import           Basement.Imports hiding (from)
+import           Basement.From (from)
 import           Basement.Monad
 -- import           Basement.UArray hiding (unsafeFreeze)
 import           Basement.UArray.Mutable (MUArray)
@@ -57,7 +57,7 @@ getGCStats = do
     if r then pure Nothing else Just <$> GHC.getGCStats
 
 diffGC :: Maybe GHC.GCStats -> Maybe GHC.GCStats -> Maybe Word64
-diffGC gc2 gc1 = integralCast <$> (((-) `on` GHC.bytesAllocated) <$> gc2 <*> gc1)
+diffGC gc2 gc1 = cast <$> (((-) `on` GHC.bytesAllocated) <$> gc2 <*> gc1)
 #endif
 
 -- | Simple one-time measurement of time & other metrics spent in a function
@@ -72,7 +72,7 @@ stopWatch f !a = do
 -- | In depth timing & other metrics analysis of a function
 measure :: Word -> (a -> b) -> a -> IO Measure
 measure nbIters f a = do
-    d <- mutNew (integralCast nbIters) :: IO (MUArray NanoSeconds (PrimState IO))
+    d <- mutNew (from nbIters) :: IO (MUArray NanoSeconds (PrimState IO))
     loop d 0
     Measure <$> unsafeFreeze d
             <*> pure nbIters
@@ -81,5 +81,5 @@ measure nbIters f a = do
         | i == nbIters = return ()
         | otherwise    = do
             (_, r) <- measuringNanoSeconds (evaluate $ f a)
-            mutUnsafeWrite d (integralCast i) r
+            mutUnsafeWrite d (from i) r
             loop d (i+1)

--- a/Foundation/Timing.hs
+++ b/Foundation/Timing.hs
@@ -15,6 +15,9 @@ module Foundation.Timing
 
 import           Basement.Imports hiding (from)
 import           Basement.From (from)
+#if __GLASGOW_HASKELL__ < 802
+import           Basement.Cast (cast)
+#endif
 import           Basement.Monad
 -- import           Basement.UArray hiding (unsafeFreeze)
 import           Basement.UArray.Mutable (MUArray)

--- a/basement/Basement/Alg/Native/UTF8.hs
+++ b/basement/Basement/Alg/Native/UTF8.hs
@@ -25,7 +25,6 @@ module Basement.Alg.Native.UTF8
     , primIndex64
     , primRead8
     , primWrite8
-    , sizeChar
     ) where
 
 import           GHC.Int
@@ -125,16 +124,6 @@ prevSkip ba offset = loop (offset `offsetMinusE` sz1)
     loop o
         | isContinuation (primIndex8 ba o) = loop (o `offsetMinusE` sz1)
         | otherwise                       = o
-
-sizeChar :: Char -> CountOf Word8
-sizeChar !c
-    | bool# (ltWord# x 0x80##   ) = CountOf 1
-    | bool# (ltWord# x 0x800##  ) = CountOf 2
-    | bool# (ltWord# x 0x10000##) = CountOf 3
-    | otherwise                   = CountOf 4
-  where
-    !(I# xi) = fromEnum c
-    !x       = int2Word# xi
 
 write :: PrimMonad prim => Mutable (PrimState prim) -> Offset8 -> Char -> prim Offset8
 write mba !i !c

--- a/basement/Basement/Alg/Native/UTF8.hs
+++ b/basement/Basement/Alg/Native/UTF8.hs
@@ -25,6 +25,7 @@ module Basement.Alg.Native.UTF8
     , primIndex64
     , primRead8
     , primWrite8
+    , sizeChar
     ) where
 
 import           GHC.Int
@@ -124,6 +125,16 @@ prevSkip ba offset = loop (offset `offsetMinusE` sz1)
     loop o
         | isContinuation (primIndex8 ba o) = loop (o `offsetMinusE` sz1)
         | otherwise                       = o
+
+sizeChar :: Char -> CountOf Word8
+sizeChar !c
+    | bool# (ltWord# x 0x80##   ) = CountOf 1
+    | bool# (ltWord# x 0x800##  ) = CountOf 2
+    | bool# (ltWord# x 0x10000##) = CountOf 3
+    | otherwise                   = CountOf 4
+  where
+    !(I# xi) = fromEnum c
+    !x       = int2Word# xi
 
 write :: PrimMonad prim => Mutable (PrimState prim) -> Offset8 -> Char -> prim Offset8
 write mba !i !c

--- a/basement/Basement/Block/Base.hs
+++ b/basement/Basement/Block/Base.hs
@@ -8,6 +8,7 @@ module Basement.Block.Base
     , unsafeNew
     , unsafeThaw
     , unsafeFreeze
+    , unsafeShrink
     , unsafeCopyElements
     , unsafeCopyElementsRO
     , unsafeCopyBytes
@@ -239,6 +240,10 @@ unsafeFreeze (MutableBlock mba) = primitive $ \s1 ->
     case unsafeFreezeByteArray# mba s1 of
         (# s2, ba #) -> (# s2, Block ba #)
 {-# INLINE unsafeFreeze #-}
+
+unsafeShrink :: PrimMonad prim => MutableBlock ty (PrimState prim) -> CountOf ty -> prim ()
+unsafeShrink (MutableBlock mba) (CountOf (I# nsz)) = primitive $ \s ->
+  (# shrinkMutableByteArray# mba nsz s, () #)
 
 -- | Thaw an immutable block.
 --

--- a/basement/Basement/Block/Base.hs
+++ b/basement/Basement/Block/Base.hs
@@ -13,6 +13,7 @@ module Basement.Block.Base
     , unsafeCopyElementsRO
     , unsafeCopyBytes
     , unsafeCopyBytesRO
+    , unsafeCopyBytesPtr
     , unsafeRead
     , unsafeWrite
     , unsafeIndex
@@ -325,6 +326,17 @@ unsafeCopyBytesRO :: forall prim ty . PrimMonad prim
 unsafeCopyBytesRO (MutableBlock dstMba) (Offset (I# d)) (Block srcBa) (Offset (I# s)) (CountOf (I# n)) =
     primitive $ \st -> (# copyByteArray# srcBa s dstMba d n st, () #)
 {-# INLINE unsafeCopyBytesRO #-}
+
+-- | Copy a number of bytes from a Ptr to a MutableBlock with specific byte offsets
+unsafeCopyBytesPtr :: forall prim ty . PrimMonad prim
+                   => MutableBlock ty (PrimState prim) -- ^ destination mutable block
+                   -> Offset Word8                     -- ^ offset at destination
+                   -> Ptr ty                           -- ^ source block
+                   -> CountOf Word8                    -- ^ number of bytes to copy
+                   -> prim ()
+unsafeCopyBytesPtr (MutableBlock dstMba) (Offset (I# d)) (Ptr srcBa) (CountOf (I# n)) =
+    primitive $ \st -> (# copyAddrToByteArray# srcBa dstMba d n st, () #)
+{-# INLINE unsafeCopyBytesPtr #-}
 
 -- | read from a cell in a mutable block without bounds checking.
 --

--- a/basement/Basement/Block/Base.hs
+++ b/basement/Basement/Block/Base.hs
@@ -26,6 +26,7 @@ module Basement.Block.Base
     , newPinned
     , withPtr
     , mutableWithPtr
+    , unsafeRecast
     ) where
 
 import           GHC.Prim
@@ -379,3 +380,8 @@ mutableWithPtr :: PrimMonad prim
 mutableWithPtr mb f = do
     b <- unsafeFreeze mb
     withPtr b f
+
+unsafeRecast :: (PrimType t1, PrimType t2)
+             => MutableBlock t1 st
+             -> MutableBlock t2 st
+unsafeRecast (MutableBlock mba) = MutableBlock mba

--- a/basement/Basement/Block/Builder.hs
+++ b/basement/Basement/Block/Builder.hs
@@ -22,6 +22,8 @@ module Basement.Block.Builder
     ) where
 
 import qualified Basement.Alg.Native.UTF8      as PrimBA
+import           Basement.UTF8.Helper          (charToBytes)
+import           Basement.Numerical.Conversion (charToInt)
 import           Basement.Block.Base (Block(..), MutableBlock(..))
 import qualified Basement.Block.Base as B
 import           Basement.Cast
@@ -135,5 +137,5 @@ emitString (String str) = Builder size $ Action $ \arr off ->
 --
 -- this function may be replaced by `emit :: Encoding -> Char -> Builder`
 emitUTF8Char :: Char -> Builder
-emitUTF8Char c = Builder 4 $ Action $ \(MutableBlock arr) off ->
+emitUTF8Char c = Builder (charToBytes $ charToInt c) $ Action $ \(MutableBlock arr) off ->
     PrimBA.write arr off c

--- a/basement/Basement/Block/Builder.hs
+++ b/basement/Basement/Block/Builder.hs
@@ -1,0 +1,138 @@
+-- |
+-- Module      : Basement.Block.Builder
+-- License     : BSD-style
+-- Maintainer  : Foundation
+--
+-- Block builder
+
+{-# LANGUAGE Rank2Types #-}
+
+module Basement.Block.Builder
+    ( Builder
+    , run
+
+    -- * Emit functions
+    , emit
+    , emitPrim
+    , emitString
+    , emitUTF8Char
+
+    -- * unsafe
+    , unsafeRunString
+    ) where
+
+import qualified Basement.Alg.Native.UTF8      as PrimBA
+import           Basement.Block.Base (Block(..), MutableBlock(..))
+import qualified Basement.Block.Base as B
+import           Basement.Cast
+import           Basement.Compat.Base
+import           Basement.Compat.Semigroup
+import           Basement.Monad
+import           Basement.FinalPtr (FinalPtr, withFinalPtr)
+import           Basement.Numerical.Additive
+import           Basement.String                (String(..))
+import qualified Basement.String as S
+import           Basement.Types.OffsetSize
+import           Basement.PrimType (PrimType(..), primMbaWrite)
+import           Basement.UArray.Base (UArray(..))
+import qualified Basement.UArray.Base as A
+
+import           GHC.ST
+import           Data.Proxy
+
+newtype Action = Action
+    { runAction_ :: forall prim . PrimMonad prim
+                 => MutableBlock Word8 (PrimState prim)
+                 -> Offset Word8
+                 -> prim (Offset Word8)
+    }
+
+data Builder = Builder Action (CountOf Word8)
+
+instance Semigroup Builder where
+    (<>) = append
+    {-# INLINABLE (<>) #-}
+instance Monoid Builder where
+    mempty = empty
+    {-# INLINE mempty #-}
+    mappend = append
+    {-# INLINABLE mappend #-}
+
+-- | create an empty builder
+--
+-- this does nothing, build nothing, take no space (in the resulted block)
+empty :: Builder
+empty = Builder (Action $ \_ _ -> pure 0) 0
+{-# INLINE empty #-}
+
+-- | concatenate the 2 given bulider
+append :: Builder -> Builder -> Builder
+append (Builder (Action action1) size1) (Builder (Action action2) size2) =
+    Builder action size
+  where
+    action = Action $ \arr off -> do
+      off' <- action1 arr off
+      action2 arr off'
+    size = size1 + size2
+{-# INLINABLE append #-}
+
+-- | run the given builder and return the generated block
+run :: PrimMonad prim => Builder -> prim (Block Word8)
+run (Builder action sz) = do
+    mb <- B.new sz
+    off <- runAction_ action mb 0
+    B.unsafeShrink mb (offsetAsSize off)
+    B.unsafeFreeze mb
+
+-- | run the given builder and return a UTF8String
+--
+-- this action is unsafe as there is no guarantee upon the validity of the
+-- content of the built block.
+unsafeRunString :: PrimMonad prim => Builder -> prim String
+unsafeRunString b = do
+    str <- run b
+    pure $ String $ A.UArray 0 (B.length str) (A.UArrayBA str)
+
+-- | add a Block in the builder
+emit :: Block a -> Builder
+emit b = flip Builder size $ Action $ \arr off ->
+    B.unsafeCopyBytesRO arr off b' 0 size *> pure (off + sizeAsOffset size)
+  where
+    b' :: Block Word8
+    b' = cast b
+    size :: CountOf Word8
+    size = B.length b'
+
+emitPrim :: (PrimType ty, ty ~ Word8) => ty -> Builder
+emitPrim a = flip Builder size $ Action $ \(MutableBlock arr) off ->
+    primMbaWrite arr off a *> pure (off + sizeAsOffset size)
+  where
+    size = getSize Proxy a
+    getSize :: PrimType ty => Proxy ty -> ty -> CountOf Word8
+    getSize p _ = primSizeInBytes p
+
+-- | add a string in the builder
+emitString :: String -> Builder
+emitString (String str) = flip Builder size $ Action $ \arr off ->
+    A.onBackendPrim (onBA arr off) (onAddr arr off) str *> pure (off + sizeAsOffset size)
+  where
+    size = A.length str
+    onBA :: PrimMonad prim
+         => MutableBlock Word8 (PrimState prim)
+         -> Offset Word8
+         -> Block Word8
+         -> prim ()
+    onBA   arr off ba   = B.unsafeCopyBytesRO arr off ba 0 size
+    onAddr :: PrimMonad prim
+           => MutableBlock Word8 (PrimState prim)
+           -> Offset Word8
+           -> FinalPtr Word8
+           -> prim ()
+    onAddr arr off fptr = withFinalPtr fptr $ \ptr -> B.unsafeCopyBytesPtr arr off ptr size
+
+-- | emit a UTF8 char in the builder
+--
+-- this function may be replaced by `emit :: Encoding -> Char -> Builder`
+emitUTF8Char :: Char -> Builder
+emitUTF8Char c = flip Builder 4 $ Action $ \(MutableBlock arr) off ->
+    PrimBA.write arr off c

--- a/basement/Basement/Block/Mutable.hs
+++ b/basement/Basement/Block/Mutable.hs
@@ -55,6 +55,7 @@ module Basement.Block.Mutable
     , unsafeCopyElementsRO
     , unsafeCopyBytes
     , unsafeCopyBytesRO
+    , unsafeCopyBytesPtr
     ) where
 
 import           GHC.Prim

--- a/basement/Basement/Cast.hs
+++ b/basement/Basement/Cast.hs
@@ -1,0 +1,151 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE ConstraintKinds       #-}
+{-# LANGUAGE CPP                   #-}
+{-# LANGUAGE MagicHash             #-}
+{-# LANGUAGE UndecidableInstances  #-}
+-- |
+-- Module      : Basement.Cast
+-- License     : BSD-style
+-- Maintainer  : Haskell Foundation
+--
+module Basement.Cast
+    ( Cast(..)
+    ) where
+
+import           Basement.Compat.Base
+
+import           GHC.Types
+import           GHC.Prim
+import           GHC.Int
+import           GHC.Word
+import           Basement.Numerical.Number
+import           Basement.Numerical.Conversion
+import qualified Basement.Block.Base as Block
+import qualified Basement.BoxedArray as BoxArray
+import qualified Basement.UArray as UArray
+import qualified Basement.String as String
+import qualified Basement.Types.AsciiString as AsciiString
+import           Basement.Types.Word128 (Word128(..))
+import           Basement.Types.Word256 (Word256(..))
+import qualified Basement.Types.Word128 as Word128
+import qualified Basement.Types.Word256 as Word256
+import           Basement.These
+import           Basement.PrimType (PrimType)
+import           Basement.Types.OffsetSize
+import           Basement.Compat.Natural
+import qualified Prelude (fromIntegral)
+
+-- | `Cast` an object of type a to b.
+--
+-- Do not add instance of this class if the source type is not of the same
+-- size of the destination type. Also keep in mind this is casting a value
+-- of a given type into a destination type. The value won't be changed to
+-- fit the destination represention.
+--
+-- If you wish to convert a value of a given type into another type, look at
+-- `From` and `TryFrom`.
+--
+-- @
+-- cast (-10 :: Int) :: Word === 18446744073709551606
+-- @
+--
+class Cast source destination where
+    cast :: source -> destination
+
+instance Cast Int Word where
+    cast (I# i) = W# (int2Word# i)
+instance Cast Word Int where
+    cast (W# w) = I# (word2Int# w)
+
+-- Int casts
+
+instance Cast Int8 Int16 where
+    cast (I8# i) = I16# i
+instance Cast Int8 Int32 where
+    cast (I8# i) = I32# i
+instance Cast Int8 Int64 where
+    cast (I8# i) = intToInt64 (I# i)
+instance Cast Int8 Int where
+    cast (I8# i) = I# i
+
+instance Cast Int16 Int32 where
+    cast (I16# i) = I32# i
+instance Cast Int16 Int64 where
+    cast (I16# i) = intToInt64 (I# i)
+instance Cast Int16 Int where
+    cast (I16# i) = I# i
+
+instance Cast Int32 Int64 where
+    cast (I32# i) = intToInt64 (I# i)
+instance Cast Int32 Int where
+    cast (I32# i) = I# i
+
+instance Cast Int Int64 where
+    cast = intToInt64
+
+-- Word casts
+
+instance Cast Word8 Word16 where
+    cast (W8# i) = W16# i
+instance Cast Word8 Word32 where
+    cast (W8# i) = W32# i
+instance Cast Word8 Word64 where
+    cast (W8# i) = wordToWord64 (W# i)
+instance Cast Word8 Word128 where
+    cast (W8# i) = Word128 0 (wordToWord64 $ W# i)
+instance Cast Word8 Word256 where
+    cast (W8# i) = Word256 0 0 0 (wordToWord64 $ W# i)
+instance Cast Word8 Word where
+    cast (W8# i) = W# i
+instance Cast Word8 Int8 where
+    cast (W8# w) = I8# (word2Int# w)
+instance Cast Word8 Int16 where
+    cast (W8# w) = I16# (word2Int# w)
+instance Cast Word8 Int32 where
+    cast (W8# w) = I32# (word2Int# w)
+instance Cast Word8 Int64 where
+    cast (W8# w) = intToInt64 (I# (word2Int# w))
+instance Cast Word8 Int where
+    cast (W8# w) = I# (word2Int# w)
+
+instance Cast Word16 Word32 where
+    cast (W16# i) = W32# i
+instance Cast Word16 Word64 where
+    cast (W16# i) = wordToWord64 (W# i)
+instance Cast Word16 Word128 where
+    cast (W16# i) = Word128 0 (wordToWord64 $ W# i)
+instance Cast Word16 Word256 where
+    cast (W16# i) = Word256 0 0 0 (wordToWord64 $ W# i)
+instance Cast Word16 Word where
+    cast (W16# i) = W# i
+instance Cast Word16 Int16 where
+    cast (W16# w) = I16# (word2Int# w)
+instance Cast Word16 Int32 where
+    cast (W16# w) = I32# (word2Int# w)
+instance Cast Word16 Int64 where
+    cast (W16# w) = intToInt64 (I# (word2Int# w))
+instance Cast Word16 Int where
+    cast (W16# w) = I# (word2Int# w)
+
+instance Cast Word32 Word64 where
+    cast (W32# i) = wordToWord64 (W# i)
+instance Cast Word32 Word128 where
+    cast (W32# i) = Word128 0 (wordToWord64 $ W# i)
+instance Cast Word32 Word256 where
+    cast (W32# i) = Word256 0 0 0 (wordToWord64 $ W# i)
+instance Cast Word32 Word where
+    cast (W32# i) = W# i
+
+instance Cast Word64 Word128 where
+    cast w = Word128 0 w
+instance Cast Word64 Word256 where
+    cast w = Word256 0 0 0 w
+
+instance Cast Word Word64 where
+    cast = wordToWord64
+
+
+instance Cast (Block.Block a) (Block.Block Word8) where
+    cast (Block.Block ba) = Block.Block ba

--- a/basement/Basement/Cast.hs
+++ b/basement/Basement/Cast.hs
@@ -64,7 +64,7 @@ instance Cast Int16 Word16 where
 instance Cast Int32 Word32 where
     cast (I32# i) = W32# (narrow32Word# (int2Word# i))
 instance Cast Int64 Word64 where
-    cast (I64# i) = W64# (int2Word# i)
+    cast = int64ToWord64
 instance Cast Int   Word where
     cast (I# i) = W# (int2Word# i)
 
@@ -75,7 +75,7 @@ instance Cast Word16 Int16 where
 instance Cast Word32 Int32 where
     cast (W32# i) = I32# (narrow32Int# (word2Int# i))
 instance Cast Word64 Int64 where
-    cast (W64# i) = I64# (word2Int# i)
+    cast = word64ToInt64
 instance Cast Word   Int where
     cast (W# w) = I# (word2Int# w)
 

--- a/basement/Basement/Cast.hs
+++ b/basement/Basement/Cast.hs
@@ -10,7 +10,7 @@
 -- Maintainer  : Haskell Foundation
 --
 module Basement.Cast
-    ( Cast, cast
+    ( Cast(..)
     ) where
 
 #include "MachDeps.h"

--- a/basement/Basement/Cast.hs
+++ b/basement/Basement/Cast.hs
@@ -26,6 +26,7 @@ import           Data.Proxy (Proxy(..))
 
 import           GHC.Int
 import           GHC.Prim
+import           GHC.Types
 import           GHC.ST
 import           GHC.Word
 

--- a/basement/Basement/From.hs
+++ b/basement/Basement/From.hs
@@ -154,6 +154,12 @@ instance From Word16 Word256 where
     from (W16# i) = Word256 0 0 0 (wordToWord64 $ W# i)
 instance From Word16 Word where
     from (W16# i) = W# i
+instance From Word16 Int32 where
+    from (W16# w) = I32# (word2Int# w)
+instance From Word16 Int64 where
+    from (W16# w) = intToInt64 (I# (word2Int# w))
+instance From Word16 Int where
+    from (W16# w) = I# (word2Int# w)
 
 instance From Word32 Word64 where
     from (W32# i) = wordToWord64 (W# i)
@@ -163,6 +169,10 @@ instance From Word32 Word256 where
     from (W32# i) = Word256 0 0 0 (wordToWord64 $ W# i)
 instance From Word32 Word where
     from (W32# i) = W# i
+instance From Word32 Int64 where
+    from (W32# w) = intToInt64 (I# (word2Int# w))
+instance From Word32 Int where
+    from (W32# w) = I# (word2Int# w)
 
 instance From Word64 Word128 where
     from w = Word128 0 w

--- a/basement/Basement/From.hs
+++ b/basement/Basement/From.hs
@@ -41,6 +41,7 @@ import           Basement.Numerical.Number
 import           Basement.Numerical.Conversion
 import qualified Basement.Block as Block
 import qualified Basement.BoxedArray as BoxArray
+import           Basement.Cast (cast)
 import qualified Basement.UArray as UArray
 import qualified Basement.String as String
 import qualified Basement.Types.AsciiString as AsciiString
@@ -191,7 +192,9 @@ instance From (Maybe a) (Either () a) where
 instance From (CountOf ty) Int where
     from (CountOf n) = n
 instance From (CountOf ty) Word where
-    from (CountOf n) = from n
+    -- here it is ok to cast the underlying `Int` held by `CountOf` to a `Word`
+    -- as the `Int` should never hold a negative value.
+    from (CountOf n) = cast n
 
 instance From (Either a b) (These a b) where
     from (Left a) = This a

--- a/basement/Basement/From.hs
+++ b/basement/Basement/From.hs
@@ -94,12 +94,6 @@ tryInto = tryFrom
 instance From a a where
     from = id
 
--- Simple numerical instances
-instance From Int Word where
-    from (I# i) = W# (int2Word# i)
-instance From Word Int where
-    from (W# w) = I# (word2Int# w)
-
 instance IsNatural n => From n Natural where
     from = toNatural
 instance IsIntegral n => From n Integer where

--- a/basement/Basement/From.hs
+++ b/basement/Basement/From.hs
@@ -195,6 +195,18 @@ instance From (CountOf ty) Word where
     -- here it is ok to cast the underlying `Int` held by `CountOf` to a `Word`
     -- as the `Int` should never hold a negative value.
     from (CountOf n) = cast n
+instance From Word (Offset ty) where
+    from w = Offset (cast w)
+instance TryFrom Int (Offset ty) where
+    tryFrom i
+        | i < 0     = Nothing
+        | otherwise = Just (Offset i)
+instance TryFrom Int (CountOf ty) where
+    tryFrom i
+        | i < 0     = Nothing
+        | otherwise = Just (CountOf i)
+instance From Word (CountOf ty) where
+    from w = CountOf (cast w)
 
 instance From (Either a b) (These a b) where
     from (Left a) = This a

--- a/basement/Basement/IntegralConv.hs
+++ b/basement/Basement/IntegralConv.hs
@@ -7,7 +7,6 @@
 module Basement.IntegralConv
     ( IntegralDownsize(..)
     , IntegralUpsize(..)
-    , IntegralCast(..)
     , intToInt64
     , int64ToInt
     , wordToWord64
@@ -43,13 +42,6 @@ class IntegralDownsize a b where
 -- than the size type of 'a'
 class IntegralUpsize a b where
     integralUpsize      :: a -> b
-
--- | Cast an integral value to another value
--- that have the same representional size
-class IntegralCast a b where
-    integralCast :: a -> b
-    default integralCast :: a ~ b => a -> b
-    integralCast = id
 
 integralDownsizeBounded :: forall a b . (Ord a, Bounded b, IntegralDownsize a b, IntegralUpsize b a)
                         => (a -> b)
@@ -219,30 +211,3 @@ instance IntegralDownsize Natural Word32 where
 instance IntegralDownsize Natural Word64 where
     integralDownsize = fromIntegral
     integralDownsizeCheck = integralDownsizeBounded integralDownsize
-
-instance IntegralCast Word Int where
-    integralCast (W# w) = I# (word2Int# w)
-instance IntegralCast Int Word where
-    integralCast (I# i) = W# (int2Word# i)
-instance IntegralCast Word64 Int64 where
-    integralCast = word64ToInt64
-instance IntegralCast Int64 Word64 where
-    integralCast = int64ToWord64
-
-instance IntegralCast Int8 Word8 where
-    integralCast (I8# i) = W8# (narrow8Word# (int2Word# i))
-
-instance IntegralCast Int16 Word16 where
-    integralCast (I16# i) = W16# (narrow16Word# (int2Word# i))
-
-instance IntegralCast Int32 Word32 where
-    integralCast (I32# i) = W32# (narrow32Word# (int2Word# i))
-
-instance IntegralCast Word8 Int8 where
-    integralCast (W8# i) = I8# (narrow8Int# (word2Int# i))
-
-instance IntegralCast Word16 Int16 where
-    integralCast (W16# i) = I16# (narrow16Int# (word2Int# i))
-
-instance IntegralCast Word32 Int32 where
-    integralCast (W32# i) = I32# (narrow32Int# (word2Int# i))

--- a/basement/Basement/Numerical/Conversion.hs
+++ b/basement/Basement/Numerical/Conversion.hs
@@ -3,6 +3,7 @@
 module Basement.Numerical.Conversion
     ( intToInt64
     , int64ToInt
+    , intToWord
     , wordToWord64
     , word64ToWord
     , Word32x2(..)
@@ -91,6 +92,9 @@ wordToChar (W# word) = C# (chr# (word2Int# word))
 
 wordToInt :: Word -> Int
 wordToInt (W# word) = I# (word2Int# word)
+
+intToWord :: Int -> Word
+intToWord (I# i) = W# (int2Word# i)
 
 charToInt :: Char -> Int
 charToInt (C# x) = I# (ord# x)

--- a/basement/Basement/PrimType.hs
+++ b/basement/Basement/PrimType.hs
@@ -50,6 +50,7 @@ import           Basement.Endianness
 import           Basement.Types.Word128 (Word128(..))
 import           Basement.Types.Word256 (Word256(..))
 import           Basement.Monad
+import           Basement.Nat
 import qualified Prelude (quot)
 
 #if WORD_SIZE_IN_BITS < 64

--- a/basement/Basement/PrimType.hs
+++ b/basement/Basement/PrimType.hs
@@ -4,6 +4,7 @@
 -- Stability   : experimental
 -- Portability : portable
 --
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -160,6 +161,9 @@ primMutableArrayWrite ma (Offset (I# ofs)) v =
 --
 -- Types need to be a instance of storable and have fixed sized.
 class Eq ty => PrimType ty where
+    -- | type level size of the given `ty`
+    type PrimSize ty :: Nat
+
     -- | get the size in bytes of a ty element
     primSizeInBytes :: Proxy ty -> CountOf Word8
 
@@ -227,6 +231,11 @@ shiftWord = 2
 {-# SPECIALIZE [3] primBaUIndex :: ByteArray# -> Offset Word8 -> Word8 #-}
 
 instance PrimType Int where
+#if WORD_SIZE_IN_BITS == 64
+    type PrimSize Int = 8
+#else
+    type PrimSize Int = 4
+#endif
     primSizeInBytes _ = sizeInt
     {-# INLINE primSizeInBytes #-}
     primShiftToBytes _ = shiftInt
@@ -245,6 +254,11 @@ instance PrimType Int where
     {-# INLINE primAddrWrite #-}
 
 instance PrimType Word where
+#if WORD_SIZE_IN_BITS == 64
+    type PrimSize Word = 8
+#else
+    type PrimSize Word = 4
+#endif
     primSizeInBytes _ = sizeWord
     {-# INLINE primSizeInBytes #-}
     primShiftToBytes _ = shiftWord
@@ -263,6 +277,7 @@ instance PrimType Word where
     {-# INLINE primAddrWrite #-}
 
 instance PrimType Word8 where
+    type PrimSize Word8 = 1
     primSizeInBytes _ = CountOf 1
     {-# INLINE primSizeInBytes #-}
     primShiftToBytes _ = 0
@@ -281,6 +296,7 @@ instance PrimType Word8 where
     {-# INLINE primAddrWrite #-}
 
 instance PrimType Word16 where
+    type PrimSize Word16 = 2
     primSizeInBytes _ = CountOf 2
     {-# INLINE primSizeInBytes #-}
     primShiftToBytes _ = 1
@@ -298,6 +314,7 @@ instance PrimType Word16 where
     primAddrWrite addr (Offset (I# n)) (W16# w) = primitive $ \s1 -> (# writeWord16OffAddr# addr n w s1, () #)
     {-# INLINE primAddrWrite #-}
 instance PrimType Word32 where
+    type PrimSize Word32 = 4
     primSizeInBytes _ = CountOf 4
     {-# INLINE primSizeInBytes #-}
     primShiftToBytes _ = 2
@@ -315,6 +332,7 @@ instance PrimType Word32 where
     primAddrWrite addr (Offset (I# n)) (W32# w) = primitive $ \s1 -> (# writeWord32OffAddr# addr n w s1, () #)
     {-# INLINE primAddrWrite #-}
 instance PrimType Word64 where
+    type PrimSize Word64 = 8
     primSizeInBytes _ = CountOf 8
     {-# INLINE primSizeInBytes #-}
     primShiftToBytes _ = 3
@@ -332,6 +350,7 @@ instance PrimType Word64 where
     primAddrWrite addr (Offset (I# n)) (W64# w) = primitive $ \s1 -> (# writeWord64OffAddr# addr n w s1, () #)
     {-# INLINE primAddrWrite #-}
 instance PrimType Word128 where
+    type PrimSize Word128 = 16
     primSizeInBytes _ = CountOf 16
     {-# INLINE primSizeInBytes #-}
     primShiftToBytes _ = 4
@@ -364,6 +383,7 @@ instance PrimType Word128 where
       where (# n1, n2 #) = offset128_64 n
     {-# INLINE primAddrWrite #-}
 instance PrimType Word256 where
+    type PrimSize Word256 = 32
     primSizeInBytes _ = CountOf 32
     {-# INLINE primSizeInBytes #-}
     primShiftToBytes _ = 5
@@ -406,6 +426,7 @@ instance PrimType Word256 where
       where (# n1, n2, n3, n4 #) = offset256_64 n
     {-# INLINE primAddrWrite #-}
 instance PrimType Int8 where
+    type PrimSize Int8 = 1
     primSizeInBytes _ = CountOf 1
     {-# INLINE primSizeInBytes #-}
     primShiftToBytes _ = 0
@@ -423,6 +444,7 @@ instance PrimType Int8 where
     primAddrWrite addr (Offset (I# n)) (I8# w) = primitive $ \s1 -> (# writeInt8OffAddr# addr n w s1, () #)
     {-# INLINE primAddrWrite #-}
 instance PrimType Int16 where
+    type PrimSize Int16 = 2
     primSizeInBytes _ = CountOf 2
     {-# INLINE primSizeInBytes #-}
     primShiftToBytes _ = 1
@@ -440,6 +462,7 @@ instance PrimType Int16 where
     primAddrWrite addr (Offset (I# n)) (I16# w) = primitive $ \s1 -> (# writeInt16OffAddr# addr n w s1, () #)
     {-# INLINE primAddrWrite #-}
 instance PrimType Int32 where
+    type PrimSize Int32 = 4
     primSizeInBytes _ = CountOf 4
     {-# INLINE primSizeInBytes #-}
     primShiftToBytes _ = 2
@@ -457,6 +480,7 @@ instance PrimType Int32 where
     primAddrWrite addr (Offset (I# n)) (I32# w) = primitive $ \s1 -> (# writeInt32OffAddr# addr n w s1, () #)
     {-# INLINE primAddrWrite #-}
 instance PrimType Int64 where
+    type PrimSize Int64 = 8
     primSizeInBytes _ = CountOf 8
     {-# INLINE primSizeInBytes #-}
     primShiftToBytes _ = 3
@@ -475,6 +499,7 @@ instance PrimType Int64 where
     {-# INLINE primAddrWrite #-}
 
 instance PrimType Float where
+    type PrimSize Float = 4
     primSizeInBytes _ = CountOf 4
     {-# INLINE primSizeInBytes #-}
     primShiftToBytes _ = 2
@@ -492,6 +517,7 @@ instance PrimType Float where
     primAddrWrite addr (Offset (I# n)) (F# w) = primitive $ \s1 -> (# writeFloatOffAddr# addr n w s1, () #)
     {-# INLINE primAddrWrite #-}
 instance PrimType Double where
+    type PrimSize Double = 8
     primSizeInBytes _ = CountOf 8
     {-# INLINE primSizeInBytes #-}
     primShiftToBytes _ = 3
@@ -510,6 +536,7 @@ instance PrimType Double where
     {-# INLINE primAddrWrite #-}
 
 instance PrimType Char where
+    type PrimSize Char = 4
     primSizeInBytes _ = CountOf 4
     {-# INLINE primSizeInBytes #-}
     primShiftToBytes _ = 2
@@ -528,6 +555,7 @@ instance PrimType Char where
     {-# INLINE primAddrWrite #-}
 
 instance PrimType CChar where
+    type PrimSize CChar = 1
     primSizeInBytes _ = CountOf 1
     {-# INLINE primSizeInBytes #-}
     primShiftToBytes _ = 0
@@ -545,6 +573,7 @@ instance PrimType CChar where
     primAddrWrite addr (Offset n) (CChar int8) = primAddrWrite addr (Offset n) int8
     {-# INLINE primAddrWrite #-}
 instance PrimType CUChar where
+    type PrimSize CUChar = 1
     primSizeInBytes _ = CountOf 1
     {-# INLINE primSizeInBytes #-}
     primShiftToBytes _ = 0
@@ -563,6 +592,7 @@ instance PrimType CUChar where
     {-# INLINE primAddrWrite #-}
 
 instance PrimType Char7 where
+    type PrimSize Char7 = 1
     primSizeInBytes _ = CountOf 1
     {-# INLINE primSizeInBytes #-}
     primShiftToBytes _ = 0
@@ -581,6 +611,7 @@ instance PrimType Char7 where
     {-# INLINE primAddrWrite #-}
 
 instance PrimType a => PrimType (LE a) where
+    type PrimSize (LE a) = PrimSize a
     primSizeInBytes _ = primSizeInBytes (Proxy :: Proxy a)
     {-# INLINE primSizeInBytes #-}
     primShiftToBytes _ = primShiftToBytes (Proxy :: Proxy a)
@@ -598,6 +629,7 @@ instance PrimType a => PrimType (LE a) where
     primAddrWrite addr (Offset a) (LE w) = primAddrWrite addr (Offset a) w
     {-# INLINE primAddrWrite #-}
 instance PrimType a => PrimType (BE a) where
+    type PrimSize (BE a) = PrimSize a
     primSizeInBytes _ = primSizeInBytes (Proxy :: Proxy a)
     {-# INLINE primSizeInBytes #-}
     primShiftToBytes _ = primShiftToBytes (Proxy :: Proxy a)

--- a/basement/Basement/String.hs
+++ b/basement/Basement/String.hs
@@ -109,6 +109,7 @@ import           Basement.Numerical.Additive
 import           Basement.Numerical.Subtractive
 import           Basement.Numerical.Multiplicative
 import           Basement.Numerical.Number
+import           Basement.Cast
 import           Basement.Monad
 import           Basement.PrimType
 import           Basement.FinalPtr
@@ -611,7 +612,7 @@ length (String arr)
 replicate :: CountOf Char -> Char -> String
 replicate (CountOf n) c = runST (new nbBytes >>= fill)
   where
-    nbBytes   = scale (integralCast n :: Word) sz
+    nbBytes   = scale (cast n :: Word) sz
     sz = charToBytes (fromEnum c)
     fill :: PrimMonad prim => MutableString (PrimState prim) -> prim String
     fill ms = loop (Offset 0)
@@ -1135,7 +1136,7 @@ readRational s =
         case mExponant of
             Just exponent
                 | exponent < -10000 || exponent > 10000 -> Nothing
-                | otherwise                             -> Just $ modF isNegative integral % (10 Prelude.^ (integralCast floatingDigits - exponent))
+                | otherwise                             -> Just $ modF isNegative integral % (10 Prelude.^ (cast floatingDigits - exponent))
             Nothing                                     -> Just $ modF isNegative integral % (10 Prelude.^ floatingDigits)
   where
     modF True  = negate . integralUpsize
@@ -1192,9 +1193,9 @@ readFloatingExact str f
         consumeFloat isNegative integral startOfs =
             case decimalDigitsBA integral ba eofs startOfs of
                 (# acc, True, endOfs #) | endOfs > startOfs -> let (CountOf !diff) = endOfs - startOfs
-                                                                in f isNegative acc (integralCast diff) Nothing
+                                                                in f isNegative acc (cast diff) Nothing
                 (# acc, False, endOfs #) | endOfs > startOfs -> let (CountOf !diff) = endOfs - startOfs
-                                                                in consumeExponant isNegative acc (integralCast diff) endOfs
+                                                                in consumeExponant isNegative acc (cast diff) endOfs
                 _                                           -> Nothing
 
         consumeExponant !isNegative !integral !floatingDigits !startOfs
@@ -1232,9 +1233,9 @@ readFloatingExact str f
         consumeFloat isNegative integral startOfs =
             case decimalDigitsPtr integral ptr eofs startOfs of
                 (# acc, True, endOfs #) | endOfs > startOfs -> let (CountOf !diff) = endOfs - startOfs
-                                                                in f isNegative acc (integralCast diff) Nothing
+                                                                in f isNegative acc (cast diff) Nothing
                 (# acc, False, endOfs #) | endOfs > startOfs -> let (CountOf !diff) = endOfs - startOfs
-                                                                in consumeExponant isNegative acc (integralCast diff) endOfs
+                                                                in consumeExponant isNegative acc (cast diff) endOfs
                 _                                           -> Nothing
 
         consumeExponant !isNegative !integral !floatingDigits !startOfs

--- a/basement/Basement/String/Builder.hs
+++ b/basement/Basement/String/Builder.hs
@@ -1,0 +1,51 @@
+-- |
+-- Module      : Basement.String.Builder
+-- License     : BSD-style
+-- Maintainer  : Foundation
+--
+-- String builder
+
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Basement.String.Builder
+    ( Builder
+    , run
+    , runUnsafe
+
+    -- * Emit functions
+    , emit
+    , emitChar
+    ) where
+
+
+import qualified Basement.Block.Base as Block (length)
+import qualified Basement.Block.Builder as Block
+import           Basement.Compat.Base
+import           Basement.Compat.Semigroup
+import           Basement.Monad
+import           Basement.String (String, ValidationFailure, Encoding (UTF8), fromBytes)
+import           Basement.UArray.Base (UArray)
+import qualified Basement.UArray.Base as A
+
+newtype Builder = Builder Block.Builder
+  deriving (Semigroup, Monoid)
+
+run :: PrimMonad prim => Builder -> prim (String, Maybe ValidationFailure, UArray Word8)
+run (Builder builder) = do
+    block <- Block.run builder
+    let array = A.UArray 0 (Block.length block) (A.UArrayBA block)
+    pure $ fromBytes UTF8 array
+
+-- | run the given builder and return the generated String
+--
+-- prefer `run`
+runUnsafe :: PrimMonad prim => Builder -> prim String
+runUnsafe (Builder builder) = Block.unsafeRunString builder
+
+-- | add a string in the builder
+emit :: String -> Builder
+emit = Builder . Block.emitString
+
+-- | emit a UTF8 char in the builder
+emitChar :: Char -> Builder
+emitChar = Builder . Block.emitUTF8Char

--- a/basement/Basement/Types/OffsetSize.hs
+++ b/basement/Basement/Types/OffsetSize.hs
@@ -61,6 +61,7 @@ import Basement.Numerical.Number
 import Basement.Numerical.Additive
 import Basement.Numerical.Subtractive
 import Basement.Numerical.Multiplicative
+import Basement.Numerical.Conversion (intToWord)
 import Basement.Nat
 import Basement.IntegralConv
 import Data.List (foldl')
@@ -88,14 +89,10 @@ newtype Offset ty = Offset Int
 instance IsIntegral (Offset ty) where
     toInteger (Offset i) = toInteger i
 instance IsNatural (Offset ty) where
-    toNatural (Offset i) = toNatural (integralCast i :: Word)
+    toNatural (Offset i) = toNatural (intToWord i)
 instance Subtractive (Offset ty) where
     type Difference (Offset ty) = CountOf ty
     (Offset a) - (Offset b) = CountOf (a-b)
-instance IntegralCast Int (Offset ty) where
-    integralCast i = Offset i
-instance IntegralCast Word (Offset ty) where
-    integralCast (W# w) = Offset (I# (word2Int# w))
 
 (+.) :: Offset ty -> Int -> Offset ty
 (+.) (Offset a) b = Offset (a + b)
@@ -192,7 +189,7 @@ instance Prelude.Num (CountOf ty) where
 instance IsIntegral (CountOf ty) where
     toInteger (CountOf i) = toInteger i
 instance IsNatural (CountOf ty) where
-    toNatural (CountOf i) = toNatural (integralCast i :: Word)
+    toNatural (CountOf i) = toNatural (intToWord i)
 
 instance Additive (CountOf ty) where
     azero = CountOf 0
@@ -210,11 +207,6 @@ instance Monoid (CountOf ty) where
     mempty = azero
     mappend = (+)
     mconcat = foldl' (+) 0
-
-instance IntegralCast Int (CountOf ty) where
-    integralCast i = CountOf i
-instance IntegralCast Word (CountOf ty) where
-    integralCast (W# w) = CountOf (I# (word2Int# w))
 
 sizeOfE :: CountOf Word8 -> CountOf ty -> CountOf Word8
 sizeOfE (CountOf sz) (CountOf ty) = CountOf (ty * sz)

--- a/basement/Basement/UArray/Mutable.hs
+++ b/basement/Basement/UArray/Mutable.hs
@@ -165,10 +165,10 @@ copyFromPtr src@(Ptr src#) count marr
     ofs = mutableOffset marr
 
     sz = primSizeInBytes (Proxy :: Proxy ty)
-    !(CountOf bytes@(I# bytes#)) = sizeOfE sz count
-    !(Offset od@(I# od#)) = offsetOfE sz ofs
+    !count'@(CountOf bytes@(I# bytes#)) = sizeOfE sz count
+    !off'@(Offset od@(I# od#)) = offsetOfE sz ofs
 
-    copyNative (MutableBlock mba) = primitive $ \st -> (# copyAddrToByteArray# src# mba od# bytes# st, () #)
+    copyNative mba = MBLK.unsafeCopyBytesPtr mba off' src count'
     copyPtr fptr = withFinalPtr fptr $ \dst ->
         unsafePrimFromIO $ copyBytes (dst `plusPtr` od) src bytes
 

--- a/basement/basement.cabal
+++ b/basement/basement.cabal
@@ -33,6 +33,7 @@ library
                      Basement.PrimType
 
                      Basement.Exception
+                     Basement.Cast
                      Basement.From
 
                      Basement.Types.Char7

--- a/basement/basement.cabal
+++ b/basement/basement.cabal
@@ -52,6 +52,7 @@ library
                      Basement.BoxedArray
                      Basement.Block
                      Basement.Block.Mutable
+                     Basement.Block.Builder
                      Basement.UArray
                      Basement.UArray.Mutable
                      Basement.String

--- a/basement/basement.cabal
+++ b/basement/basement.cabal
@@ -56,6 +56,7 @@ library
                      Basement.UArray
                      Basement.UArray.Mutable
                      Basement.String
+                     Basement.String.Builder
                      Basement.NonEmpty
                      
                      -- Utils

--- a/tests/Test/Data/List.hs
+++ b/tests/Test/Data/List.hs
@@ -8,10 +8,12 @@ module Test.Data.List
     ) where
 
 import Foundation
-import Foundation.Primitive
 import Foundation.Collection (nonEmpty_, NonEmpty)
 import Foundation.Check
 import Foundation.Monad
+
+import Basement.From (from)
+import Basement.Cast (cast)
 
 -- | convenient function to replicate thegiven Generator of `e` a randomly
 -- choosen amount of time.
@@ -21,19 +23,19 @@ generateListOfElement = generateListOfElementMaxN 100
 -- | convenient function to generate up to a certain amount of time the given
 -- generator.
 generateListOfElementMaxN :: CountOf e -> Gen e -> Gen [e]
-generateListOfElementMaxN (CountOf n) e = replicateBetween 0 (integralCast n) e
+generateListOfElementMaxN n e = replicateBetween 0 (from n) e
 
 generateNonEmptyListOfElement :: CountOf e -> Gen e -> Gen (NonEmpty [e])
-generateNonEmptyListOfElement (CountOf n) e = nonEmpty_ <$> replicateBetween 1 (integralCast n) e
+generateNonEmptyListOfElement n e = nonEmpty_ <$> replicateBetween 1 (from n) e
 
 data RandomList = RandomList [Int]
     deriving (Show,Eq)
 
 instance Arbitrary RandomList where
-    arbitrary = RandomList <$> replicateBetween 100 400 (integralCast <$> between (0,8))
+    arbitrary = RandomList <$> replicateBetween 100 400 (cast <$> between (0,8))
 
 replicateBetween n1 n2 f =
     between (n1, n2) >>= \n -> replicateM (CountOf (toInt n)) f
   where
     toInt :: Word -> Int
-    toInt = integralCast
+    toInt = cast


### PR DESCRIPTION
* add Builder for `Block Word8`
* add Builder for `String`

also introduce `Cast` type family in basement instead of `From` for certain types.

one of the issue with `From` is that it kinda implies _value conversion_ while actually we were litteraly casting the value into the new type:

example:

```haskell
cast (-10 :: Int) :: Word == 18446744073709551606
```
  