### PR TITLE
Eta convert a lambda to fix GHC 9 type error

### DIFF
--- a/foundation/Foundation/Conduit/Internal.hs
+++ b/foundation/Foundation/Conduit/Internal.hs
@@ -126,7 +126,7 @@ instance MonadThrow m => MonadThrow (Conduit i o m) where
 instance MonadCatch m => MonadCatch (Conduit i o m) where
     catch (Conduit c0) onExc = Conduit $ \rest -> let
         go (PipeM m) =
-            PipeM $ catch (liftM go m) (return . flip unConduit rest . onExc)
+            PipeM $ catch (liftM go m) (\x -> return $ unConduit (onExc x) rest)
         go (Done r) = rest r
         go (Await p c) = Await (go . p) (go . c)
         go (Yield p m o) = Yield (go p) m o


### PR DESCRIPTION
Previously this code did not compile on (soon to be released GHC 9). I think it is caused by the [simplified subsumption work](https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.0#simplified-subsumption).

I was able to compile `foundation` on GHC 9 with this change alongside with https://github.com/haskell-foundation/foundation/pull/538 and https://github.com/haskell-foundation/foundation/pull/537.