### PR TITLE
Foreign/Native-PrimArray Algorithms: avoid computing 'endIndex' twice

### DIFF
--- a/basement/Basement/Alg/PrimArray.hs
+++ b/basement/Basement/Alg/PrimArray.hs
@@ -35,15 +35,13 @@ findIndexElem ty ba startIndex endIndex = loop startIndex
 {-# INLINE findIndexElem #-}
 
 revFindIndexElem :: (Indexable container ty, Eq ty) => ty -> container -> Offset ty -> Offset ty -> Offset ty
-revFindIndexElem ty ba startIndex endIndex
-    | endIndex > startIndex = loop (endIndex `offsetMinusE` 1)
-    | otherwise             = sentinel
+revFindIndexElem ty ba startIndex endIndex = loop endIndex
   where
-    loop !i
-        | t == ty        = i
-        | i > startIndex = loop (i `offsetMinusE` 1)
-        | otherwise      = sentinel
-      where t = index ba i
+    loop !iplus1
+        | iplus1 <= startIndex = sentinel
+        | index ba i == ty     = i
+        | otherwise            = loop i
+      where !i = iplus1 `offsetMinusE` 1
 {-# INLINE revFindIndexElem #-}
 
 findIndexPredicate :: Indexable container ty => (ty -> Bool) -> container -> Offset ty -> Offset ty -> Offset ty
@@ -57,15 +55,13 @@ findIndexPredicate predicate ba startIndex endIndex = loop startIndex
 {-# INLINE findIndexPredicate #-}
 
 revFindIndexPredicate :: Indexable container ty => (ty -> Bool) -> container -> Offset ty -> Offset ty -> Offset ty
-revFindIndexPredicate predicate ba startIndex endIndex
-    | endIndex > startIndex = loop (endIndex `offsetMinusE` 1)
-    | otherwise             = sentinel
+revFindIndexPredicate predicate ba startIndex endIndex = loop endIndex
   where
-    loop !i
-        | found          = i
-        | i > startIndex = loop (i `offsetMinusE` 1)
-        | otherwise      = sentinel
-      where found = predicate (index ba i)
+    loop !iplus1
+        | iplus1 <= startIndex   = sentinel
+        | predicate (index ba i) = i
+        | otherwise              = loop i
+      where !i = iplus1 `offsetMinusE` 1
 {-# INLINE revFindIndexPredicate #-}
 
 foldl :: Indexable container ty => (a -> ty -> a) -> a -> container -> Offset ty -> Offset ty -> a

--- a/basement/Basement/Alg/PrimArray.hs
+++ b/basement/Basement/Alg/PrimArray.hs
@@ -28,10 +28,9 @@ findIndexElem :: (Indexable container ty, Eq ty) => ty -> container -> Offset ty
 findIndexElem ty ba startIndex endIndex = loop startIndex
   where
     loop !i
-        | i >= endIndex = sentinel
-        | t == ty       = i
-        | otherwise     = loop (i+1)
-      where t = index ba i
+        | i >= endIndex    = sentinel
+        | index ba i == ty = i
+        | otherwise        = loop (i+1)
 {-# INLINE findIndexElem #-}
 
 revFindIndexElem :: (Indexable container ty, Eq ty) => ty -> container -> Offset ty -> Offset ty -> Offset ty
@@ -48,10 +47,9 @@ findIndexPredicate :: Indexable container ty => (ty -> Bool) -> container -> Off
 findIndexPredicate predicate ba startIndex endIndex = loop startIndex
   where
     loop !i
-        | i >= endIndex = sentinel
-        | found         = i
-        | otherwise     = loop (i+1)
-      where found = predicate (index ba i)
+        | i >= endIndex          = sentinel
+        | predicate (index ba i) = i
+        | otherwise              = loop (i+1)
 {-# INLINE findIndexPredicate #-}
 
 revFindIndexPredicate :: Indexable container ty => (ty -> Bool) -> container -> Offset ty -> Offset ty -> Offset ty

--- a/basement/Basement/Alg/PrimArray.hs
+++ b/basement/Basement/Alg/PrimArray.hs
@@ -28,20 +28,21 @@ findIndexElem :: (Indexable container ty, Eq ty) => ty -> container -> Offset ty
 findIndexElem ty ba startIndex endIndex = loop startIndex
   where
     loop !i
-        | i < endIndex && t /= ty = loop (i+1)
-        | otherwise               = i
+        | i >= endIndex = sentinel
+        | t == ty       = i
+        | otherwise     = loop (i+1)
       where t = index ba i
 {-# INLINE findIndexElem #-}
 
 revFindIndexElem :: (Indexable container ty, Eq ty) => ty -> container -> Offset ty -> Offset ty -> Offset ty
 revFindIndexElem ty ba startIndex endIndex
     | endIndex > startIndex = loop (endIndex `offsetMinusE` 1)
-    | otherwise             = endIndex
+    | otherwise             = sentinel
   where
     loop !i
         | t == ty        = i
         | i > startIndex = loop (i `offsetMinusE` 1)
-        | otherwise      = endIndex
+        | otherwise      = sentinel
       where t = index ba i
 {-# INLINE revFindIndexElem #-}
 
@@ -49,20 +50,21 @@ findIndexPredicate :: Indexable container ty => (ty -> Bool) -> container -> Off
 findIndexPredicate predicate ba !startIndex !endIndex = loop startIndex
   where
     loop !i
-        | i < endIndex && not found = loop (i+1)
-        | otherwise                 = i
+        | i >= endIndex = sentinel
+        | found         = i
+        | otherwise     = loop (i+1)
       where found = predicate (index ba i)
 {-# INLINE findIndexPredicate #-}
 
 revFindIndexPredicate :: Indexable container ty => (ty -> Bool) -> container -> Offset ty -> Offset ty -> Offset ty
 revFindIndexPredicate predicate ba startIndex endIndex
     | endIndex > startIndex = loop (endIndex `offsetMinusE` 1)
-    | otherwise             = endIndex
+    | otherwise             = sentinel
   where
     loop !i
         | found          = i
         | i > startIndex = loop (i `offsetMinusE` 1)
-        | otherwise      = endIndex
+        | otherwise      = sentinel
       where found = predicate (index ba i)
 {-# INLINE revFindIndexPredicate #-}
 

--- a/basement/Basement/Alg/PrimArray.hs
+++ b/basement/Basement/Alg/PrimArray.hs
@@ -47,7 +47,7 @@ revFindIndexElem ty ba startIndex endIndex
 {-# INLINE revFindIndexElem #-}
 
 findIndexPredicate :: Indexable container ty => (ty -> Bool) -> container -> Offset ty -> Offset ty -> Offset ty
-findIndexPredicate predicate ba !startIndex !endIndex = loop startIndex
+findIndexPredicate predicate ba startIndex endIndex = loop startIndex
   where
     loop !i
         | i >= endIndex = sentinel

--- a/basement/Basement/Block.hs
+++ b/basement/Basement/Block.hs
@@ -278,12 +278,11 @@ break predicate blk = findBreak 0
 
 breakEnd :: PrimType ty => (ty -> Bool) -> Block ty -> (Block ty, Block ty)
 breakEnd predicate blk
-    | k == end  = (blk, mempty)
-    | otherwise = splitAt (offsetAsSize (k+1)) blk
+    | k == sentinel = (blk, mempty)
+    | otherwise     = splitAt (offsetAsSize (k+1)) blk
   where
-    k = Alg.revFindIndexPredicate predicate blk 0 end
-    end = 0 `offsetPlusE` len
-    !len = length blk
+    !k = Alg.revFindIndexPredicate predicate blk 0 end
+    !end = sizeAsOffset $ length blk
 {-# SPECIALIZE [2] breakEnd :: (Word8 -> Bool) -> Block Word8 -> (Block Word8, Block Word8) #-}
 
 span :: PrimType ty => (ty -> Bool) -> Block ty -> (Block ty, Block ty)

--- a/basement/Basement/Types/OffsetSize.hs
+++ b/basement/Basement/Types/OffsetSize.hs
@@ -17,6 +17,7 @@ module Basement.Types.OffsetSize
     ( FileSize(..)
     , Offset(..)
     , Offset8
+    , sentinel
     , offsetOfE
     , offsetPlusE
     , offsetMinusE
@@ -85,6 +86,8 @@ type Offset8 = Offset Word8
 -- Trying to bring some sanity by a lightweight wrapping.
 newtype Offset ty = Offset Int
     deriving (Show,Eq,Ord,Enum,Additive,Typeable,Integral,Prelude.Num)
+
+sentinel = Offset (-1)
 
 instance IsIntegral (Offset ty) where
     toInteger (Offset i) = toInteger i

--- a/basement/Basement/UArray/Base.hs
+++ b/basement/Basement/UArray/Base.hs
@@ -292,16 +292,17 @@ onBackendPure :: (Block ty -> a)
 onBackendPure goBA goAddr arr = onBackend goBA (\_ -> pureST . goAddr) arr
 {-# INLINE onBackendPure #-}
 
-onBackendPure' :: PrimType  ty
+onBackendPure' :: forall ty a . PrimType  ty
                => UArray ty
                -> (forall container. Alg.Indexable container ty 
                    => container -> Offset ty -> Offset ty -> a)
                -> a
-onBackendPure' arr f = onBackendPure (\c -> f c start end) 
-                                     (\c -> f c start end) arr
-  where !len = length arr
-        !start = offset arr
-        !end = start `offsetPlusE` len
+onBackendPure' arr f = onBackendPure f' f' arr
+  where f' :: Alg.Indexable container ty => container -> a
+        f' c = f c start end
+          where !len = length arr
+                !start = offset arr
+                !end = start `offsetPlusE` len
 {-# INLINE onBackendPure' #-}
 
 onBackendPrim :: PrimMonad prim

--- a/basement/Basement/UArray/Base.hs
+++ b/basement/Basement/UArray/Base.hs
@@ -300,9 +300,7 @@ onBackendPure' :: forall ty a . PrimType  ty
 onBackendPure' arr f = onBackendPure f' f' arr
   where f' :: Alg.Indexable container ty => container -> a
         f' c = f c start end
-          where !len = length arr
-                !start = offset arr
-                !end = start `offsetPlusE` len
+          where (ValidRange !start !end) = offsetsValidRange arr
 {-# INLINE onBackendPure' #-}
 
 onBackendPrim :: PrimMonad prim


### PR DESCRIPTION
This is a follow up on PR #434 which got partially merged.

`findIndexElem` (and related functions) have been changed to return `Offset -1` (rather than `Maybe (Offset ty)`) when no matching element has been found. This avoids the use of `Maybe` (as originally done in #434) but still avoids computing the `endIndex` multiple times (c.f. UArray.findIndex). It makes the assumption that `-1` is never a valid index.

Moreover, I adjusted the implementation of `revFindIndexElem` and `revfindIndexPredicate`. The initial bound check (that the array is not empty) is unified with the loop bound check (that the processing reached the start).