### PR TITLE
Fix the build on GHC 7.8

### DIFF
--- a/Foundation/Exception.hs
+++ b/Foundation/Exception.hs
@@ -9,7 +9,7 @@ import Control.Exception (Exception, SomeException)
 import Foundation.Monad.Exception
 
 finally :: MonadBracket m => m a -> m b -> m a
-finally f g = generalBracket (pure ()) (\() a -> g >> pure a) (\() _ -> g) (const f)
+finally f g = generalBracket (return ()) (\() a -> g >> return a) (\() _ -> g) (const f)
 
 try :: (MonadCatch m, Exception e) => m a -> m (Either e a)
 try a = catch (a >>= \ v -> return (Right v)) (\e -> return (Left e))


### PR DESCRIPTION
This fixes the build on GHC 7.8
The problem is that we're using `pure` given just a `Monad` constraint, which doesn't work before the Applicative-Monad-Proposal went though in GHC 7.10

Currently users on 7.8 can get bad build plans involving foundation 0.0.18. Please issue a hackage metadata revision to tighten foundation 0.0.18's base bound, since it is unbuildable on GHC 7.8. The correct bound for that version would be `base >=4.8 && <5`. This means that users won't get a bad build plan. They won't get a build plan at all, which is a better outcome as it allows the solver to select another version of foundation if it's within their bounds.

Hackage metadata revisions can be issued from here:
https://matrix.hackage.haskell.org/package/foundation#GHC-7.8/foundation-0.0.18

I would appreciate if this fix could be merged and released as part of 0.0.19 to reinstate GHC 7.8 support.

Thanks!