### PR TITLE
Block/UArray/Builder: `concat` performance update

### DIFF
--- a/basement/Basement/Block/Base.hs
+++ b/basement/Basement/Block/Base.hs
@@ -231,29 +231,26 @@ append a b
     !la = lengthBytes a
     !lb = lengthBytes b
 
-concat :: [Block ty] -> Block ty
-concat [] = empty
-concat l  =
-    case filterAndSum 0 [] l of
-        (_,[])            -> empty
-        (_,[x])           -> x
-        (totalLen,chunks) -> runST $ do
-            r <- unsafeNew Unpinned totalLen
-            doCopy r 0 chunks
-            unsafeFreeze r
+concat :: forall ty . [Block ty] -> Block ty
+concat original = runST $ do
+    r <- unsafeNew Unpinned total
+    goCopy r zero original
+    unsafeFreeze r
   where
-    -- TODO would go faster not to reverse but pack from the end instead
-    filterAndSum !totalLen acc []     = (totalLen, Data.List.reverse acc)
-    filterAndSum !totalLen acc (x:xs)
-        | len == 0  = filterAndSum totalLen acc xs
-        | otherwise = filterAndSum (len+totalLen) (x:acc) xs
-      where len = lengthBytes x
+    !total = size 0 original
+    -- size
+    size !sz []     = sz
+    size !sz (x:xs) = size (lengthBytes x + sz) xs
 
-    doCopy _ _ []     = return ()
-    doCopy r i (x:xs) = do
-        unsafeCopyBytesRO r i x 0 lx
-        doCopy r (i `offsetPlusE` lx) xs
-      where !lx = lengthBytes x
+    zero = Offset 0
+
+    goCopy r = loop
+      where
+        loop _  []      = pure ()
+        loop !i (x:xs) = do
+            unsafeCopyBytesRO r i x zero lx
+            loop (i `offsetPlusE` lx) xs
+          where !lx = lengthBytes x
 
 -- | Freeze a mutable block into a block.
 --

--- a/basement/Basement/Block/Builder.hs
+++ b/basement/Basement/Block/Builder.hs
@@ -60,6 +60,8 @@ instance Monoid Builder where
     {-# INLINE mempty #-}
     mappend = append
     {-# INLINABLE mappend #-}
+    mconcat = concat
+    {-# INLINABLE mconcat #-}
 
 -- | create an empty builder
 --
@@ -78,6 +80,15 @@ append (Builder size1 (Action action1)) (Builder size2 (Action action2)) =
       action2 arr off'
     size = size1 + size2
 {-# INLINABLE append #-}
+
+-- | concatenate the list of builder
+concat :: [Builder] -> Builder
+concat = loop 0 (Action $ \_ !off -> pure off)
+  where
+    loop !sz acc          []                              = Builder sz acc
+    loop !sz (Action acc) (Builder !s (Action action):xs) =
+       loop (sz + s) (Action $ \arr off -> acc arr off >>= action arr) xs
+{-# INLINABLE concat #-}
 
 -- | run the given builder and return the generated block
 run :: PrimMonad prim => Builder -> prim (Block Word8)

--- a/benchs/Fake/ByteString.hs
+++ b/benchs/Fake/ByteString.hs
@@ -17,6 +17,7 @@ module Fake.ByteString
     , readInt
     , readInteger
     , unpack
+    , concat
     ) where
 
 import Prelude (undefined, Maybe(..))
@@ -41,6 +42,8 @@ foldr _ _ _ = undefined
 and _ _ = undefined
 all _ _ = undefined
 any _ _ = undefined
+concat :: [ByteString] -> ByteString
+concat _ = undefined
 unpack :: ByteString -> [Word8]
 unpack = undefined
 

--- a/benchs/Fake/Vector.hs
+++ b/benchs/Fake/Vector.hs
@@ -15,6 +15,7 @@ module Fake.Vector
     , and
     , all
     , any
+    , concat
     ) where
 
 import Prelude (undefined)
@@ -40,3 +41,4 @@ foldr _ _ _ = undefined
 and _ _ = undefined
 all _ _ = undefined
 any _ _ = undefined
+concat = undefined


### PR DESCRIPTION
instead of #205 

improved the Block bench of about _200 μs_

| Test | Mean |
|----|----|
| types/ByteArray/Monoid/mconcat/listBs20/[UArray_W8] | 541.4 ns  ( +- 8.050 ns  ) |
| types/ByteArray/Monoid/mconcat/listBs20/[Block_W8] | **185.4 ns**  ( +- 1.653 ns  ) |
| types/ByteArray/Monoid/mconcat/listBs20/[ByteString] | 162.9 ns  ( +- 1.422 ns  ) |
| types/ByteArray/Monoid/mconcat/listBs20/[Vector_W8] | 228.9 ns  ( +- 1.219 ns  ) |
| types/ByteArray/Monoid/mconcat/listBs200/[UArray_W8] | 6.728 μs  ( +- 107.6 ns  ) |
| types/ByteArray/Monoid/mconcat/listBs200/[Block_W8] |  **3.887 μs**  ( +- 38.41 ns  ) |
| types/ByteArray/Monoid/mconcat/listBs200/[ByteString] |  3.400 μs  ( +- 110.7 ns  ) |
| types/ByteArray/Monoid/mconcat/listBs200/[Vector_W8] |  3.817 μs  ( +- 47.31 ns  ) |
| types/ByteArray/Monoid/mconcat/listBs2000/[UArray_W8] |  937.6 μs  ( +- 36.67 μs  ) |
| types/ByteArray/Monoid/mconcat/listBs2000/[Block_W8] |  **692.0 μs**  ( +- 24.46 μs  ) |
| types/ByteArray/Monoid/mconcat/listBs2000/[ByteString] |  581.1 μs  ( +- 19.47 μs  ) |
| types/ByteArray/Monoid/mconcat/listBs2000/[Vector_W8] |  932.0 μs  ( +- 19.45 μs  ) |
| types/ByteArray/Monoid/builder/[block Word8]* | **733.3 μs**  ( +- 27.22 μs  ) |

> *this last bench is interesting to compare the little difference between this new implementation of `concat` and using builder added in #455 

I just did this quickly and I think there is still room for improvement (I believe we can go faster or at least as fast as bytestring). Below is an quote from the core dump of the function where I believe we might be able to improve things, here the `Offset` is not unpacked in the code and we have a case to access it, this might be the source of the performance issue here:

```haskell
                          case ds1_d1dZF
                               `cast` (Basement.Types.OffsetSize.N:Offset[0] <Word8>_P
                                       :: (Offset Word8 :: *) ~R# (Int :: *))
                          of
                          { I# ipv4_s1eaO ->
                          case ipv2_s1eaJ of { Block ba_a1cMZ ->
                          let {
                            ipv5_s1eaS [Dmd=<S,U>] :: Int#
                            [LclId]
                            ipv5_s1eaS = sizeofByteArray# ba_a1cMZ } in
                          case copyByteArray#
                                 @ (PrimState (ST RealWorld))
                                 ba_a1cMZ
                                 0#
                                 ipv1_s1e8T
                                 ipv4_s1eaO
                                 ipv5_s1eaS
```

I wonder what else I could do to help GHC understand it can optimise away down to `I#` like it does for computing the length of the `Block` to create:

```haskell
Basement.Block.Base.$wpoly_size
  = \ (@ ty_s1fkN)
      (ww_s1fkS :: Int#)
      (w_s1fkP :: [Block ty_s1fkN]) ->
      case w_s1fkP of {
        [] -> ww_s1fkS;
        : x_a1cO9 xs_a1cOa ->
          case x_a1cO9 of { Block ba_a1cMZ ->
          Basement.Block.Base.$wpoly_size
            @ ty_s1fkN (+# (sizeofByteArray# ba_a1cMZ) ww_s1fkS) xs_a1cOa
          }
      }
```