### PR TITLE
BlockN operators and helpers

### DIFF
--- a/Foundation/Check/Main.hs
+++ b/Foundation/Check/Main.hs
@@ -34,7 +34,6 @@ import           Foundation.List.DList
 import           Foundation.Random
 import           Foundation.Monad
 import           Foundation.Monad.State
-import           Control.Monad (when)
 import           Data.Maybe (catMaybes)
 
 nbFail :: TestResult -> HasFailures

--- a/Foundation/Collection/Copy.hs
+++ b/Foundation/Collection/Copy.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE CPP #-}
 
 module Foundation.Collection.Copy
     ( Copy(..)
@@ -9,25 +10,31 @@ import           Basement.Compat.Base ((>>=))
 import           Basement.Nat
 import           Basement.Types.OffsetSize
 import qualified Basement.Block as BLK
-import qualified Basement.Sized.Block as BLKN
-import qualified Basement.Sized.List  as LN
 import qualified Basement.UArray as UA
 import qualified Basement.BoxedArray as BA
 import qualified Basement.String as S
+
+#if MIN_VERSION_base(4,9,0)
+import qualified Basement.Sized.Block as BLKN
+import qualified Basement.Sized.List  as LN
+#endif
 
 class Copy a where
     copy :: a -> a
 instance Copy [ty] where
     copy a = a
-instance Copy (LN.ListN n ty) where
-    copy a = a
 instance UA.PrimType ty => Copy (BLK.Block ty) where
     copy blk = runST (BLK.thaw blk >>= BLK.unsafeFreeze)
-instance (Countable ty n, UA.PrimType ty, KnownNat n) => Copy (BLKN.BlockN n ty) where
-    copy blk = runST (BLKN.thaw blk >>= BLKN.freeze)
 instance UA.PrimType ty => Copy (UA.UArray ty) where
     copy = UA.copy
 instance Copy (BA.Array ty) where
     copy = BA.copy
 instance Copy S.String where
     copy = S.copy
+
+#if MIN_VERSION_base(4,9,0)
+instance Copy (LN.ListN n ty) where
+    copy a = a
+instance (Countable ty n, UA.PrimType ty, KnownNat n) => Copy (BLKN.BlockN n ty) where
+    copy blk = runST (BLKN.thaw blk >>= BLKN.freeze)
+#endif

--- a/Foundation/Collection/Copy.hs
+++ b/Foundation/Collection/Copy.hs
@@ -1,10 +1,16 @@
+{-# LANGUAGE UndecidableInstances #-}
+
 module Foundation.Collection.Copy
     ( Copy(..)
     ) where
 
 import           GHC.ST (runST)
 import           Basement.Compat.Base ((>>=))
+import           Basement.Nat
+import           Basement.Types.OffsetSize
 import qualified Basement.Block as BLK
+import qualified Basement.Sized.Block as BLKN
+import qualified Basement.Sized.List  as LN
 import qualified Basement.UArray as UA
 import qualified Basement.BoxedArray as BA
 import qualified Basement.String as S
@@ -13,8 +19,12 @@ class Copy a where
     copy :: a -> a
 instance Copy [ty] where
     copy a = a
+instance Copy (LN.ListN n ty) where
+    copy a = a
 instance UA.PrimType ty => Copy (BLK.Block ty) where
     copy blk = runST (BLK.thaw blk >>= BLK.unsafeFreeze)
+instance (Countable ty n, UA.PrimType ty, KnownNat n) => Copy (BLKN.BlockN n ty) where
+    copy blk = runST (BLKN.thaw blk >>= BLKN.freeze)
 instance UA.PrimType ty => Copy (UA.UArray ty) where
     copy = UA.copy
 instance Copy (BA.Array ty) where

--- a/Foundation/Collection/Element.hs
+++ b/Foundation/Collection/Element.hs
@@ -17,11 +17,15 @@ import Basement.String (String)
 import Basement.Types.AsciiString (AsciiString)
 import Basement.Types.Char7 (Char7)
 import Basement.NonEmpty
+import Basement.Sized.Block (BlockN)
+import Basement.Sized.List  (ListN)
 
 -- | Element type of a collection
 type family Element container
 type instance Element [a] = a
+type instance Element (ListN n a) = a
 type instance Element (Block ty) = ty
+type instance Element (BlockN n ty) = ty
 type instance Element (UArray ty) = ty
 type instance Element (Array ty) = ty
 type instance Element String = Char

--- a/Foundation/Collection/Element.hs
+++ b/Foundation/Collection/Element.hs
@@ -5,6 +5,9 @@
 -- Stability   : experimental
 -- Portability : portable
 --
+
+{-# LANGUAGE CPP #-}
+
 module Foundation.Collection.Element
     ( Element
     ) where
@@ -17,17 +20,23 @@ import Basement.String (String)
 import Basement.Types.AsciiString (AsciiString)
 import Basement.Types.Char7 (Char7)
 import Basement.NonEmpty
+
+#if MIN_VERSION_base(4,9,0)
 import Basement.Sized.Block (BlockN)
 import Basement.Sized.List  (ListN)
+#endif
 
 -- | Element type of a collection
 type family Element container
 type instance Element [a] = a
-type instance Element (ListN n a) = a
 type instance Element (Block ty) = ty
-type instance Element (BlockN n ty) = ty
 type instance Element (UArray ty) = ty
 type instance Element (Array ty) = ty
 type instance Element String = Char
 type instance Element AsciiString = Char7
 type instance Element (NonEmpty a) = Element a
+
+#if MIN_VERSION_base(4,9,0)
+type instance Element (BlockN n ty) = ty
+type instance Element (ListN n a) = a
+#endif

--- a/Foundation/Collection/Foldable.hs
+++ b/Foundation/Collection/Foldable.hs
@@ -8,8 +8,12 @@
 -- A mono-morphic re-thinking of the Foldable class
 --
 
+{-# LANGUAGE CPP                   #-}
+
+#if MIN_VERSION_base(4,9,0)
 {-# LANGUAGE DataKinds     #-}
 {-# LANGUAGE TypeOperators #-}
+#endif
 
 module Foundation.Collection.Foldable
     ( Foldable(..)
@@ -24,8 +28,11 @@ import qualified Data.List
 import qualified Basement.UArray as UV
 import qualified Basement.Block as BLK
 import qualified Basement.BoxedArray as BA
+
+#if MIN_VERSION_base(4,9,0)
 import qualified Basement.Sized.List as LN
 import qualified Basement.Sized.Block as BLKN
+#endif
 
 -- | Give the ability to fold a collection on itself
 class Foldable collection where
@@ -70,9 +77,6 @@ class Foldable f => Fold1able f where
 instance Foldable [a] where
     foldr = Data.List.foldr
     foldl' = Data.List.foldl'
-instance Foldable (LN.ListN n a) where
-    foldr = LN.foldr
-    foldl' = LN.foldl'
 
 instance UV.PrimType ty => Foldable (UV.UArray ty) where
     foldr = UV.foldr
@@ -83,19 +87,23 @@ instance Foldable (BA.Array ty) where
 instance UV.PrimType ty => Foldable (BLK.Block ty) where
     foldr = BLK.foldr
     foldl' = BLK.foldl'
+
+#if MIN_VERSION_base(4,9,0)
+instance Foldable (LN.ListN n a) where
+    foldr = LN.foldr
+    foldl' = LN.foldl'
 instance UV.PrimType ty => Foldable (BLKN.BlockN n ty) where
     foldr = BLKN.foldr
     foldl' = BLKN.foldl'
+#endif
 
 ----------------------------
 -- Fold1able instances
 ----------------------------
+
 instance Fold1able [a] where
     foldr1  f = Data.List.foldr1  f . getNonEmpty
     foldl1' f = Data.List.foldl1' f . getNonEmpty
-instance (1 <= n) => Fold1able (LN.ListN n a) where
-    foldr1  f = LN.foldr1  f . getNonEmpty
-    foldl1' f = LN.foldl1' f . getNonEmpty
 
 instance UV.PrimType ty => Fold1able (UV.UArray ty) where
     foldr1 = UV.foldr1
@@ -106,3 +114,9 @@ instance Fold1able (BA.Array ty) where
 instance UV.PrimType ty => Fold1able (BLK.Block ty) where
     foldr1  = BLK.foldr1
     foldl1' = BLK.foldl1'
+
+#if MIN_VERSION_base(4,9,0)
+instance (1 <= n) => Fold1able (LN.ListN n a) where
+    foldr1  f = LN.foldr1  f . getNonEmpty
+    foldl1' f = LN.foldl1' f . getNonEmpty
+#endif

--- a/Foundation/Collection/Foldable.hs
+++ b/Foundation/Collection/Foldable.hs
@@ -7,6 +7,10 @@
 --
 -- A mono-morphic re-thinking of the Foldable class
 --
+
+{-# LANGUAGE DataKinds     #-}
+{-# LANGUAGE TypeOperators #-}
+
 module Foundation.Collection.Foldable
     ( Foldable(..)
     , Fold1able(..)
@@ -15,10 +19,13 @@ module Foundation.Collection.Foldable
 import           Basement.Compat.Base
 import           Foundation.Collection.Element
 import           Basement.NonEmpty
+import           Basement.Nat
 import qualified Data.List
 import qualified Basement.UArray as UV
 import qualified Basement.Block as BLK
 import qualified Basement.BoxedArray as BA
+import qualified Basement.Sized.List as LN
+import qualified Basement.Sized.Block as BLKN
 
 -- | Give the ability to fold a collection on itself
 class Foldable collection where
@@ -63,6 +70,9 @@ class Foldable f => Fold1able f where
 instance Foldable [a] where
     foldr = Data.List.foldr
     foldl' = Data.List.foldl'
+instance Foldable (LN.ListN n a) where
+    foldr = LN.foldr
+    foldl' = LN.foldl'
 
 instance UV.PrimType ty => Foldable (UV.UArray ty) where
     foldr = UV.foldr
@@ -73,13 +83,19 @@ instance Foldable (BA.Array ty) where
 instance UV.PrimType ty => Foldable (BLK.Block ty) where
     foldr = BLK.foldr
     foldl' = BLK.foldl'
+instance UV.PrimType ty => Foldable (BLKN.BlockN n ty) where
+    foldr = BLKN.foldr
+    foldl' = BLKN.foldl'
 
 ----------------------------
 -- Fold1able instances
 ----------------------------
 instance Fold1able [a] where
-  foldr1 f  = Data.List.foldr1 f . getNonEmpty
-  foldl1' f = Data.List.foldl1' f . getNonEmpty
+    foldr1  f = Data.List.foldr1  f . getNonEmpty
+    foldl1' f = Data.List.foldl1' f . getNonEmpty
+instance (1 <= n) => Fold1able (LN.ListN n a) where
+    foldr1  f = LN.foldr1  f . getNonEmpty
+    foldl1' f = LN.foldl1' f . getNonEmpty
 
 instance UV.PrimType ty => Fold1able (UV.UArray ty) where
     foldr1 = UV.foldr1

--- a/Foundation/Collection/Indexed.hs
+++ b/Foundation/Collection/Indexed.hs
@@ -11,6 +11,7 @@ module Foundation.Collection.Indexed
     ) where
 
 import           Basement.Compat.Base
+import           Basement.Numerical.Additive ((+))
 import           Basement.Types.OffsetSize
 import           Foundation.Collection.Element
 import qualified Data.List
@@ -36,14 +37,14 @@ instance IndexedCollection [a] where
 instance UV.PrimType ty => IndexedCollection (BLK.Block ty) where
     (!) l n
         | A.isOutOfBound n (BLK.length l) = Nothing
-        | otherwise                           = Just $ BLK.index l n
+        | otherwise                       = Just $ BLK.index l n
     findIndex predicate c = loop 0
       where
         !len = BLK.length c
         loop i
             | i .==# len                      = Nothing
             | predicate (BLK.unsafeIndex c i) = Just i
-            | otherwise                       = Nothing
+            | otherwise                       = loop (i + 1)
 
 instance UV.PrimType ty => IndexedCollection (UV.UArray ty) where
     (!) l n

--- a/Foundation/Network/IPv6.hs
+++ b/Foundation/Network/IPv6.hs
@@ -25,7 +25,6 @@ import Prelude (fromIntegral, read)
 import qualified Text.Printf as Base
 import Data.Char (isHexDigit, isDigit)
 import Numeric (readHex)
-import Control.Monad (when)
 
 import Foundation.Class.Storable
 import Foundation.Hashing.Hashable

--- a/Foundation/Timing/Main.hs
+++ b/Foundation/Timing/Main.hs
@@ -14,7 +14,6 @@ module Foundation.Timing.Main
 import           Basement.Imports
 import           Foundation.IO.Terminal
 import           Foundation.Collection
-import           Control.Monad (when)
 
 data MainConfig = MainConfig
     { mainHelp       :: Bool

--- a/Foundation/UUID.hs
+++ b/Foundation/UUID.hs
@@ -9,7 +9,6 @@ module Foundation.UUID
     , uuidParser
     ) where
 
-import Control.Monad (unless)
 import Data.Maybe (fromMaybe)
 
 import           Basement.Compat.Base

--- a/basement/Basement/Block/Base.hs
+++ b/basement/Basement/Block/Base.hs
@@ -469,13 +469,11 @@ withMutablePtrHint skipCopy skipCopyBack mb f
     | isMutablePinned mb == Pinned = callWithPtr mb
     | otherwise                    = do
         trampoline <- unsafeNew Pinned vecSz
-        if not skipCopy
-            then unsafeCopyBytes trampoline 0 mb 0 vecSz
-            else pure ()
+        unless skipCopy $
+            unsafeCopyBytes trampoline 0 mb 0 vecSz
         r <- callWithPtr trampoline
-        if not skipCopyBack
-            then unsafeCopyBytes mb 0 trampoline 0 vecSz
-            else pure ()
+        unless skipCopyBack $
+            unsafeCopyBytes mb 0 trampoline 0 vecSz
         pure r
   where
     vecSz = mutableLengthBytes mb

--- a/basement/Basement/Block/Base.hs
+++ b/basement/Basement/Block/Base.hs
@@ -386,7 +386,7 @@ unsafeWrite (MutableBlock mba) i v = primMbaWrite mba i v
 -- to use to modify the contents
 --
 -- If the Block is pinned, then its address is returned as is,
--- however if it's unpinned, a pinned copy of the UArray is made
+-- however if it's unpinned, a pinned copy of the Block is made
 -- before getting the address.
 withPtr :: PrimMonad prim
         => Block ty

--- a/basement/Basement/Compat/Base.hs
+++ b/basement/Basement/Compat/Base.hs
@@ -34,6 +34,8 @@ module Basement.Compat.Base
     , Prelude.Functor (..)
     , Control.Applicative.Applicative (..)
     , Prelude.Monad (..)
+    , Control.Monad.when
+    , Control.Monad.unless
     , Prelude.Maybe (..)
     , Prelude.Ordering (..)
     , Prelude.Bool (..)
@@ -69,6 +71,7 @@ import qualified Prelude
 import qualified Control.Category
 import qualified Control.Applicative
 import qualified Control.Exception
+import qualified Control.Monad
 import qualified Data.Monoid
 import qualified Data.Data
 import qualified Data.Word

--- a/basement/Basement/From.hs
+++ b/basement/Basement/From.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE CPP                   #-}
 {-# LANGUAGE MagicHash             #-}
 {-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE TypeOperators         #-}
 -- |
 -- Module      : Basement.From
 -- License     : BSD-style
@@ -50,7 +51,7 @@ import           Basement.Types.Word256 (Word256(..))
 import qualified Basement.Types.Word128 as Word128
 import qualified Basement.Types.Word256 as Word256
 import           Basement.These
-import           Basement.PrimType (PrimType)
+import           Basement.PrimType (PrimType, PrimSize)
 import           Basement.Types.OffsetSize
 import           Basement.Compat.Natural
 import qualified Prelude (fromIntegral)
@@ -247,6 +248,9 @@ instance TryFrom (UArray.UArray Word8) String.String where
 #if __GLASGOW_HASKELL__ >= 800
 instance From (BlockN.BlockN n ty) (Block.Block ty) where
     from = BlockN.toBlock
+instance (PrimType a, PrimType b, KnownNat n, KnownNat m, ((PrimSize b) Basement.Nat.* m) ~ ((PrimSize a) Basement.Nat.* n))
+      => From (BlockN.BlockN n a) (BlockN.BlockN m b) where
+    from = BlockN.cast
 instance (NatWithinBound Int n, PrimType ty) => From (BlockN.BlockN n ty) (UArray.UArray ty) where
     from = UArray.fromBlock . BlockN.toBlock
 instance (NatWithinBound Int n, PrimType ty) => From (BlockN.BlockN n ty) (BoxArray.Array ty) where

--- a/basement/Basement/Imports.hs
+++ b/basement/Basement/Imports.hs
@@ -36,6 +36,8 @@ module Basement.Imports
     , Prelude.Functor (..)
     , Control.Applicative.Applicative (..)
     , Prelude.Monad (..)
+    , Control.Monad.when
+    , Control.Monad.unless
     , Prelude.Maybe (..)
     , Prelude.Ordering (..)
     , Prelude.Bool (..)
@@ -87,6 +89,7 @@ import qualified Prelude
 import qualified Control.Category
 import qualified Control.Applicative
 import qualified Control.Exception
+import qualified Control.Monad
 import qualified Data.Monoid
 import qualified Data.Data
 import qualified Data.Typeable

--- a/basement/Basement/Sized/Block.hs
+++ b/basement/Basement/Sized/Block.hs
@@ -83,12 +83,10 @@ length :: forall n ty
 length _ = toCount @n
 
 lengthBytes :: forall n ty
-             . (PrimType ty, KnownNat n, Countable ty n)
+             . PrimType ty
             => BlockN n ty
             -> CountOf Word8
-lengthBytes b = scale bytes (sizeCast Proxy (length b))
-  where
-    bytes = primSizeInBytes (Proxy @ty)
+lengthBytes = B.lengthBytes . unBlock
 
 toBlock :: BlockN n ty -> Block ty
 toBlock = unBlock

--- a/basement/Basement/Sized/List.hs
+++ b/basement/Basement/Sized/List.hs
@@ -47,6 +47,7 @@ module Basement.Sized.List
     , scanl'
     , scanl1'
     , foldr
+    , foldr1
     , reverse
     , append
     , minimum
@@ -277,6 +278,10 @@ foldl1' f (ListN l) = Data.List.foldl1' f l
 -- | Fold all elements from right
 foldr :: (a -> b -> b) -> b -> ListN n a -> b
 foldr f acc (ListN l) = Prelude.foldr f acc l
+
+-- | Fold all elements from right assuming at least one element is in the list.
+foldr1 :: (1 <= n) => (a -> a -> a) -> ListN n a -> a
+foldr1 f (ListN l) = Prelude.foldr1 f l
 
 -- | 'scanl' is similar to 'foldl', but returns a list of successive
 -- reduced values from the left

--- a/basement/Basement/UArray.hs
+++ b/basement/Basement/UArray.hs
@@ -106,7 +106,6 @@ module Basement.UArray
     , toBase64Internal
     ) where
 
-import           Control.Monad (when)
 import           GHC.Prim
 import           GHC.Types
 import           GHC.Word


### PR DESCRIPTION
add missing `withPtr` and `withMutablePtr` for `BlockN` and `MutableBlockN`

this will allow us to add support in `memory` for `ByteArrayAccess` on `BlockN`