### PR TITLE
Explicitly bring fail into scope in module with incomplete patterns in do blocks

### DIFF
--- a/basement/Basement/Block.hs
+++ b/basement/Basement/Block.hs
@@ -66,6 +66,7 @@ module Basement.Block
     , withPtr
     ) where
 
+import           Control.Monad.Fail (fail)
 import           GHC.Prim
 import           GHC.Types
 import           GHC.ST

--- a/basement/Basement/Block/Base.hs
+++ b/basement/Basement/Block/Base.hs
@@ -35,6 +35,7 @@ module Basement.Block.Base
     , unsafeRecast
     ) where
 
+import           Control.Monad.Fail (fail)
 import           GHC.Prim
 import           GHC.Types
 import           GHC.ST

--- a/basement/Basement/Block/Mutable.hs
+++ b/basement/Basement/Block/Mutable.hs
@@ -64,6 +64,7 @@ module Basement.Block.Mutable
     , copyToPtr
     ) where
 
+import           Control.Monad.Fail (fail)
 import           GHC.Prim
 import           GHC.Types
 import           Basement.Compat.Base

--- a/basement/Basement/BoxedArray.hs
+++ b/basement/Basement/BoxedArray.hs
@@ -74,6 +74,7 @@ module Basement.BoxedArray
     , builderBuild_
     ) where
 
+import           Control.Monad.Fail (fail)
 import           GHC.Prim
 import           GHC.Types
 import           GHC.ST

--- a/basement/Basement/String.hs
+++ b/basement/Basement/String.hs
@@ -129,6 +129,7 @@ import qualified Basement.Alg.UTF8 as UTF8
 import qualified Basement.Alg.String as Alg
 import           Basement.Types.Char7 (Char7(..), c7Upper, c7Lower)
 import qualified Basement.Types.Char7 as Char7
+import           Control.Monad.Fail (fail)
 import           GHC.Prim
 import           GHC.ST
 import           GHC.Types

--- a/basement/Basement/UArray.hs
+++ b/basement/Basement/UArray.hs
@@ -106,6 +106,7 @@ module Basement.UArray
     , toBase64Internal
     ) where
 
+import           Control.Monad.Fail (fail)
 import           GHC.Prim
 import           GHC.Types
 import           GHC.Word

--- a/basement/Basement/UArray/Base.hs
+++ b/basement/Basement/UArray/Base.hs
@@ -53,6 +53,7 @@ module Basement.UArray.Base
     , pureST
     ) where
 
+import           Control.Monad.Fail (fail)
 import           GHC.Prim
 import           GHC.Types
 import           GHC.Ptr

--- a/basement/Basement/UTF8/Base.hs
+++ b/basement/Basement/UTF8/Base.hs
@@ -15,6 +15,7 @@
 module Basement.UTF8.Base
     where
 
+import           Control.Monad.Fail (fail)
 import           GHC.ST (ST, runST)
 import           GHC.Types
 import           GHC.Word


### PR DESCRIPTION
Resolves https://github.com/haskell-foundation/foundation/issues/518