### PR TITLE
Remove FP Chat slack link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Documentation:
 
 Discuss:
 
-* [FP Chat](https://fpchat-invite.herokuapp.com) `#haskell-foundation` channel
 * [Gitter](https://gitter.im/haskell-foundation/foundation)
 
 Goals


### PR DESCRIPTION
Discussed with @NicolasDP this morning.  The FP Chat #haskell-foundation channel was a decent experiment, but that slack is way too hectic and message history is not saved.  This PR removes the link to FP chat.