### PR TITLE
Make IPv4 parser safe

### DIFF
--- a/foundation/Foundation/Network/IPv4.hs
+++ b/foundation/Foundation/Network/IPv4.hs
@@ -20,7 +20,7 @@ module Foundation.Network.IPv4
     , ipv4Parser
     ) where
 
-import Prelude (fromIntegral,read)
+import Prelude (fromIntegral)
 
 import Foundation.Class.Storable
 import Foundation.Hashing.Hashable
@@ -31,6 +31,7 @@ import Foundation.Primitive
 import Basement.Bits
 import Foundation.Parser hiding (peek)
 import Foundation.Collection (Sequential, Element, elem)
+import Text.Read (readMaybe)
 
 import qualified Prelude (String)
 
@@ -107,8 +108,12 @@ ipv4Parser = do
     return $ fromTuple (i1, i2, i3, i4)
   where
     takeAWord8 = do
-      n <- (read :: Prelude.String -> Integer) . toList <$> takeWhile isAsciiDecimal
-      if n > 256
-        then reportError $ Satisfy $ Just "expected smaller integer than 256"
-        else return (fromIntegral n)
+      maybeN <- (readMaybe :: Prelude.String -> Maybe Integer) . toList <$> takeWhile isAsciiDecimal
+      case maybeN of
+        Nothing -> reportError $ Satisfy $ Just "expected integer"
+        Just n ->
+          if n > 256
+          then reportError $ Satisfy $ Just "expected smaller integer than 256"
+          else return (fromIntegral n)
+
     isAsciiDecimal = flip elem ['0'..'9']

--- a/foundation/tests/Test/Foundation/Network/IPv4.hs
+++ b/foundation/tests/Test/Foundation/Network/IPv4.hs
@@ -50,4 +50,6 @@ testNetworkIPv4 = Group "IPv4"
     , testPropertyStorableFixed "StorableFixed" (Proxy :: Proxy IPv4)
     , Property "Word8 overflow is detected" $
         forAll genOverflowingIPv4String $ \x -> isLeft $ parseOnly ipv4Parser x
+    , Property "www.example.com" $
+        isLeft $ parseOnly ipv4Parser ("www.example.com" :: String)
     ]


### PR DESCRIPTION
The parser returned `error` if it was passed anything that didn't look like an IP address instead of `ParseError`, thanks to `read` being unsafe. This PR fixes it.