### PR TITLE
Import unsafeCoerce# from GHC.Exts for compatibility with GHC 8.12

### DIFF
--- a/basement/Basement/Block/Base.hs
+++ b/basement/Basement/Block/Base.hs
@@ -36,7 +36,7 @@ module Basement.Block.Base
     , unsafeRecast
     ) where
 
-import           GHC.Prim
+import           GHC.Exts
 import           GHC.Types
 import           GHC.ST
 import           GHC.IO

--- a/basement/Basement/BoxedArray.hs
+++ b/basement/Basement/BoxedArray.hs
@@ -74,7 +74,7 @@ module Basement.BoxedArray
     , builderBuild_
     ) where
 
-import           GHC.Prim
+import           GHC.Exts
 import           GHC.Types
 import           GHC.ST
 import           Data.Proxy
@@ -631,7 +631,7 @@ find predicate vec = loop 0
             let e = unsafeIndex vec i
              in if predicate e then Just e else loop (i+1)
 
-instance (PrimMonad prim, st ~ PrimState prim) 
+instance (PrimMonad prim, st ~ PrimState prim)
          => Alg.RandomAccess (MArray ty st) prim ty where
     read (MArray _ _ mba) = primMutableArrayRead mba
     write (MArray _ _ mba) = primMutableArrayWrite mba

--- a/basement/Basement/Monad.hs
+++ b/basement/Basement/Monad.hs
@@ -33,7 +33,7 @@ import           GHC.ST
 import           GHC.STRef
 import           GHC.IORef
 import           GHC.IO
-import           GHC.Prim
+import           GHC.Exts
 import           Basement.Compat.Base (Exception, (.), ($), Applicative, Monad)
 
 -- | Primitive monad that can handle mutation.


### PR DESCRIPTION
Fixes #536.