### PR TITLE
Migrate to new stack.yaml structure

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,6 @@
 resolver: lts-13.5
 packages:
-- location: foundation/
-- location: basement/
-  extra-dep: false
+- foundation
+- basement
 extra-deps:
 - gauge-0.2.1

--- a/with-edge.yaml
+++ b/with-edge.yaml
@@ -1,6 +1,6 @@
 resolver: lts-13.5
 packages:
-- '.'
-- location: basement/
-  extra-dep: true
-- location: edge/
+- foundation
+- edge
+extra-deps:
+- basement


### PR DESCRIPTION
The project doesn't compile with the latest stack (2.1.1).
I have verified that the project still builds with stack 1.9.3 after the changes in this PR.