### PR TITLE
Fix for "unknown symbol `___divmoddi4'" on 32-bit mingw builds

### DIFF
--- a/foundation/foundation.cabal
+++ b/foundation/foundation.cabal
@@ -203,6 +203,8 @@ library
                    , ghc-prim
     if os(windows)
       build-depends: Win32
+      if arch(i386)
+        extra-libraries: gcc
 
   build-depends: basement == 0.0.8
 


### PR DESCRIPTION
Hi there,

I've ran into a trouble in my project while building it with 32-bit GHC 8.4.3 on Windows (MinGW).
I'm doing an upgrade from quite an ancient GHC 7.10.3, but this upgrade went OK on Linux but on Windows I got an error like this one:
```
Building library for viinex-lm-0.2.0..
[14 of 15] Compiling ViinexLm.Firmware ( src\ViinexLm\Firmware.hs, dist\build\ViinexLm\Firmware.o )

<no location info>: error:
    ghc.exe: unable to load package `foundation-0.0.21'
ghc.exe:  | C:\Projects\viinex-lm\.cabal-sandbox\i386-windows-ghc-8.4.3\foundation-0.0.21-3fR5LfsB4NN8k8cOnaPWAU\HSfoundation-0.0.21-3fR5LfsB4NN8k8cOnaPWAU.o: unknown symbol `___divmoddi4'
```

After some googling I found this story https://ghc.haskell.org/trac/ghc/ticket/15094 which describes pretty much everything about this - it's GHC/toolchain bug, when a 32-bit compiler inserts an instrinsic instead of instruction but forgets to reference the libgcc. So it needs to be referenced explicitly.

Unfortunately this cannot be done in dependent project, only in the project where all that replacement is introduced. And I guess this is the C bit of the foundation library, namely the cbits/foundation_time.c.

With the proposed change to the foundation.cabal and rebuilding the foundation library with that change, - my project has built successfully as well.

So this is a workaround for still broken GCC but could you please accept this, - otherwise the whole bunch of libraries become unusable with those GHC who uses GCC 7 on 32-bit MinGW (that's modern 8.4). Thank you in advance.
