### PR TITLE
Mark ghcjs as not buildable

### DIFF
--- a/foundation/foundation.cabal
+++ b/foundation/foundation.cabal
@@ -196,7 +196,7 @@ library
                       BangPatterns
                       DeriveDataTypeable
 
-  if impl(ghc < 8.0)
+  if impl(ghc < 8.0) || impl(ghcjs)
     buildable: False
   else
     build-depends:   base


### PR DESCRIPTION
ghcjs support is broken under certain cases. According to:

https://github.com/vincenthz/haskell-pkg-guidelines/blob/master/support.md

It is not supported. See #486