### PR TITLE
Switch from importing GHC.Prim to GHC.Exts

### DIFF
--- a/basement/Basement/Alg/Mutable.hs
+++ b/basement/Basement/Alg/Mutable.hs
@@ -4,7 +4,7 @@ module Basement.Alg.Mutable
     ) where
 
 import           GHC.Types
-import           GHC.Prim
+import           GHC.Exts
 import           Basement.Compat.Base
 import           Basement.Numerical.Additive
 import           Basement.Numerical.Multiplicative

--- a/basement/Basement/Alg/PrimArray.hs
+++ b/basement/Basement/Alg/PrimArray.hs
@@ -15,7 +15,7 @@ module Basement.Alg.PrimArray
     ) where
 
 import           GHC.Types
-import           GHC.Prim
+import           GHC.Exts
 import           Basement.Alg.Class
 import           Basement.Compat.Base
 import           Basement.Numerical.Additive

--- a/basement/Basement/Alg/String.hs
+++ b/basement/Basement/Alg/String.hs
@@ -12,7 +12,7 @@ module Basement.Alg.String
     , revFindIndexPredicate
     ) where
 
-import           GHC.Prim
+import           GHC.Exts
 import           GHC.ST
 import           Basement.Alg.Class
 import           Basement.Alg.UTF8

--- a/basement/Basement/Alg/UTF8.hs
+++ b/basement/Basement/Alg/UTF8.hs
@@ -24,7 +24,7 @@ module Basement.Alg.UTF8
 
 import           GHC.Types
 import           GHC.Word
-import           GHC.Prim
+import           GHC.Exts hiding (toList)
 import           Data.Bits
 import           Data.Proxy
 import           Basement.Alg.Class

--- a/basement/Basement/Base16.hs
+++ b/basement/Basement/Base16.hs
@@ -9,7 +9,7 @@ module Basement.Base16
     , Base16Escape(..)
     ) where
 
-import GHC.Prim
+import GHC.Exts
 import GHC.Types
 import GHC.Word
 import Basement.Types.Char7

--- a/basement/Basement/Bindings/Memory.hs
+++ b/basement/Basement/Bindings/Memory.hs
@@ -5,7 +5,7 @@ module Basement.Bindings.Memory
     where
 
 import GHC.IO
-import GHC.Prim
+import GHC.Exts
 import GHC.Word
 import Basement.Compat.C.Types
 import Foreign.Ptr

--- a/basement/Basement/Bits.hs
+++ b/basement/Basement/Bits.hs
@@ -47,7 +47,7 @@ import qualified Data.Bits as OldBits
 import Data.Maybe (fromMaybe)
 import Data.Proxy
 import GHC.Base hiding ((.))
-import GHC.Prim
+import GHC.Exts
 import GHC.Types
 import GHC.Word
 import GHC.Int

--- a/basement/Basement/Block.hs
+++ b/basement/Basement/Block.hs
@@ -68,7 +68,7 @@ module Basement.Block
     , withPtr
     ) where
 
-import           GHC.Prim
+import           GHC.Exts
 import           GHC.Types
 import           GHC.ST
 import qualified Data.List

--- a/basement/Basement/Block/Base.hs
+++ b/basement/Basement/Block/Base.hs
@@ -36,7 +36,7 @@ module Basement.Block.Base
     , unsafeRecast
     ) where
 
-import           GHC.Prim
+import           GHC.Exts
 import           GHC.Types
 import           GHC.ST
 import           GHC.IO

--- a/basement/Basement/Block/Mutable.hs
+++ b/basement/Basement/Block/Mutable.hs
@@ -64,7 +64,7 @@ module Basement.Block.Mutable
     , copyToPtr
     ) where
 
-import           GHC.Prim
+import           GHC.Exts
 import           GHC.Types
 import           Basement.Compat.Base
 import           Data.Proxy

--- a/basement/Basement/BoxedArray.hs
+++ b/basement/Basement/BoxedArray.hs
@@ -74,7 +74,7 @@ module Basement.BoxedArray
     , builderBuild_
     ) where
 
-import           GHC.Prim
+import           GHC.Exts
 import           GHC.Types
 import           GHC.ST
 import           Data.Proxy

--- a/basement/Basement/Cast.hs
+++ b/basement/Basement/Cast.hs
@@ -25,7 +25,7 @@ import           Basement.PrimType
 import           Data.Proxy (Proxy(..))
 
 import           GHC.Int
-import           GHC.Prim
+import           GHC.Exts
 import           GHC.Types
 import           GHC.ST
 import           GHC.Word

--- a/basement/Basement/Compat/PrimTypes.hs
+++ b/basement/Basement/Compat/PrimTypes.hs
@@ -14,7 +14,7 @@ module Basement.Compat.PrimTypes
     , Pinned#
     ) where
 
-import GHC.Prim
+import GHC.Exts
 
 -- | File size in bytes
 type FileSize# = Word64#

--- a/basement/Basement/Compat/Primitive.hs
+++ b/basement/Basement/Compat/Primitive.hs
@@ -20,7 +20,7 @@ module Basement.Compat.Primitive
 
 import qualified Prelude
 import           GHC.Exts
-import           GHC.Prim
+import           GHC.Exts
 import           GHC.Word
 import           GHC.IO
 

--- a/basement/Basement/Error.hs
+++ b/basement/Basement/Error.hs
@@ -10,7 +10,7 @@ module Basement.Error
     ( error
     ) where
 
-import           GHC.Prim
+import           GHC.Exts
 import           Basement.UTF8.Base
 import           Basement.Compat.CallStack
 

--- a/basement/Basement/Floating.hs
+++ b/basement/Basement/Floating.hs
@@ -15,7 +15,7 @@ module Basement.Floating
     ) where
 
 import           GHC.Types
-import           GHC.Prim
+import           GHC.Exts
 import           GHC.Float
 import           GHC.Word
 import           GHC.ST

--- a/basement/Basement/From.hs
+++ b/basement/Basement/From.hs
@@ -35,7 +35,7 @@ import           Basement.Compat.Base
 
 -- basic instances
 import           GHC.Types
-import           GHC.Prim
+import           GHC.Exts
 import           GHC.Int
 import           GHC.Word
 import           Basement.Numerical.Number

--- a/basement/Basement/IntegralConv.hs
+++ b/basement/Basement/IntegralConv.hs
@@ -20,7 +20,7 @@ module Basement.IntegralConv
     ) where
 
 import GHC.Types
-import GHC.Prim
+import GHC.Exts
 import GHC.Int
 import GHC.Word
 import Prelude (Integer, fromIntegral)

--- a/basement/Basement/Monad.hs
+++ b/basement/Basement/Monad.hs
@@ -33,7 +33,7 @@ import           GHC.ST
 import           GHC.STRef
 import           GHC.IORef
 import           GHC.IO
-import           GHC.Prim
+import           GHC.Exts
 import           Basement.Compat.Base (Exception, (.), ($), Applicative, Monad)
 
 -- | Primitive monad that can handle mutation.

--- a/basement/Basement/Numerical/Additive.hs
+++ b/basement/Basement/Numerical/Additive.hs
@@ -15,7 +15,7 @@ import           Basement.Compat.Natural
 import           Basement.Numerical.Number
 import qualified Prelude
 import           GHC.Types
-import           GHC.Prim
+import           GHC.Exts
 import           GHC.Int
 import           GHC.Word
 import           Basement.Bounded

--- a/basement/Basement/Numerical/Conversion.hs
+++ b/basement/Basement/Numerical/Conversion.hs
@@ -19,7 +19,7 @@ module Basement.Numerical.Conversion
 #include "MachDeps.h"
 
 import GHC.Types
-import GHC.Prim
+import GHC.Exts
 import GHC.Int
 import GHC.Word
 

--- a/basement/Basement/PrimType.hs
+++ b/basement/Basement/PrimType.hs
@@ -35,7 +35,7 @@ module Basement.PrimType
 
 #include "MachDeps.h"
 
-import           GHC.Prim
+import           GHC.Exts
 import           GHC.Int
 import           GHC.Types
 import           GHC.Word

--- a/basement/Basement/String.hs
+++ b/basement/Basement/String.hs
@@ -129,7 +129,7 @@ import qualified Basement.Alg.UTF8 as UTF8
 import qualified Basement.Alg.String as Alg
 import           Basement.Types.Char7 (Char7(..), c7Upper, c7Lower)
 import qualified Basement.Types.Char7 as Char7
-import           GHC.Prim
+import           GHC.Exts
 import           GHC.ST
 import           GHC.Types
 import           GHC.Word

--- a/basement/Basement/String/Encoding/ASCII7.hs
+++ b/basement/Basement/String/Encoding/ASCII7.hs
@@ -18,7 +18,7 @@ import Basement.Types.OffsetSize
 import Basement.Numerical.Additive
 import Basement.Monad
 
-import GHC.Prim
+import GHC.Exts
 import GHC.Word
 import GHC.Types
 import Basement.UArray

--- a/basement/Basement/String/Encoding/ISO_8859_1.hs
+++ b/basement/Basement/String/Encoding/ISO_8859_1.hs
@@ -18,7 +18,7 @@ import Basement.Types.OffsetSize
 import Basement.Numerical.Additive
 import Basement.Monad
 
-import GHC.Prim
+import GHC.Exts
 import GHC.Word
 import GHC.Types
 import Basement.UArray

--- a/basement/Basement/String/Encoding/UTF16.hs
+++ b/basement/Basement/String/Encoding/UTF16.hs
@@ -11,7 +11,7 @@ module Basement.String.Encoding.UTF16
     , UTF16_Invalid(..)
     ) where
 
-import GHC.Prim
+import GHC.Exts
 import GHC.Word
 import GHC.Types
 import Data.Bits

--- a/basement/Basement/String/Encoding/UTF32.hs
+++ b/basement/Basement/String/Encoding/UTF32.hs
@@ -11,7 +11,7 @@ module Basement.String.Encoding.UTF32
     , UTF32_Invalid
     ) where
 
-import GHC.Prim
+import GHC.Exts
 import GHC.Word
 import GHC.Types
 import Basement.Compat.Base

--- a/basement/Basement/Types/Char7.hs
+++ b/basement/Basement/Types/Char7.hs
@@ -30,7 +30,7 @@ module Basement.Types.Char7
     , c7Lower
     ) where
 
-import GHC.Prim
+import GHC.Exts
 import GHC.Word
 import GHC.Types
 import Data.Bits

--- a/basement/Basement/Types/OffsetSize.hs
+++ b/basement/Basement/Types/OffsetSize.hs
@@ -51,7 +51,7 @@ module Basement.Types.OffsetSize
 import GHC.Types
 import GHC.Word
 import GHC.Int
-import GHC.Prim
+import GHC.Exts
 import System.Posix.Types (CSsize (..))
 import Data.Bits
 import Basement.Compat.Base

--- a/basement/Basement/Types/Ptr.hs
+++ b/basement/Basement/Types/Ptr.hs
@@ -15,7 +15,7 @@ import           Basement.Compat.Base
 import           Basement.Compat.C.Types
 import           Basement.Types.OffsetSize
 import           GHC.Ptr
-import           GHC.Prim
+import           GHC.Exts
 import           GHC.Types
 
 data Addr = Addr Addr#

--- a/basement/Basement/Types/Word128.hs
+++ b/basement/Basement/Types/Word128.hs
@@ -22,7 +22,7 @@ module Basement.Types.Word128
     , fromNatural
     ) where
 
-import           GHC.Prim
+import           GHC.Exts
 import           GHC.Word
 import           GHC.Types
 import qualified Prelude (fromInteger, show, Num(..), quot, rem, mod)

--- a/basement/Basement/Types/Word256.hs
+++ b/basement/Basement/Types/Word256.hs
@@ -21,7 +21,7 @@ module Basement.Types.Word256
     , fromNatural
     ) where
 
-import           GHC.Prim
+import           GHC.Exts
 import           GHC.Word
 import           GHC.Types
 import qualified Prelude (fromInteger, show, Num(..), quot, rem, mod)

--- a/basement/Basement/UArray.hs
+++ b/basement/Basement/UArray.hs
@@ -106,7 +106,7 @@ module Basement.UArray
     , toBase64Internal
     ) where
 
-import           GHC.Prim
+import           GHC.Exts
 import           GHC.Types
 import           GHC.Word
 import           GHC.ST

--- a/basement/Basement/UArray/Base.hs
+++ b/basement/Basement/UArray/Base.hs
@@ -54,7 +54,7 @@ module Basement.UArray.Base
     , pureST
     ) where
 
-import           GHC.Prim
+import           GHC.Exts
 import           GHC.Types
 import           GHC.Ptr
 import           GHC.ST

--- a/basement/Basement/UArray/Mutable.hs
+++ b/basement/Basement/UArray/Mutable.hs
@@ -40,7 +40,7 @@ module Basement.UArray.Mutable
     , withMutablePtrHint
     ) where
 
-import           GHC.Prim
+import           GHC.Exts
 import           GHC.Types
 import           GHC.Ptr
 import           Basement.Compat.Base

--- a/basement/Basement/UTF8/Base.hs
+++ b/basement/Basement/UTF8/Base.hs
@@ -18,7 +18,7 @@ module Basement.UTF8.Base
 import           GHC.ST (ST, runST)
 import           GHC.Types
 import           GHC.Word
-import           GHC.Prim
+import           GHC.Exts
 import           GHC.Exts (build)
 import           Basement.Compat.Base
 import           Basement.Numerical.Additive

--- a/basement/Basement/UTF8/Helper.hs
+++ b/basement/Basement/UTF8/Helper.hs
@@ -20,7 +20,7 @@ import           Basement.Compat.Base
 import           Basement.Compat.Primitive
 import           Basement.Types.OffsetSize
 import           Basement.UTF8.Types
-import           GHC.Prim
+import           GHC.Exts
 import           GHC.Types
 import           GHC.Word
 

--- a/basement/Basement/UTF8/Table.hs
+++ b/basement/Basement/UTF8/Table.hs
@@ -16,7 +16,7 @@ module Basement.UTF8.Table
     , getNbBytes#
     ) where
 
-import           GHC.Prim
+import           GHC.Exts
 import           GHC.Types
 import           GHC.Word
 import           Basement.Compat.Base

--- a/foundation/Foundation/Random/XorShift.hs
+++ b/foundation/Foundation/Random/XorShift.hs
@@ -28,7 +28,7 @@ import           Basement.Compat.Bifunctor
 import           Basement.Compat.ExtList (reverse)
 import qualified Basement.UArray as A
 import qualified Prelude
-import           GHC.Prim
+import           GHC.Exts
 import           GHC.Float
 
 


### PR DESCRIPTION
In GHC 8.12, unsafeCoerce# is no longer exported by GHC.Prim. Additionally, the documentation for GHC.Prim tells users to import GHC.Exts instead.