### PR TITLE
Optimise casing for ASCII

### DIFF
--- a/basement/Basement/Alg/String.hs
+++ b/basement/Basement/Alg/String.hs
@@ -39,9 +39,9 @@ copyFilter predicate !sz dst src start = loop (Offset 0) start
     loop !d !s
         | s == end  = pure (offsetAsSize d)
         | otherwise =
-            let !h = index src s
+            let !h = nextAscii src s
              in case headerIsAscii h of
-                    True | predicate (toChar1 h) -> primMbaWrite dst d h >> loop (d + Offset 1) (s + Offset 1)
+                    True | predicate (toChar1 h) -> primMbaWrite dst d (stepAsciiRawValue h) >> loop (d + Offset 1) (s + Offset 1)
                          | otherwise             -> loop d (s + Offset 1)
                     False ->
                         case next src s of
@@ -58,10 +58,10 @@ validate end ba ofsStart = loop4 ofsStart
   where
     loop4 !ofs
         | ofs4 < end =
-            let h1 = index ba ofs
-                h2 = index ba (ofs+1)
-                h3 = index ba (ofs+2)
-                h4 = index ba (ofs+3)
+            let h1 = nextAscii ba ofs
+                h2 = nextAscii ba (ofs+1)
+                h3 = nextAscii ba (ofs+2)
+                h4 = nextAscii ba (ofs+3)
              in if headerIsAscii h1 && headerIsAscii h2 && headerIsAscii h3 && headerIsAscii h4
                     then loop4 ofs4
                     else loop ofs
@@ -73,7 +73,7 @@ validate end ba ofsStart = loop4 ofsStart
         | headerIsAscii h = loop (ofs + Offset 1)
         | otherwise       = multi (CountOf $ getNbBytes h) ofs
       where
-        h = index ba ofs
+        h = nextAscii ba ofs
 
     multi (CountOf 0xff) pos = (pos, Just InvalidHeader)
     multi nbConts pos

--- a/basement/Basement/Alg/UTF8.hs
+++ b/basement/Basement/Alg/UTF8.hs
@@ -62,13 +62,13 @@ next ba n =
         3 -> Step (toChar4 h (index ba (n + Offset 1))
                              (index ba (n + Offset 2))
                              (index ba (n + Offset 3))) (n + Offset 4)
-        r -> error ("next: internal error: invalid input: offset=" <> show n <> " table=" <> show r <> " h=" <> show h)
+        r -> error ("next: internal error: invalid input: offset=" <> show n <> " table=" <> show r <> " h=" <> show (stepAsciiRawValue h))
   where
-    !h = index ba n
+    !h = nextAscii ba n
 {-# INLINE next #-}
 
 nextSkip :: Indexable container Word8 => container -> Offset Word8 -> Offset Word8
-nextSkip ba n = n + 1 + Offset (getNbBytes (index ba n))
+nextSkip ba n = n + 1 + Offset (getNbBytes (nextAscii ba n))
 {-# INLINE nextSkip #-}
 
 -- Given a non null offset, give the previous character and the offset of this character
@@ -245,24 +245,24 @@ reverse dst dstOfs src start end
   where
     loop !d !s
         | s == end        = pure ()
-        | headerIsAscii h = primMbaWrite dst d h >> loop (d `offsetSub` 1) (s + 1)
+        | headerIsAscii h = primMbaWrite dst d (stepAsciiRawValue h) >> loop (d `offsetSub` 1) (s + 1)
         | otherwise       = do
             case getNbBytes h of
                 1 -> do
-                    primMbaWrite dst (d `offsetSub` 1) h
+                    primMbaWrite dst (d `offsetSub` 1) (stepAsciiRawValue h)
                     primMbaWrite dst d                 (index src (s + 1))
                     loop (d `offsetSub` 2) (s + 2)
                 2 -> do
-                    primMbaWrite dst (d `offsetSub` 2) h
+                    primMbaWrite dst (d `offsetSub` 2) (stepAsciiRawValue h)
                     primMbaWrite dst (d `offsetSub` 1) (index src (s + 1))
                     primMbaWrite dst d                 (index src (s + 2))
                     loop (d `offsetSub` 3) (s + 3)
                 3 -> do
-                    primMbaWrite dst (d `offsetSub` 3) h
+                    primMbaWrite dst (d `offsetSub` 3) (stepAsciiRawValue h)
                     primMbaWrite dst (d `offsetSub` 2) (index src (s + 1))
                     primMbaWrite dst (d `offsetSub` 1) (index src (s + 2))
                     primMbaWrite dst d                 (index src (s + 3))
                     loop (d `offsetSub` 4) (s + 4)
                 _ -> error "impossible"
-      where h = index src s
+      where h = nextAscii src s
 {-# INLINE reverse #-}

--- a/basement/Basement/String.hs
+++ b/basement/Basement/String.hs
@@ -194,7 +194,7 @@ mutableValidate mba ofsStart sz = do
                 (pos, Just failure) -> return (pos, Just failure)
 
     one pos = do
-        h <- Vec.unsafeRead mba pos
+        h <- StepASCII <$> Vec.unsafeRead mba pos
         let nbConts = getNbBytes h
         if nbConts == 0xff
             then return (pos, Just InvalidHeader)

--- a/basement/Basement/Types/Char7.hs
+++ b/basement/Basement/Types/Char7.hs
@@ -24,6 +24,9 @@ module Basement.Types.Char7
     , c7_7
     , c7_8
     , c7_9
+    -- * Upper / Lower With ASCII
+    , c7Upper
+    , c7Lower
     ) where
 
 import GHC.Prim
@@ -98,3 +101,15 @@ c7_6 = Char7 0x36
 c7_7 = Char7 0x37
 c7_8 = Char7 0x38
 c7_9 = Char7 0x39
+
+c7Lower :: Char7 -> Char7
+c7Lower c@(Char7 w)
+    | c <  c7_A = c
+    | c <= c7_Z = Char7 (w .|. 0x20)
+    | otherwise = c
+
+c7Upper :: Char7 -> Char7
+c7Upper c@(Char7 w)
+    | c <  c7_a = c
+    | c <= c7_z = Char7 (w .&. 0xdf)
+    | otherwise = c

--- a/basement/Basement/Types/CharUTF8.hs
+++ b/basement/Basement/Types/CharUTF8.hs
@@ -1,0 +1,8 @@
+module Basement.Types.CharUTF8
+    ( CharUTF8(..)
+    , encodeCharUTF8
+    , decodeCharUTF8
+    ) where
+
+import Basement.UTF8.Types
+import Basement.UTF8.Helper

--- a/basement/Basement/UTF8/Helper.hs
+++ b/basement/Basement/UTF8/Helper.hs
@@ -145,3 +145,88 @@ charToBytes c
     | c < 0x10000  = CountOf 3
     | c < 0x110000 = CountOf 4
     | otherwise    = error ("invalid code point: " `mappend` show c)
+
+-- | Encode a Char into a CharUTF8
+encodeCharUTF8 :: Char -> CharUTF8
+encodeCharUTF8 !(C# c)
+    | bool# (ltWord# x 0x80##   ) = CharUTF8 (W32# x)
+    | bool# (ltWord# x 0x800##  ) = CharUTF8 encode2
+    | bool# (ltWord# x 0x10000##) = CharUTF8 encode3
+    | otherwise                   = CharUTF8 encode4
+  where
+    !x = int2Word# (ord# c)
+
+    -- clearing mask, clearing all the bits that need to be clear as per the UTF8 encoding
+    mask2 = 0x0000bfdf## -- 1 continuation , 5 bits header
+    mask3 = 0x00bfbfef## -- 2 continuations, 4 bits header
+    mask4 = 0xbfbfbff7## -- 3 continuations, 3 bits header
+
+    -- setting mask, settings all the bits that need to be set per the UTF8 encoding
+    set2  = 0x000080c0## -- 10xxxxxx     110xxxxx
+    set3  = 0x008080e0## -- 10xxxxxx * 2 1110xxxx
+    set4  = 0x808080f0## -- 10xxxxxx * 3 11111xxx
+
+    encode2 = W32# (and# mask2 (or3# set2
+                                     (uncheckedShiftRL# x 6#) -- 5 bits to 1st byte
+                                     (uncheckedShiftL# x 8# ) -- move lowest bits to the 2nd byte
+                               ))
+    encode3 = W32# (and# mask3 (or4# set3
+                                     (uncheckedShiftRL# x 12#) -- 4 bits to 1st byte
+                                     (and# 0x3f00## (uncheckedShiftL# x 2#)) -- 6 bits to the 2nd byte
+                                     (uncheckedShiftL# x 16# ) -- move lowest bits to the 3rd byte
+                               ))
+    encode4 = W32# (and# mask4 (or4# set4
+                                     (uncheckedShiftRL# x 18#) -- 3 bits to 1st byte
+                                     (or# (and# 0x3f00## (uncheckedShiftRL# x 4#))   -- 6 bits to the 2nd byte
+                                          (and# 0x3f0000## (uncheckedShiftL# x 10#)) -- 6 bits to the 3nd byte
+                                     )
+                                     (uncheckedShiftL# x 24# ) -- move lowest bits to the 4rd byte
+                               ))
+
+-- | decode a CharUTF8 into a Char
+--
+-- If the value inside a CharUTF8 is not properly encoded, this will result in violation
+-- of the Char invariants
+decodeCharUTF8 :: CharUTF8 -> Char
+decodeCharUTF8 c@(CharUTF8 !(W32# w))
+    | isCharUTF8Case1 c = toChar# w
+    | isCharUTF8Case2 c = encode2
+    | isCharUTF8Case3 c = encode3
+    | otherwise         = encode4
+  where
+    encode2 =
+        toChar# (or# (uncheckedShiftL# (maskHeader2# w) 6#)
+                     (maskContinuation# (uncheckedShiftRL# w 8#))
+                )
+    encode3 =
+        toChar# (or3# (uncheckedShiftL# (maskHeader3# w) 12#)
+                      (uncheckedShiftRL# (and# 0x3f00## w) 8#)
+                      (maskContinuation# (uncheckedShiftRL# w 16#))
+                )
+    encode4 =
+        toChar# (or4# (uncheckedShiftL#  (maskHeader4# w) 18#)
+                      (uncheckedShiftRL# (and# 0x3f00## w) 10#)
+                      (uncheckedShiftL#  (and# 0x3f0000## w) 4#)
+                      (maskContinuation# (uncheckedShiftRL# w 24#))
+                )
+
+    -- clearing mask, removing all UTF8 metadata and keeping only signal (content)
+    --maskContent2 = 0x00003f1f## -- 1 continuation , 5 bits header
+    --maskContent3 = 0x003f3f0f## -- 2 continuations, 4 bits header
+    --maskContent4 = 0x3f3f3f07## -- 3 continuations, 3 bits header
+
+isCharUTF8Case1 :: CharUTF8 -> Bool
+isCharUTF8Case1 (CharUTF8 !(W32# w)) = bool# (eqWord# (and# w 0x80##) 0##)
+{-# INLINE isCharUTF8Case1 #-}
+
+isCharUTF8Case2 :: CharUTF8 -> Bool
+isCharUTF8Case2 (CharUTF8 !(W32# w)) = bool# (eqWord# (and# w 0x20##) 0##)
+{-# INLINE isCharUTF8Case2 #-}
+
+isCharUTF8Case3 :: CharUTF8 -> Bool
+isCharUTF8Case3 (CharUTF8 !(W32# w)) = bool# (eqWord# (and# w 0x10##) 0##)
+{-# INLINE isCharUTF8Case3 #-}
+
+isCharUTF8Case4 :: CharUTF8 -> Bool
+isCharUTF8Case4 (CharUTF8 !(W32# w)) = bool# (eqWord# (and# w 0x08##) 0##)
+{-# INLINE isCharUTF8Case4 #-}

--- a/basement/Basement/UTF8/Table.hs
+++ b/basement/Basement/UTF8/Table.hs
@@ -21,6 +21,7 @@ import           GHC.Types
 import           GHC.Word
 import           Basement.Compat.Base
 import           Basement.Compat.Primitive
+import           Basement.UTF8.Types (StepASCII(..))
 
 -- | Check if the byte is a continuation byte
 isContinuation :: Word8 -> Bool
@@ -52,8 +53,8 @@ data NbBytesCont = NbBytesInvalid | NbBytesCont0 | NbBytesCont1 | NbBytesCont2 |
 data NbBytesCont_ = NbBytesCont0_ | NbBytesCont1_ | NbBytesCont2_ | NbBytesCont3_
 
 -- | Get the number of following bytes given the first byte of a UTF8 sequence.
-getNbBytes :: Word8 -> Int
-getNbBytes (W8# w) = I# (getNbBytes# w)
+getNbBytes :: StepASCII -> Int
+getNbBytes (StepASCII (W8# w)) = I# (getNbBytes# w)
 {-# INLINE getNbBytes #-}
 
 -- | Check if the byte is a continuation byte

--- a/basement/Basement/UTF8/Types.hs
+++ b/basement/Basement/UTF8/Types.hs
@@ -9,6 +9,8 @@ module Basement.UTF8.Types
     , isValidStepDigit
     -- * Unicode Errors
     , ValidationFailure(..)
+    -- * UTF8 Encoded 'Char'
+    , CharUTF8(..)
     -- * Case Conversion
     , CM (..)
     ) where
@@ -38,6 +40,17 @@ newtype StepASCII = StepASCII { stepAsciiRawValue :: Word8 }
 
 -- | Specialized tuple used for case mapping.
 data CM = CM {-# UNPACK #-} !Char {-# UNPACK #-} !Char {-# UNPACK #-} !Char deriving (Eq)
+
+-- | Represent an already encoded UTF8 Char where the the lowest 8 bits is the start of the
+-- sequence. If this contains a multi bytes sequence then each higher 8 bits are filled with
+-- the remaining sequence 8 bits per 8 bits.
+--
+-- For example:
+-- 'A' => U+0041  => 41          => 0x00000041
+-- '€  => U+20AC  => E2 82 AC    => 0x00AC82E2
+-- '𐍈' => U+10348 => F0 90 8D 88 => 0x888D90F0
+--
+newtype CharUTF8 = CharUTF8 Word32
 
 isValidStepASCII :: StepASCII -> Bool
 isValidStepASCII (StepASCII w) = w < 0x80

--- a/basement/Basement/UTF8/Types.hs
+++ b/basement/Basement/UTF8/Types.hs
@@ -34,7 +34,7 @@ data StepBack = StepBack {-# UNPACK #-} !Char {-# UNPACK #-} !(Offset Word8)
 newtype StepDigit = StepDigit Word8
 
 -- | Step when processing ASCII character
-newtype StepASCII = StepASCII Word8
+newtype StepASCII = StepASCII { stepAsciiRawValue :: Word8 }
 
 -- | Specialized tuple used for case mapping.
 data CM = CM {-# UNPACK #-} !Char {-# UNPACK #-} !Char {-# UNPACK #-} !Char deriving (Eq)

--- a/basement/basement.cabal
+++ b/basement/basement.cabal
@@ -36,6 +36,7 @@ library
                      Basement.From
 
                      Basement.Types.Char7
+                     Basement.Types.CharUTF8
                      Basement.Types.OffsetSize
                      Basement.Types.Ptr
                      Basement.Types.AsciiString

--- a/foundation.cabal
+++ b/foundation.cabal
@@ -233,6 +233,8 @@ test-suite check-foundation
                      Test.Foundation.String.Base64
                      Test.Foundation.String
                      Test.Foundation.Bits
+                     Test.Basement
+                     Test.Basement.UTF8
                      Test.Data.Network
                      Test.Data.List
                      Test.Foundation.Network.IPv4

--- a/tests/Checks.hs
+++ b/tests/Checks.hs
@@ -30,6 +30,7 @@ import Test.Foundation.String.Base64
 import Test.Checks.Property.Collection
 import Test.Foundation.Format
 import qualified Test.Foundation.Bits as Bits
+import qualified Test.Basement as Basement
 
 #if MIN_VERSION_base(4,9,0)
 import Test.Foundation.Primitive.BlockN
@@ -110,6 +111,7 @@ main = defaultMain $ Group "foundation"
             ]
         , Group "Number" testNumberRefs
         ]
+    , Basement.tests
     , Bits.tests
     , Group "String"
         [ Group "reading"

--- a/tests/Test/Basement.hs
+++ b/tests/Test/Basement.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedStrings   #-}
+module Test.Basement
+    ( tests
+    ) where
+
+import Foundation
+import Foundation.Check
+import qualified Test.Basement.UTF8 as UTF8
+
+tests = Group "basement"
+    [ UTF8.tests
+    ]

--- a/tests/Test/Basement/UTF8.hs
+++ b/tests/Test/Basement/UTF8.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE OverloadedStrings   #-}
+module Test.Basement.UTF8
+    ( tests )
+    where
+
+import Basement.Types.CharUTF8
+import Foundation
+import Foundation.Check
+import Foundation.String
+
+tests = Group "utf8"
+    [ Property "CharUTF8" $ \c -> decodeCharUTF8 (encodeCharUTF8 c) === c
+    ]


### PR DESCRIPTION
related to #485
This massively speed up the ASCII cases, but the unicode speeding up is not finished. The idea is to pre-encode the unicode cases in a pre-processed format (`CharUtf8`) ready to be blitted to memory with just a simple shift per byte compared to multiple shift and masks per byte.
