### PR TITLE
Consistent underflow for Word types

### DIFF
--- a/basement/Basement/Types/Word128.hs
+++ b/basement/Basement/Types/Word128.hs
@@ -144,7 +144,7 @@ applyBiWordOnNatural f = (fromNatural .) . (f `on` toNatural)
 (-) :: Word128 -> Word128 -> Word128
 (-) a b
     | a >= b    = applyBiWordOnNatural (Prelude.-) a b
-    | otherwise = complement $ applyBiWordOnNatural (Prelude.-) b a
+    | otherwise = complement (applyBiWordOnNatural (Prelude.-) b a) + 1
 
 -- | Multiplication
 (*) :: Word128 -> Word128 -> Word128

--- a/basement/Basement/Types/Word256.hs
+++ b/basement/Basement/Types/Word256.hs
@@ -179,7 +179,7 @@ applyBiWordOnNatural f = (fromNatural .) . (f `on` toNatural)
 (-) :: Word256 -> Word256 -> Word256
 (-) a b
     | a >= b    = applyBiWordOnNatural (Prelude.-) a b
-    | otherwise = complement $ applyBiWordOnNatural (Prelude.-) b a
+    | otherwise = complement (applyBiWordOnNatural (Prelude.-) b a) + 1
 
 -- | Multiplication
 (*) :: Word256 -> Word256 -> Word256

--- a/foundation/tests/Test/Foundation/Bits.hs
+++ b/foundation/tests/Test/Foundation/Bits.hs
@@ -1,10 +1,12 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
 module Test.Foundation.Bits
     ( tests
     ) where
 
+import Basement.Cast
 import Foundation.Bits
 import Foundation.Check
 import Foundation
@@ -16,7 +18,7 @@ instance Arbitrary Shifter where
     arbitrary = Shifter . applyMod <$> arbitrary
       where applyMod i = abs i `mod` 256
 
-testBits :: forall a . (Integral a, IsIntegral a, Bits a, Show a, Eq a, Arbitrary a, Typeable a)
+testBits :: forall a . (Additive a, Bounded a, Difference a ~ a, Integral a, IsIntegral a, Bits a, Show a, Subtractive a, Eq a, Arbitrary a, Typeable a)
          => String
          -> Proxy a
          -> Gen a
@@ -26,6 +28,21 @@ testBits n _ _ = Group n
         (a `shiftR` i) === convertBack (toInteger a `shiftR` i)
     , Property "shiftL" $ \(a :: a) (Shifter i) ->
         (a `shiftL` i) === convertBack (toInteger a `shiftL` i)
+    , Property "maxBound value" $ \(a :: a) ->
+        case bitSizeMaybe a of
+          Just bs ->
+            let actualMaxBound :: a
+                actualMaxBound = maxBound
+                expectedMaxBound :: Integer
+                expectedMaxBound = 2^(cast bs :: Word) - (1 :: Integer)
+            in toInteger actualMaxBound === expectedMaxBound
+          Nothing -> propertyFail "Expected FiniteBits"
+    , Property "complement maxBound" $
+        complement 0 === (maxBound :: a)
+    , Property "overflow maxBound" $
+        maxBound + 1 === (0 :: a)
+    , Property "underflow zero" $
+        (0 :: a) - 1 === maxBound
     ]
   where
     convertBack x


### PR DESCRIPTION
Addresses #497 .

The current behaviour for underflow e.g. `0 - 1` is inconsistent between `Word32/64` (two's complement) and `Word128/256` (ones' complement). This PR changes that to consistently use two's complement.