### PR TITLE
Primitive seps

### DIFF
--- a/basement/Basement/Base16.hs
+++ b/basement/Basement/Base16.hs
@@ -9,10 +9,11 @@ module Basement.Base16
     , Base16Escape(..)
     ) where
 
-import GHC.Prim
+import GHC.Prim (Addr#, indexWord8OffAddr#, word2Int#, chr#)
 import GHC.Types
 import GHC.Word
 import Basement.Types.Char7
+import Basement.Compat.Primitive
 
 data Base16Escape = Base16Escape {-# UNPACK #-} !Char7 {-# UNPACK #-} !Char7
 
@@ -22,41 +23,42 @@ data Base16Escape = Base16Escape {-# UNPACK #-} !Char7 {-# UNPACK #-} !Char7
 -- The output words# are guaranteed to be included in the 0 to 2^7-1 range
 --
 -- Note that calling convertByte with a value greater than 256
--- will cause segfault or other horrible effect.
-unsafeConvertByte :: Word# -> (# Word#, Word# #)
+-- will cause segfault or other horrible effect. From GHC9.2, Word8#
+-- cannot be >= 256.
+unsafeConvertByte :: Word8# -> (# Word8#, Word8# #)
 unsafeConvertByte b = (# r tableHi b, r tableLo b #)
   where
-    r :: Table -> Word# -> Word#
-    r (Table !table) index = indexWord8OffAddr# table (word2Int# index)
+    r :: Table -> Word8# -> Word8#
+    r (Table !table) index = indexWord8OffAddr# table (word2Int# (word8ToWord# index))
 {-# INLINE unsafeConvertByte #-}
 
 escapeByte :: Word8 -> Base16Escape
 escapeByte !(W8# b) = Base16Escape (r tableHi b) (r tableLo b)
   where
-    r :: Table -> Word# -> Char7
-    r (Table !table) index = Char7 (W8# (indexWord8OffAddr# table (word2Int# index)))
+    r :: Table -> Word8# -> Char7
+    r (Table !table) index = Char7 (W8# (indexWord8OffAddr# table (word2Int# (word8ToWord# index))))
 {-# INLINE escapeByte #-}
 
 -- | hex word16
 hexWord16 :: Word16 -> (Char, Char, Char, Char)
 hexWord16 (W16# w) = (toChar w1,toChar w2,toChar w3,toChar w4)
   where
-    toChar :: Word# -> Char
-    toChar c = C# (chr# (word2Int# c))
-    !(# w1, w2 #) = unsafeConvertByte (uncheckedShiftRL# w 8#)
-    !(# w3, w4 #) = unsafeConvertByte (and# w 0xff##)
+    toChar :: Word8# -> Char
+    toChar c = C# (chr# (word2Int# (word8ToWord# c)))
+    !(# w1, w2 #) = unsafeConvertByte (word16ToWord8# (uncheckedShiftRLWord16# w 8#))
+    !(# w3, w4 #) = unsafeConvertByte (word16ToWord8# w)
 
 -- | hex word32
 hexWord32 :: Word32 -> (Char, Char, Char, Char, Char, Char, Char, Char)
 hexWord32 (W32# w) = (toChar w1,toChar w2,toChar w3,toChar w4
                      ,toChar w5,toChar w6,toChar w7,toChar w8)
   where
-    toChar :: Word# -> Char
-    toChar c = C# (chr# (word2Int# c))
-    !(# w1, w2 #) = unsafeConvertByte (uncheckedShiftRL# w 24#)
-    !(# w3, w4 #) = unsafeConvertByte (and# (uncheckedShiftRL# w 16#) 0xff##)
-    !(# w5, w6 #) = unsafeConvertByte (and# (uncheckedShiftRL# w 8#) 0xff##)
-    !(# w7, w8 #) = unsafeConvertByte (and# w 0xff##)
+    toChar :: Word8# -> Char
+    toChar c = C# (chr# (word2Int# (word8ToWord# c)))
+    !(# w1, w2 #) = unsafeConvertByte (word32ToWord8# (uncheckedShiftRLWord32# w 24#))
+    !(# w3, w4 #) = unsafeConvertByte (word32ToWord8# (uncheckedShiftRLWord32# w 16#))
+    !(# w5, w6 #) = unsafeConvertByte (word32ToWord8# (uncheckedShiftRLWord32# w 8#))
+    !(# w7, w8 #) = unsafeConvertByte (word32ToWord8# w)
 
 data Table = Table Addr#
 
@@ -81,4 +83,3 @@ tableHi = Table
     \aaaaaaaaaaaaaaaabbbbbbbbbbbbbbbb\
     \ccccccccccccccccdddddddddddddddd\
     \eeeeeeeeeeeeeeeeffffffffffffffff"#
-

--- a/basement/Basement/Bits.hs
+++ b/basement/Basement/Bits.hs
@@ -51,6 +51,7 @@ import GHC.Prim
 import GHC.Types
 import GHC.Word
 import GHC.Int
+import Basement.Compat.Primitive
 
 #if WORD_SIZE_IN_BITS < 64
 import GHC.IntWord64
@@ -235,196 +236,114 @@ instance BitOps Bool where
 
 instance FiniteBitsOps Word8 where
     numberOfBits _ = 8
-    rotateL (W8# x#) (CountOf (I# i#))
-        | isTrue# (i'# ==# 0#) = W8# x#
-        | otherwise  = W8# (narrow8Word# ((x# `uncheckedShiftL#` i'#) `or#`
-                                          (x# `uncheckedShiftRL#` (8# -# i'#))))
-      where
-        !i'# = word2Int# (int2Word# i# `and#` 7##)
-    rotateR (W8# x#) (CountOf (I# i#))
-        | isTrue# (i'# ==# 0#) = W8# x#
-        | otherwise  = W8# (narrow8Word# ((x# `uncheckedShiftRL#` i'#) `or#`
-                                          (x# `uncheckedShiftL#` (8# -# i'#))))
-      where
-        !i'# = word2Int# (int2Word# i# `and#` 7##)
-    bitFlip (W8# x#) = W8# (x# `xor#` mb#)
-        where !(W8# mb#) = maxBound
-    popCount (W8# x#) = CountOf $ wordToInt (W# (popCnt8# x#))
-    countLeadingZeros (W8# w#) = CountOf $ wordToInt (W# (clz8# w#))
-    countTrailingZeros (W8# w#) = CountOf $ wordToInt (W# (ctz8# w#))
+    rotateL w (CountOf i) = w `OldBits.rotateL` i
+    rotateR w (CountOf i) = w `OldBits.rotateR` i
+    bitFlip = OldBits.complement
+    popCount (W8# x#) = CountOf $ wordToInt (W# (popCnt8# (word8ToWord# x#)))
+    countLeadingZeros (W8# w) = CountOf (wordToInt (W# (clz8# (word8ToWord# w))))
+    countTrailingZeros (W8# w) = CountOf (wordToInt (W# (ctz8# (word8ToWord# w))))
 instance BitOps Word8 where
-    (W8# x#) .&. (W8# y#)   = W8# (x# `and#` y#)
-    (W8# x#) .|. (W8# y#)   = W8# (x# `or#`  y#)
-    (W8# x#) .^. (W8# y#)   = W8# (x# `xor#` y#)
-    (W8# x#) .<<. (CountOf (I# i#)) = W8# (narrow8Word# (x# `shiftL#` i#))
-    (W8# x#) .>>. (CountOf (I# i#)) = W8# (narrow8Word# (x# `shiftRL#` i#))
+    (.&.)    a b    = (a OldBits..&. b)
+    (.|.)    a b    = (a OldBits..|. b)
+    (.^.)    a b    = (a `OldBits.xor` b)
+    (.<<.)   a (CountOf w) = (a `OldBits.shiftL` w)
+    (.>>.)   a (CountOf w) = (a `OldBits.shiftR` w)
 
 -- Word16 ---------------------------------------------------------------------
 
 instance FiniteBitsOps Word16 where
     numberOfBits _ = 16
-    rotateL (W16# x#) (CountOf (I# i#))
-        | isTrue# (i'# ==# 0#) = W16# x#
-        | otherwise  = W16# (narrow16Word# ((x# `uncheckedShiftL#` i'#) `or#`
-                                            (x# `uncheckedShiftRL#` (16# -# i'#))))
-      where
-        !i'# = word2Int# (int2Word# i# `and#` 15##)
-    rotateR (W16# x#) (CountOf (I# i#))
-        | isTrue# (i'# ==# 0#) = W16# x#
-        | otherwise  = W16# (narrow16Word# ((x# `uncheckedShiftRL#` i'#) `or#`
-                                            (x# `uncheckedShiftL#` (16# -# i'#))))
-      where
-        !i'# = word2Int# (int2Word# i# `and#` 15##)
-    bitFlip (W16# x#) = W16# (x# `xor#` mb#)
-        where !(W16# mb#) = maxBound
-    popCount (W16# x#) = CountOf $ wordToInt (W# (popCnt16# x#))
-    countLeadingZeros (W16# w#) = CountOf $ wordToInt (W# (clz16# w#))
-    countTrailingZeros (W16# w#) = CountOf $ wordToInt (W# (ctz16# w#))
+    rotateL w (CountOf i) = w `OldBits.rotateL` i
+    rotateR w (CountOf i) = w `OldBits.rotateR` i
+    bitFlip = OldBits.complement
+    popCount (W16# x#) = CountOf $ wordToInt (W# (popCnt16# (word16ToWord# x#)))
+    countLeadingZeros (W16# w#) = CountOf $ wordToInt (W# (clz16# (word16ToWord# w#)))
+    countTrailingZeros (W16# w#) = CountOf $ wordToInt (W# (ctz16# (word16ToWord# w#)))
 instance BitOps Word16 where
-    (W16# x#) .&. (W16# y#)   = W16# (x# `and#` y#)
-    (W16# x#) .|. (W16# y#)   = W16# (x# `or#`  y#)
-    (W16# x#) .^. (W16# y#)   = W16# (x# `xor#` y#)
-    (W16# x#) .<<. (CountOf (I# i#)) = W16# (narrow16Word# (x# `shiftL#` i#))
-    (W16# x#) .>>. (CountOf (I# i#)) = W16# (narrow16Word# (x# `shiftRL#` i#))
+    (.&.)    a b    = (a OldBits..&. b)
+    (.|.)    a b    = (a OldBits..|. b)
+    (.^.)    a b    = (a `OldBits.xor` b)
+    (.<<.)   a (CountOf w) = (a `OldBits.shiftL` w)
+    (.>>.)   a (CountOf w) = (a `OldBits.shiftR` w)
 
 -- Word32 ---------------------------------------------------------------------
 
 instance FiniteBitsOps Word32 where
     numberOfBits _ = 32
-    rotateL (W32# x#) (CountOf (I# i#))
-        | isTrue# (i'# ==# 0#) = W32# x#
-        | otherwise  = W32# (narrow32Word# ((x# `uncheckedShiftL#` i'#) `or#`
-                                            (x# `uncheckedShiftRL#` (32# -# i'#))))
-      where
-        !i'# = word2Int# (int2Word# i# `and#` 31##)
-    rotateR (W32# x#) (CountOf (I# i#))
-        | isTrue# (i'# ==# 0#) = W32# x#
-        | otherwise  = W32# (narrow32Word# ((x# `uncheckedShiftRL#` i'#) `or#`
-                                            (x# `uncheckedShiftL#` (32# -# i'#))))
-      where
-        !i'# = word2Int# (int2Word# i# `and#` 31##)
-    bitFlip (W32# x#) = W32# (x# `xor#` mb#)
-        where !(W32# mb#) = maxBound
-    popCount (W32# x#) = CountOf $ wordToInt (W# (popCnt32# x#))
-    countLeadingZeros (W32# w#) = CountOf $ wordToInt (W# (clz32# w#))
-    countTrailingZeros (W32# w#) = CountOf $ wordToInt (W# (ctz32# w#))
+    rotateL w (CountOf i) = w `OldBits.rotateL` i
+    rotateR w (CountOf i) = w `OldBits.rotateR` i
+    bitFlip = OldBits.complement
+    popCount (W32# x#) = CountOf $ wordToInt (W# (popCnt32# (word32ToWord# x#)))
+    countLeadingZeros (W32# w#) = CountOf $ wordToInt (W# (clz32# (word32ToWord# w#)))
+    countTrailingZeros (W32# w#) = CountOf $ wordToInt (W# (ctz32# (word32ToWord# w#)))
 instance BitOps Word32 where
-    (W32# x#) .&. (W32# y#)   = W32# (x# `and#` y#)
-    (W32# x#) .|. (W32# y#)   = W32# (x# `or#`  y#)
-    (W32# x#) .^. (W32# y#)   = W32# (x# `xor#` y#)
-    (W32# x#) .<<. (CountOf (I# i#)) = W32# (narrow32Word# (x# `shiftL#` i#))
-    (W32# x#) .>>. (CountOf (I# i#)) = W32# (narrow32Word# (x# `shiftRL#` i#))
+    (.&.)    a b    = (a OldBits..&. b)
+    (.|.)    a b    = (a OldBits..|. b)
+    (.^.)    a b    = (a `OldBits.xor` b)
+    (.<<.)   a (CountOf w) = (a `OldBits.shiftL` w)
+    (.>>.)   a (CountOf w) = (a `OldBits.shiftR` w)
 
 -- Word ---------------------------------------------------------------------
 
 #if WORD_SIZE_IN_BITS == 64
 instance FiniteBitsOps Word where
     numberOfBits _ = 64
-    rotateL (W# x#) (CountOf (I# i#))
-        | isTrue# (i'# ==# 0#) = W# x#
-        | otherwise  = W# ((x# `uncheckedShiftL#` i'#) `or#`
-                           (x# `uncheckedShiftRL#` (64# -# i'#)))
-      where
-        !i'# = word2Int# (int2Word# i# `and#` 63##)
-    rotateR (W# x#) (CountOf (I# i#))
-        | isTrue# (i'# ==# 0#) = W# x#
-        | otherwise  = W# ((x# `uncheckedShiftRL#` i'#) `or#`
-                           (x# `uncheckedShiftL#` (64# -# i'#)))
-      where
-        !i'# = word2Int# (int2Word# i# `and#` 63##)
-    bitFlip (W# x#) = W# (x# `xor#` mb#)
-        where !(W# mb#) = maxBound
+    rotateL w (CountOf i) = w `OldBits.rotateL` i
+    rotateR w (CountOf i) = w `OldBits.rotateR` i
+    bitFlip = OldBits.complement
     popCount (W# x#) = CountOf $ wordToInt (W# (popCnt64# x#))
     countLeadingZeros (W# w#) = CountOf $ wordToInt (W# (clz64# w#))
     countTrailingZeros (W# w#) = CountOf $ wordToInt (W# (ctz64# w#))
 #else
 instance FiniteBitsOps Word where
     numberOfBits _ = 32
-    rotateL (W# x#) (CountOf (I# i#))
-        | isTrue# (i'# ==# 0#) = W# x#
-        | otherwise  = W# ((x# `uncheckedShiftL#` i'#) `or#`
-                           (x# `uncheckedShiftRL#` (32# -# i'#)))
-      where
-        !i'# = word2Int# (int2Word# i# `and#` 31##)
-    rotateR (W# x#) (CountOf (I# i#))
-        | isTrue# (i'# ==# 0#) = W# x#
-        | otherwise  = W# ((x# `uncheckedShiftRL#` i'#) `or#`
-                           (x# `uncheckedShiftL#` (32# -# i'#)))
-      where
-        !i'# = word2Int# (int2Word# i# `and#` 31##)
-    bitFlip (W# x#) = W# (x# `xor#` mb#)
-        where !(W# mb#) = maxBound
+    rotateL w (CountOf i) = w `OldBits.rotateL` i
+    rotateR w (CountOf i) = w `OldBits.rotateR` i
+    bitFlip = OldBits.complement
     popCount (W# x#) = CountOf $ wordToInt (W# (popCnt32# x#))
     countLeadingZeros (W# w#) = CountOf $ wordToInt (W# (clz32# w#))
     countTrailingZeros (W# w#) = CountOf $ wordToInt (W# (ctz32# w#))
 #endif
 
 instance BitOps Word where
-    (W# x#) .&. (W# y#)   = W# (x# `and#` y#)
-    (W# x#) .|. (W# y#)   = W# (x# `or#`  y#)
-    (W# x#) .^. (W# y#)   = W# (x# `xor#` y#)
-    (W# x#) .<<. (CountOf (I# i#)) = W# ((x# `shiftL#` i#))
-    (W# x#) .>>. (CountOf (I# i#)) = W# ((x# `shiftRL#` i#))
+    (.&.)    a b    = (a OldBits..&. b)
+    (.|.)    a b    = (a OldBits..|. b)
+    (.^.)    a b    = (a `OldBits.xor` b)
+    (.<<.)   a (CountOf w) = (a `OldBits.shiftL` w)
+    (.>>.)   a (CountOf w) = (a `OldBits.shiftR` w)
 
 -- Word64 ---------------------------------------------------------------------
 
 #if WORD_SIZE_IN_BITS == 64
 instance FiniteBitsOps Word64 where
     numberOfBits _ = 64
-    rotateL (W64# x#) (CountOf (I# i#))
-        | isTrue# (i'# ==# 0#) = W64# x#
-        | otherwise  = W64# ((x# `uncheckedShiftL#` i'#) `or#`
-                             (x# `uncheckedShiftRL#` (64# -# i'#)))
-      where
-        !i'# = word2Int# (int2Word# i# `and#` 63##)
-    rotateR (W64# x#) (CountOf (I# i#))
-        | isTrue# (i'# ==# 0#) = W64# x#
-        | otherwise  = W64# ((x# `uncheckedShiftRL#` i'#) `or#`
-                             (x# `uncheckedShiftL#` (64# -# i'#)))
-      where
-        !i'# = word2Int# (int2Word# i# `and#` 63##)
-    bitFlip (W64# x#) = W64# (x# `xor#` mb#)
-        where !(W64# mb#) = maxBound
+    rotateL w (CountOf i) = w `OldBits.rotateL` i
+    rotateR w (CountOf i) = w `OldBits.rotateR` i
+    bitFlip = OldBits.complement
     popCount (W64# x#) = CountOf $ wordToInt (W# (popCnt64# x#))
     countLeadingZeros (W64# w#) = CountOf $ wordToInt (W# (clz64# w#))
     countTrailingZeros (W64# w#) = CountOf $ wordToInt (W# (ctz64# w#))
 instance BitOps Word64 where
-    (W64# x#) .&. (W64# y#)   = W64# (x# `and#` y#)
-    (W64# x#) .|. (W64# y#)   = W64# (x# `or#`  y#)
-    (W64# x#) .^. (W64# y#)   = W64# (x# `xor#` y#)
-    (W64# x#) .<<. (CountOf (I# i#)) = W64# (x# `shiftL#` i#)
-    (W64# x#) .>>. (CountOf (I# i#)) = W64# (x# `shiftRL#` i#)
+    (.&.)    a b    = (a OldBits..&. b)
+    (.|.)    a b    = (a OldBits..|. b)
+    (.^.)    a b    = (a `OldBits.xor` b)
+    (.<<.)   a (CountOf w) = (a `OldBits.shiftL` w)
+    (.>>.)   a (CountOf w) = (a `OldBits.shiftR` w)
 #else
 instance FiniteBitsOps Word64 where
     numberOfBits _ = 64
-    rotateL (W64# x#) (CountOf (I# i#))
-        | isTrue# (i'# ==# 0#) = W64# x#
-        | otherwise  = W64# ((x# `uncheckedShiftL64#` i'#) `or64#`
-                             (x# `uncheckedShiftRL64#` (64# -# i'#)))
-      where
-        !i'# = word2Int# (int2Word# i# `and#` 63##)
-    rotateR (W64# x#) (CountOf (I# i#))
-        | isTrue# (i'# ==# 0#) = W64# x#
-        | otherwise  = W64# ((x# `uncheckedShiftRL64#` i'#) `or64#`
-                             (x# `uncheckedShiftL64#` (64# -# i'#)))
-      where
-        !i'# = word2Int# (int2Word# i# `and#` 63##)
-    bitFlip (W64# x#) = W64# (not64# x#)
+    rotateL w (CountOf i) = w `OldBits.rotateL` i
+    rotateR w (CountOf i) = w `OldBits.rotateR` i
+    bitFlip = OldBits.complement
     popCount (W64# x#) = CountOf $ wordToInt (W# (popCnt64# x#))
     countLeadingZeros (W64# w#) = CountOf $ wordToInt (W# (clz64# w#))
     countTrailingZeros (W64# w#) = CountOf $ wordToInt (W# (ctz64# w#))
 instance BitOps Word64 where
-    (W64# x#) .&. (W64# y#)   = W64# (x# `and64#` y#)
-    (W64# x#) .|. (W64# y#)   = W64# (x# `or64#`  y#)
-    (W64# x#) .^. (W64# y#)   = W64# (x# `xor64#` y#)
-    (W64# x#) .<<. (CountOf (I# i#)) = W64# (x# `shiftL64#` i#)
-    (W64# x#) .>>. (CountOf (I# i#)) = W64# (x# `shiftRL64#` i#)
-
-shiftL64#, shiftRL64# :: Word64# -> Int# -> Word64#
-a `shiftL64#` b  | isTrue# (b >=# 64#) = wordToWord64# 0##
-                 | otherwise           = a `uncheckedShiftL64#` b
-a `shiftRL64#` b | isTrue# (b >=# 64#) = wordToWord64# 0##
-                 | otherwise           = a `uncheckedShiftRL64#` b
+    (.&.)    a b    = (a OldBits..&. b)
+    (.|.)    a b    = (a OldBits..|. b)
+    (.^.)    a b    = (a `OldBits.xor` b)
+    (.<<.)   a (CountOf w) = (a `OldBits.shiftL` w)
+    (.>>.)   a (CountOf w) = (a `OldBits.shiftR` w)
 #endif
 
 -- Word128 --------------------------------------------------------------------
@@ -458,156 +377,85 @@ instance BitOps Word256 where
     (.>>.) w (CountOf n) = Word256.shiftR w n
 
 -- Int8 -----------------------------------------------------------------------
-
 instance FiniteBitsOps Int8 where
     numberOfBits _ = 8
-    rotateL (I8# x#) (CountOf (I# i#))
-        | isTrue# (i'# ==# 0#) = I8# x#
-        | otherwise  = I8# (narrow8Int# (word2Int# ((x'# `uncheckedShiftL#` i'#) `or#`
-                                                    (x'# `uncheckedShiftRL#` (8# -# i'#)))))
-      where
-        !x'# = narrow8Word# (int2Word# x#)
-        !i'# = word2Int# (int2Word# i# `and#` 7##)
-    rotateR (I8# x#) (CountOf (I# i#))
-        | isTrue# (i'# ==# 0#) = I8# x#
-        | otherwise  = I8# (narrow8Int# (word2Int# ((x'# `uncheckedShiftRL#` i'#) `or#`
-                                                    (x'# `uncheckedShiftL#` (8# -# i'#)))))
-      where
-        !x'# = narrow8Word# (int2Word# x#)
-        !i'# = word2Int# (int2Word# i# `and#` 7##)
-    bitFlip (I8# x#) = I8# (word2Int# (not# (int2Word# x#)))
-    popCount (I8# x#) = CountOf $ wordToInt (W# (popCnt8# (int2Word# x#)))
-    countLeadingZeros (I8# w#) = CountOf $ wordToInt (W# (clz8# (int2Word# w#)))
-    countTrailingZeros (I8# w#) = CountOf $ wordToInt (W# (ctz8# (int2Word# w#)))
+    rotateL w (CountOf i) = w `OldBits.rotateL` i
+    rotateR w (CountOf i) = w `OldBits.rotateR` i
+    bitFlip = OldBits.complement
+    popCount (I8# x#) = CountOf $ wordToInt (W# (popCnt8# (int2Word# (int8ToInt# x#))))
+    countLeadingZeros (I8# w#) = CountOf $ wordToInt (W# (clz8# (int2Word# (int8ToInt# w#))))
+    countTrailingZeros (I8# w#) = CountOf $ wordToInt (W# (ctz8# (int2Word# (int8ToInt# w#))))
 instance BitOps Int8 where
-    (I8# x#) .&. (I8# y#)   = I8# (x# `andI#` y#)
-    (I8# x#) .|. (I8# y#)   = I8# (x# `orI#`  y#)
-    (I8# x#) .^. (I8# y#)   = I8# (x# `xorI#` y#)
-    (I8# x#) .<<. (CountOf (I# i#)) = I8# (narrow8Int# (x# `iShiftL#`  i#))
-    (I8# x#) .>>. (CountOf (I# i#)) = I8# (narrow8Int# (x# `iShiftRL#` i#))
+    (.&.)    a b    = (a OldBits..&. b)
+    (.|.)    a b    = (a OldBits..|. b)
+    (.^.)    a b    = (a `OldBits.xor` b)
+    (.<<.)   a (CountOf w) = (a `OldBits.shiftL` w)
+    (.>>.)   a (CountOf w) = (a `OldBits.shiftR` w)
 
 -- Int16 ----------------------------------------------------------------------
 
 instance FiniteBitsOps Int16 where
     numberOfBits _ = 16
-    rotateL (I16# x#) (CountOf (I# i#))
-        | isTrue# (i'# ==# 0#) = I16# x#
-        | otherwise  = I16# (narrow16Int# (word2Int# ((x'# `uncheckedShiftL#` i'#) `or#`
-                                                      (x'# `uncheckedShiftRL#` (16# -# i'#)))))
-      where
-        !x'# = narrow16Word# (int2Word# x#)
-        !i'# = word2Int# (int2Word# i# `and#` 15##)
-    rotateR (I16# x#) (CountOf (I# i#))
-        | isTrue# (i'# ==# 0#) = I16# x#
-        | otherwise  = I16# (narrow16Int# (word2Int# ((x'# `uncheckedShiftRL#` i'#) `or#`
-                                                      (x'# `uncheckedShiftL#` (16# -# i'#)))))
-      where
-        !x'# = narrow16Word# (int2Word# x#)
-        !i'# = word2Int# (int2Word# i# `and#` 15##)
-    bitFlip (I16# x#) = I16# (word2Int# (not# (int2Word# x#)))
-    popCount (I16# x#) = CountOf $ wordToInt (W# (popCnt16# (int2Word# x#)))
-    countLeadingZeros (I16# w#) = CountOf $ wordToInt (W# (clz16# (int2Word# w#)))
-    countTrailingZeros (I16# w#) = CountOf $ wordToInt (W# (ctz16# (int2Word# w#)))
+    rotateL w (CountOf i) = w `OldBits.rotateL` i
+    rotateR w (CountOf i) = w `OldBits.rotateR` i
+    bitFlip = OldBits.complement
+    popCount (I16# x#) = CountOf $ wordToInt (W# (popCnt16# (int2Word# (int16ToInt# x#))))
+    countLeadingZeros (I16# w#) = CountOf $ wordToInt (W# (clz16# (int2Word# (int16ToInt# w#))))
+    countTrailingZeros (I16# w#) = CountOf $ wordToInt (W# (ctz16# (int2Word# (int16ToInt# w#))))
 instance BitOps Int16 where
-    (I16# x#) .&. (I16# y#)   = I16# (x# `andI#` y#)
-    (I16# x#) .|. (I16# y#)   = I16# (x# `orI#`  y#)
-    (I16# x#) .^. (I16# y#)   = I16# (x# `xorI#` y#)
-    (I16# x#) .<<. (CountOf (I# i#)) = I16# (narrow16Int# (x# `iShiftL#`  i#))
-    (I16# x#) .>>. (CountOf (I# i#)) = I16# (narrow16Int# (x# `iShiftRL#` i#))
+    (.&.)    a b    = (a OldBits..&. b)
+    (.|.)    a b    = (a OldBits..|. b)
+    (.^.)    a b    = (a `OldBits.xor` b)
+    (.<<.)   a (CountOf w) = (a `OldBits.shiftL` w)
+    (.>>.)   a (CountOf w) = (a `OldBits.shiftR` w)
 
 -- Int32 ----------------------------------------------------------------------
 
 instance FiniteBitsOps Int32 where
     numberOfBits _ = 32
-    rotateL (I32# x#) (CountOf (I# i#))
-        | isTrue# (i'# ==# 0#) = I32# x#
-        | otherwise  = I32# (narrow32Int# (word2Int# ((x'# `uncheckedShiftL#` i'#) `or#`
-                                                      (x'# `uncheckedShiftRL#` (32# -# i'#)))))
-      where
-        !x'# = narrow32Word# (int2Word# x#)
-        !i'# = word2Int# (int2Word# i# `and#` 31##)
-    rotateR (I32# x#) (CountOf (I# i#))
-        | isTrue# (i'# ==# 0#) = I32# x#
-        | otherwise  = I32# (narrow32Int# (word2Int# ((x'# `uncheckedShiftRL#` i'#) `or#`
-                                                      (x'# `uncheckedShiftL#` (32# -# i'#)))))
-      where
-        !x'# = narrow32Word# (int2Word# x#)
-        !i'# = word2Int# (int2Word# i# `and#` 31##)
-    bitFlip (I32# x#) = I32# (word2Int# (not# (int2Word# x#)))
-    popCount (I32# x#) = CountOf $ wordToInt (W# (popCnt32# (int2Word# x#)))
-    countLeadingZeros (I32# w#) = CountOf $ wordToInt (W# (clz32# (int2Word# w#)))
-    countTrailingZeros (I32# w#) = CountOf $ wordToInt (W# (ctz32# (int2Word# w#)))
+    rotateL w (CountOf i) = w `OldBits.rotateL` i
+    rotateR w (CountOf i) = w `OldBits.rotateR` i
+    bitFlip = OldBits.complement
+    popCount (I32# x#) = CountOf $ wordToInt (W# (popCnt32# (int2Word# (int32ToInt# x#))))
+    countLeadingZeros (I32# w#) = CountOf $ wordToInt (W# (clz32# (int2Word# (int32ToInt# w#))))
+    countTrailingZeros (I32# w#) = CountOf $ wordToInt (W# (ctz32# (int2Word# (int32ToInt# w#))))
 instance BitOps Int32 where
-    (I32# x#) .&. (I32# y#)   = I32# (x# `andI#` y#)
-    (I32# x#) .|. (I32# y#)   = I32# (x# `orI#`  y#)
-    (I32# x#) .^. (I32# y#)   = I32# (x# `xorI#` y#)
-    (I32# x#) .<<. (CountOf (I# i#)) = I32# (narrow32Int# (x# `iShiftL#`  i#))
-    (I32# x#) .>>. (CountOf (I# i#)) = I32# (narrow32Int# (x# `iShiftRL#` i#))
-
+    (.&.)    a b    = (a OldBits..&. b)
+    (.|.)    a b    = (a OldBits..|. b)
+    (.^.)    a b    = (a `OldBits.xor` b)
+    (.<<.)   a (CountOf w) = (a `OldBits.shiftL` w)
+    (.>>.)   a (CountOf w) = (a `OldBits.shiftR` w)
 -- Int64 ----------------------------------------------------------------------
 
 #if WORD_SIZE_IN_BITS == 64
 instance FiniteBitsOps Int64 where
     numberOfBits _ = 64
-    rotateL (I64# x#) (CountOf (I# i#))
-        | isTrue# (i'# ==# 0#) = I64# x#
-        | otherwise  = I64# (word2Int# ((x'# `uncheckedShiftL#` i'#) `or#`
-                                        (x'# `uncheckedShiftRL#` (64# -# i'#))))
-      where
-        !x'# = int2Word# x#
-        !i'# = word2Int# (int2Word# i# `and#` 63##)
-    rotateR (I64# x#) (CountOf (I# i#))
-        | isTrue# (i'# ==# 0#) = I64# x#
-        | otherwise  = I64# (word2Int# ((x'# `uncheckedShiftRL#` i'#) `or#`
-                                        (x'# `uncheckedShiftL#` (64# -# i'#))))
-      where
-        !x'# = int2Word# x#
-        !i'# = word2Int# (int2Word# i# `and#` 63##)
-    bitFlip (I64# x#) = I64# (word2Int# (int2Word# x# `xor#` int2Word# (-1#)))
+    rotateL w (CountOf i) = w `OldBits.rotateL` i
+    rotateR w (CountOf i) = w `OldBits.rotateR` i
+    bitFlip = OldBits.complement
     popCount (I64# x#) = CountOf $ wordToInt (W# (popCnt64# (int2Word# x#)))
     countLeadingZeros (I64# w#) = CountOf $ wordToInt (W# (clz64# (int2Word# w#)))
     countTrailingZeros (I64# w#) = CountOf $ wordToInt (W# (ctz64# (int2Word# w#)))
 instance BitOps Int64 where
-    (I64# x#) .&. (I64# y#)   = I64# (x# `andI#` y#)
-    (I64# x#) .|. (I64# y#)   = I64# (x# `orI#`  y#)
-    (I64# x#) .^. (I64# y#)   = I64# (x# `xorI#` y#)
-    (I64# x#) .<<. (CountOf (I# w#)) = I64# (x# `iShiftL#`  w#)
-    (I64# x#) .>>. (CountOf (I# w#)) = I64# (x# `iShiftRL#` w#)
+    (.&.)    a b    = (a OldBits..&. b)
+    (.|.)    a b    = (a OldBits..|. b)
+    (.^.)    a b    = (a `OldBits.xor` b)
+    (.<<.)   a (CountOf w) = (a `OldBits.shiftL` w)
+    (.>>.)   a (CountOf w) = (a `OldBits.shiftR` w)
 #else
 instance FiniteBitsOps Int64 where
     numberOfBits _ = 64
-    rotateL (I64# x#) (CountOf (I# i#))
-        | isTrue# (i'# ==# 0#) = I64# x#
-        | otherwise  = I64# (word64ToInt64# ((x'# `uncheckedShiftL64#` i'#) `or64#`
-                                             (x'# `uncheckedShiftRL64#` (64# -# i'#))))
-      where
-        !x'# = int64ToWord64# x#
-        !i'# = word2Int# (int2Word# i# `and#` 63##)
-    rotateR (I64# x#) (CountOf (I# i#))
-        | isTrue# (i'# ==# 0#) = I64# x#
-        | otherwise  = I64# (word64ToInt64# ((x'# `uncheckedShiftRL64#` i'#) `or64#`
-                                             (x'# `uncheckedShiftL64#` (64# -# i'#))))
-      where
-        !x'# = int64ToWord64# x#
-        !i'# = word2Int# (int2Word# i# `and#` 63##)
-    bitFlip (I64# x#) = I64# (word64ToInt64# (not64# (int64ToWord64# x#)))
+    rotateL w (CountOf i) = w `OldBits.rotateL` i
+    rotateR w (CountOf i) = w `OldBits.rotateR` i
+    bitFlip = OldBits.complement
     popCount (I64# x#) = CountOf $ wordToInt (W# (popCnt64# (int64ToWord64# x#)))
     countLeadingZeros (I64# w#) = CountOf $ wordToInt (W# (clz64# (int64ToWord64# w#)))
     countTrailingZeros (I64# w#) = CountOf $ wordToInt (W# (ctz64# (int64ToWord64# w#)))
 instance BitOps Int64 where
-    (I64# x#) .&. (I64# y#)  = I64# (word64ToInt64# (int64ToWord64# x# `and64#` int64ToWord64# y#))
-    (I64# x#) .|. (I64# y#)  = I64# (word64ToInt64# (int64ToWord64# x# `or64#`  int64ToWord64# y#))
-    (I64# x#) .^. (I64# y#)  = I64# (word64ToInt64# (int64ToWord64# x# `xor64#` int64ToWord64# y#))
-    (I64# x#) .<<. (CountOf (I# w#)) = I64# (x# `iShiftL64#`  w#)
-    (I64# x#) .>>. (CountOf (I# w#)) = I64# (x# `iShiftRA64#` w#)
-
-
-iShiftL64#, iShiftRA64# :: Int64# -> Int# -> Int64#
-a `iShiftL64#` b  | isTrue# (b >=# 64#) = intToInt64# 0#
-                  | otherwise           = a `uncheckedIShiftL64#` b
-a `iShiftRA64#` b | isTrue# (b >=# 64#) && isTrue# (a `ltInt64#` (intToInt64# 0#))
-                                        = intToInt64# (-1#)
-                  | isTrue# (b >=# 64#) = intToInt64# 0#
-                  | otherwise = a `uncheckedIShiftRA64#` b
+    (.&.)    a b    = (a OldBits..&. b)
+    (.|.)    a b    = (a OldBits..|. b)
+    (.^.)    a b    = (a `OldBits.xor` b)
+    (.<<.)   a (CountOf w) = (a `OldBits.shiftL` w)
+    (.>>.)   a (CountOf w) = (a `OldBits.shiftR` w)
 
 #endif

--- a/basement/Basement/Cast.hs
+++ b/basement/Basement/Cast.hs
@@ -18,6 +18,7 @@ module Basement.Cast
 import qualified Basement.Block.Base as Block
 import           Basement.Compat.Base
 import           Basement.Compat.Natural
+import           Basement.Compat.Primitive
 import           Basement.Numerical.Number
 import           Basement.Numerical.Conversion
 import           Basement.PrimType
@@ -58,22 +59,22 @@ class Cast source destination where
         Block.unsafeRead (Block.unsafeRecast mba) 0
 
 instance Cast Int8  Word8 where
-    cast (I8# i) = W8# (narrow8Word# (int2Word# i))
+    cast (I8# i) = W8# (wordToWord8# (int2Word# (int8ToInt# i)))
 instance Cast Int16 Word16 where
-    cast (I16# i) = W16# (narrow16Word# (int2Word# i))
+    cast (I16# i) = W16# (wordToWord16# (int2Word# (int16ToInt# i)))
 instance Cast Int32 Word32 where
-    cast (I32# i) = W32# (narrow32Word# (int2Word# i))
+    cast (I32# i) = W32# (wordToWord32# (int2Word# (int32ToInt# i)))
 instance Cast Int64 Word64 where
     cast = int64ToWord64
 instance Cast Int   Word where
     cast (I# i) = W# (int2Word# i)
 
 instance Cast Word8  Int8 where
-    cast (W8# i) = I8# (narrow8Int# (word2Int# i))
+    cast (W8# i) = I8# (intToInt8# (word2Int# (word8ToWord# i)))
 instance Cast Word16 Int16 where
-    cast (W16# i) = I16# (narrow16Int# (word2Int# i))
+    cast (W16# i) = I16# (intToInt16# (word2Int# (word16ToWord# i)))
 instance Cast Word32 Int32 where
-    cast (W32# i) = I32# (narrow32Int# (word2Int# i))
+    cast (W32# i) = I32# (intToInt32# (word2Int# (word32ToWord# i)))
 instance Cast Word64 Int64 where
     cast = word64ToInt64
 instance Cast Word   Int where
@@ -101,24 +102,24 @@ instance Cast Word64 Int where
     cast (W64# w) = I# (word2Int# w)
 #else
 instance Cast Word   Word32 where
-    cast (W# w) = W32# w
+    cast (W# w) = W32# (wordToWord32# w)
 instance Cast Word32 Word where
-    cast (W32# w) = W# w
+    cast (W32# w) = W# (word32ToWord# w)
 
 instance Cast Word   Int32 where
-    cast (W# w) = I32# (word2Int# w)
+    cast (W# w) = I32# (intToInt32# (word2Int# w))
 instance Cast Int32  Word where
-    cast (I32# i) = W# (int2Word# i)
+    cast (I32# i) = W# (int2Word# (int32ToInt# i))
 
 instance Cast Int    Int32 where
-    cast (I# i) = I32# i
+    cast (I# i) = I32# (intToInt32# i)
 instance Cast Int32  Int where
-    cast (I32# i) = I# i
+    cast (I32# i) = I# (int32ToInt# i)
 
 instance Cast Int    Word32 where
-    cast (I# i) = W32# (int2Word# i)
+    cast (I# i) = W32# (wordToWord32# (int2Word# i))
 instance Cast Word32 Int where
-    cast (W32# w) = I# (word2Int# w)
+    cast (W32# w) = I# (word2Int# (word32ToWord# w))
 #endif
 
 instance Cast (Block.Block a) (Block.Block Word8) where

--- a/basement/Basement/Compat/Primitive.hs
+++ b/basement/Basement/Compat/Primitive.hs
@@ -17,16 +17,77 @@ module Basement.Compat.Primitive
     , compatIsMutableByteArrayPinned#
     , unsafeCoerce#
     , Word(..)
+    , Word8#
+    , Word16#
+    , Word32#
+    , Int8#
+    , Int16#
+    , Int32#
+    -- word upper sizing
+    , word8ToWord16#
+    , word8ToWord32#
+    , word8ToWord#
+    , word16ToWord8#
+    , word16ToWord32#
+    , word16ToWord#
+    , word32ToWord#
+    -- word down sizing
+    , word32ToWord8#
+    , word32ToWord16#
+    , wordToWord32#
+    , wordToWord16#
+    , wordToWord8#
+    -- int upper sizing
+    , int8ToInt16#
+    , int8ToInt32#
+    , int8ToInt#
+    , int16ToInt32#
+    , int16ToInt#
+    , int32ToInt#
+    -- int down sizing
+    , intToInt8#
+    , intToInt16#
+    , intToInt32#
+    -- other
+    , word8ToInt#
+    , word8ToInt16#
+    , word8ToInt32#
+    , charToWord32#
+    , word8ToChar#
+    , word16ToChar#
+    , word32ToChar#
+    , wordToChar#
+
+    -- word8 ops
+    , plusWord8#
+    -- word16 ops
+    , uncheckedShiftRLWord16#
+    , plusWord16#
+    -- word32 ops
+    , uncheckedShiftRLWord32#
+    , plusWord32#
+    -- int8 ops
+    , plusInt8#
+    -- int16 ops
+    , plusInt16#
+    -- int32 ops
+    , plusInt32#
     ) where
 
+
 import qualified Prelude
-import           GHC.Exts
-import           GHC.Prim
+import           GHC.Exts hiding (Word8#, Word16#, Word32#, Int8#, Int16#, Int32#, plusWord8#, plusWord16#, plusInt8#, plusInt16#)
+import           GHC.Prim hiding (Word8#, Word16#, Word32#, Int8#, Int16#, Int32#, plusWord8#, plusWord16#, plusInt8#, plusInt16#)
 import           GHC.Word
 import           GHC.IO
 
 import           Basement.Compat.PrimTypes
 
+#if __GLASGOW_HASKELL__ >= 902
+import           GHC.Exts (Word8#, Word16#, Word32#, Int8#, Int16#, Int32#, plusWord8#, plusWord16#, plusInt8#, plusInt16#)
+#endif
+
+--  GHC 9.2  | Base 4.16
 --  GHC 9.0  | Base 4.15
 --  GHC 8.8  | Base 4.13 4.14
 --  GHC 8.6  | Base 4.12
@@ -76,4 +137,177 @@ foreign import ccall unsafe "basement_is_bytearray_pinned"
 
 foreign import ccall unsafe "basement_is_bytearray_pinned"
     compatIsMutableByteArrayPinned# :: MutableByteArray# s -> Pinned#
+#endif
+
+#if __GLASGOW_HASKELL__ >= 902
+
+word8ToWord16# :: Word8# -> Word16#
+word8ToWord16# a = wordToWord16# (word8ToWord# a)
+
+word8ToWord32# :: Word8# -> Word32#
+word8ToWord32# a = wordToWord32# (word8ToWord# a)
+
+word16ToWord8# :: Word16# -> Word8#
+word16ToWord8# a = wordToWord8# (word16ToWord# a)
+
+word16ToWord32# :: Word16# -> Word32#
+word16ToWord32# a = wordToWord32# (word16ToWord# a)
+
+word32ToWord8# :: Word32# -> Word8#
+word32ToWord8# a = wordToWord8# (word32ToWord# a)
+
+word32ToWord16# :: Word32# -> Word16#
+word32ToWord16# a = wordToWord16# (word32ToWord# a)
+
+int8ToInt16# :: Int8# -> Int16#
+int8ToInt16# i = intToInt16# (int8ToInt# i)
+
+int8ToInt32# :: Int8# -> Int32#
+int8ToInt32# i = intToInt32# (int8ToInt# i)
+
+int16ToInt32# :: Int16# -> Int32#
+int16ToInt32# i = intToInt32# (int16ToInt# i)
+
+word8ToInt16# :: Word8# -> Int16#
+word8ToInt16# i = intToInt16# (word2Int# (word8ToWord# i))
+
+word8ToInt32# :: Word8# -> Int32#
+word8ToInt32# i = intToInt32# (word2Int# (word8ToWord# i))
+
+word8ToInt# :: Word8# -> Int#
+word8ToInt# i = word2Int# (word8ToWord# i)
+
+charToWord32# :: Char# -> Word32#
+charToWord32# ch = wordToWord32# (int2Word# (ord# ch))
+
+word8ToChar# :: Word8# -> Char#
+word8ToChar# ch = chr# (word2Int# (word8ToWord# ch))
+
+word16ToChar# :: Word16# -> Char#
+word16ToChar# ch = chr# (word2Int# (word16ToWord# ch))
+
+word32ToChar# :: Word32# -> Char#
+word32ToChar# ch = chr# (word2Int# (word32ToWord# ch))
+
+wordToChar# :: Word# -> Char#
+wordToChar# ch = chr# (word2Int# ch)
+
+#else
+type Word8# = Word#
+type Word16# = Word#
+type Word32# = Word#
+
+type Int8# = Int#
+type Int16# = Int#
+type Int32# = Int#
+
+word8ToWord16# :: Word8# -> Word16#
+word8ToWord16# a = a
+
+word8ToWord32# :: Word8# -> Word32#
+word8ToWord32# a = a
+
+word8ToWord# :: Word8# -> Word#
+word8ToWord# a = a
+
+word16ToWord32# :: Word16# -> Word32#
+word16ToWord32# a = a
+
+word16ToWord8# :: Word16# -> Word8#
+word16ToWord8# w = narrow8Word# w
+
+word16ToWord# :: Word16# -> Word#
+word16ToWord# a = a
+
+word32ToWord8# :: Word32# -> Word8#
+word32ToWord8# w = narrow32Word# w
+
+word32ToWord16# :: Word32# -> Word16#
+word32ToWord16# w = narrow16Word# w
+
+word32ToWord# :: Word32# -> Word#
+word32ToWord# a = a
+
+wordToWord32# :: Word# -> Word32#
+wordToWord32# w = narrow32Word# w
+
+wordToWord16# :: Word# -> Word16#
+wordToWord16# w = narrow16Word# w
+
+wordToWord8# :: Word# -> Word8#
+wordToWord8# w = narrow8Word# w
+
+charToWord32# :: Char# -> Word32#
+charToWord32# ch = int2Word# (ord# ch)
+
+word8ToInt16# :: Word8# -> Int16#
+word8ToInt16# w = word2Int# w
+
+word8ToInt32# :: Word8# -> Int32#
+word8ToInt32# w = word2Int# w
+
+word8ToInt# :: Word8# -> Int#
+word8ToInt# w = word2Int# w
+
+word8ToChar# :: Word8# -> Char#
+word8ToChar# w = chr# (word2Int# w)
+
+word16ToChar# :: Word16# -> Char#
+word16ToChar# w = chr# (word2Int# w)
+
+word32ToChar# :: Word32# -> Char#
+word32ToChar# w = chr# (word2Int# w)
+
+wordToChar# :: Word# -> Char#
+wordToChar# ch = chr# (word2Int# ch)
+
+int8ToInt16# :: Int8# -> Int16#
+int8ToInt16# a = a
+
+int8ToInt32# :: Int8# -> Int32#
+int8ToInt32# a = a
+
+int8ToInt# :: Int8# -> Int#
+int8ToInt# a = a
+
+int16ToInt32# :: Int16# -> Int32#
+int16ToInt32# a = a
+
+int16ToInt# :: Int16# -> Int#
+int16ToInt# a = a
+
+int32ToInt# :: Int32# -> Int#
+int32ToInt# a = a
+
+intToInt8# :: Int# -> Int8#
+intToInt8# i = narrow8Int# i
+
+intToInt16# :: Int# -> Int16#
+intToInt16# i = narrow16Int# i
+
+intToInt32# :: Int# -> Int32#
+intToInt32# i = narrow32Int# i
+
+uncheckedShiftRLWord16# = uncheckedShiftRL#
+
+uncheckedShiftRLWord32# = uncheckedShiftRL#
+
+plusWord8# :: Word8# -> Word8# -> Word8#
+plusWord8# a b = narrow8Word# (plusWord# a b)
+
+plusWord16# :: Word16# -> Word16# -> Word16#
+plusWord16# a b = narrow16Word# (plusWord# a b)
+
+plusWord32# :: Word32# -> Word32# -> Word32#
+plusWord32# a b = narrow32Word# (plusWord# a b)
+
+plusInt8# :: Int8# -> Int8# -> Int8#
+plusInt8# a b = narrow8Int# (a +# b)
+
+plusInt16# :: Int16# -> Int16# -> Int16#
+plusInt16# a b = narrow16Int# (a +# b)
+
+plusInt32# :: Int32# -> Int32# -> Int32#
+plusInt32# a b = narrow32Int# (a +# b)
+
 #endif

--- a/basement/Basement/From.hs
+++ b/basement/Basement/From.hs
@@ -54,6 +54,7 @@ import           Basement.These
 import           Basement.PrimType (PrimType, PrimSize)
 import           Basement.Types.OffsetSize
 import           Basement.Compat.Natural
+import           Basement.Compat.Primitive
 import qualified Prelude (fromIntegral)
 
 -- nat instances
@@ -102,79 +103,79 @@ instance IsIntegral n => From n Integer where
     from = toInteger
 
 instance From Int8 Int16 where
-    from (I8# i) = I16# i
+    from (I8# i) = I16# (int8ToInt16# i)
 instance From Int8 Int32 where
-    from (I8# i) = I32# i
+    from (I8# i) = I32# (int8ToInt32# i)
 instance From Int8 Int64 where
-    from (I8# i) = intToInt64 (I# i)
+    from (I8# i) = intToInt64 (I# (int8ToInt# i))
 instance From Int8 Int where
-    from (I8# i) = I# i
+    from (I8# i) = I# (int8ToInt# i)
 
 instance From Int16 Int32 where
-    from (I16# i) = I32# i
+    from (I16# i) = I32# (int16ToInt32# i)
 instance From Int16 Int64 where
-    from (I16# i) = intToInt64 (I# i)
+    from (I16# i) = intToInt64 (I# (int16ToInt# i))
 instance From Int16 Int where
-    from (I16# i) = I# i
+    from (I16# i) = I# (int16ToInt# i)
 
 instance From Int32 Int64 where
-    from (I32# i) = intToInt64 (I# i)
+    from (I32# i) = intToInt64 (I# (int32ToInt# i))
 instance From Int32 Int where
-    from (I32# i) = I# i
+    from (I32# i) = I# (int32ToInt# i)
 
 instance From Int Int64 where
     from = intToInt64
 
 instance From Word8 Word16 where
-    from (W8# i) = W16# i
+    from (W8# i) = W16# (word8ToWord16# i)
 instance From Word8 Word32 where
-    from (W8# i) = W32# i
+    from (W8# i) = W32# (word8ToWord32# i)
 instance From Word8 Word64 where
-    from (W8# i) = wordToWord64 (W# i)
+    from (W8# i) = wordToWord64 (W# (word8ToWord# i))
 instance From Word8 Word128 where
-    from (W8# i) = Word128 0 (wordToWord64 $ W# i)
+    from (W8# i) = Word128 0 (wordToWord64 $ W# (word8ToWord# i))
 instance From Word8 Word256 where
-    from (W8# i) = Word256 0 0 0 (wordToWord64 $ W# i)
+    from (W8# i) = Word256 0 0 0 (wordToWord64 $ W# (word8ToWord# i))
 instance From Word8 Word where
-    from (W8# i) = W# i
+    from (W8# i) = W# (word8ToWord# i)
 instance From Word8 Int16 where
-    from (W8# w) = I16# (word2Int# w)
+    from (W8# w) = I16# (intToInt16# (word2Int# (word8ToWord# w)))
 instance From Word8 Int32 where
-    from (W8# w) = I32# (word2Int# w)
+    from (W8# w) = I32# (intToInt32# (word2Int# (word8ToWord# w)))
 instance From Word8 Int64 where
-    from (W8# w) = intToInt64 (I# (word2Int# w))
+    from (W8# w) = intToInt64 (I# (word2Int# (word8ToWord# w)))
 instance From Word8 Int where
-    from (W8# w) = I# (word2Int# w)
+    from (W8# w) = I# (word2Int# (word8ToWord# w))
 
 instance From Word16 Word32 where
-    from (W16# i) = W32# i
+    from (W16# i) = W32# (word16ToWord32# i)
 instance From Word16 Word64 where
-    from (W16# i) = wordToWord64 (W# i)
+    from (W16# i) = wordToWord64 (W# (word16ToWord# i))
 instance From Word16 Word128 where
-    from (W16# i) = Word128 0 (wordToWord64 $ W# i)
+    from (W16# i) = Word128 0 (wordToWord64 $ W# (word16ToWord# i))
 instance From Word16 Word256 where
-    from (W16# i) = Word256 0 0 0 (wordToWord64 $ W# i)
+    from (W16# i) = Word256 0 0 0 (wordToWord64 $ W# (word16ToWord# i))
 instance From Word16 Word where
-    from (W16# i) = W# i
+    from (W16# i) = W# (word16ToWord# i)
 instance From Word16 Int32 where
-    from (W16# w) = I32# (word2Int# w)
+    from (W16# w) = I32# (intToInt32# (word2Int# (word16ToWord# w)))
 instance From Word16 Int64 where
-    from (W16# w) = intToInt64 (I# (word2Int# w))
+    from (W16# w) = intToInt64 (I# (word2Int# (word16ToWord# w)))
 instance From Word16 Int where
-    from (W16# w) = I# (word2Int# w)
+    from (W16# w) = I# (word2Int# (word16ToWord# w))
 
 instance From Word32 Word64 where
-    from (W32# i) = wordToWord64 (W# i)
+    from (W32# i) = wordToWord64 (W# (word32ToWord# i))
 instance From Word32 Word128 where
-    from (W32# i) = Word128 0 (wordToWord64 $ W# i)
+    from (W32# i) = Word128 0 (wordToWord64 $ W# (word32ToWord# i))
 instance From Word32 Word256 where
-    from (W32# i) = Word256 0 0 0 (wordToWord64 $ W# i)
+    from (W32# i) = Word256 0 0 0 (wordToWord64 $ W# (word32ToWord# i))
 instance From Word32 Word where
-    from (W32# i) = W# i
+    from (W32# i) = W# (word32ToWord# i)
 instance From Word32 Int64 where
-    from (W32# w) = intToInt64 (I# (word2Int# w))
+    from (W32# w) = intToInt64 (I# (word2Int# (word32ToWord# w)))
 instance From Word32 Int where
-    from (W32# w) = I# (word2Int# w)
+    from (W32# w) = I# (word2Int# (word32ToWord# w))
 
 instance From Word64 Word128 where
     from w = Word128 0 w
@@ -270,11 +271,11 @@ instance (NatWithinBound (CountOf ty) n, KnownNat n, PrimType ty)
     tryFrom = BlockN.toBlockN . UArray.toBlock . BoxArray.mapToUnboxed id
 
 instance (KnownNat n, NatWithinBound Word8 n) => From (Zn64 n) Word8 where
-    from = narrow . unZn64 where narrow (W64# w) = W8# (narrow8Word# (word64ToWord# w))
+    from = narrow . unZn64 where narrow (W64# w) = W8# (wordToWord8# (word64ToWord# w))
 instance (KnownNat n, NatWithinBound Word16 n) => From (Zn64 n) Word16 where
-    from = narrow . unZn64 where narrow (W64# w) = W16# (narrow16Word# (word64ToWord# w))
+    from = narrow . unZn64 where narrow (W64# w) = W16# (wordToWord16# (word64ToWord# w))
 instance (KnownNat n, NatWithinBound Word32 n) => From (Zn64 n) Word32 where
-    from = narrow . unZn64 where narrow (W64# w) = W32# (narrow32Word# (word64ToWord# w))
+    from = narrow . unZn64 where narrow (W64# w) = W32# (wordToWord32# (word64ToWord# w))
 instance From (Zn64 n) Word64 where
     from = unZn64
 instance From (Zn64 n) Word128 where
@@ -283,11 +284,11 @@ instance From (Zn64 n) Word256 where
     from = from . unZn64
 
 instance (KnownNat n, NatWithinBound Word8 n) => From (Zn n) Word8 where
-    from = narrow . naturalToWord64 . unZn where narrow (W64# w) = W8# (narrow8Word# (word64ToWord# w))
+    from = narrow . naturalToWord64 . unZn where narrow (W64# w) = W8# (wordToWord8# (word64ToWord# w))
 instance (KnownNat n, NatWithinBound Word16 n) => From (Zn n) Word16 where
-    from = narrow . naturalToWord64 . unZn where narrow (W64# w) = W16# (narrow16Word# (word64ToWord# w))
+    from = narrow . naturalToWord64 . unZn where narrow (W64# w) = W16# (wordToWord16# (word64ToWord# w))
 instance (KnownNat n, NatWithinBound Word32 n) => From (Zn n) Word32 where
-    from = narrow . naturalToWord64 . unZn where narrow (W64# w) = W32# (narrow32Word# (word64ToWord# w))
+    from = narrow . naturalToWord64 . unZn where narrow (W64# w) = W32# (wordToWord32# (word64ToWord# w))
 instance (KnownNat n, NatWithinBound Word64 n) => From (Zn n) Word64 where
     from = naturalToWord64 . unZn
 instance (KnownNat n, NatWithinBound Word128 n) => From (Zn n) Word128 where

--- a/basement/Basement/IntegralConv.hs
+++ b/basement/Basement/IntegralConv.hs
@@ -26,6 +26,7 @@ import GHC.Word
 import Prelude (Integer, fromIntegral)
 import Basement.Compat.Base
 import Basement.Compat.Natural
+import Basement.Compat.Primitive
 import Basement.Numerical.Number
 import Basement.Numerical.Conversion
 
@@ -58,69 +59,69 @@ instance IsNatural a => IntegralUpsize a Natural where
     integralUpsize = toNatural
 
 instance IntegralUpsize Int8 Int16 where
-    integralUpsize (I8# i) = I16# i
+    integralUpsize (I8# i) = I16# (int8ToInt16# i)
 instance IntegralUpsize Int8 Int32 where
-    integralUpsize (I8# i) = I32# i
+    integralUpsize (I8# i) = I32# (int8ToInt32# i)
 instance IntegralUpsize Int8 Int64 where
-    integralUpsize (I8# i) = intToInt64 (I# i)
+    integralUpsize (I8# i) = intToInt64 (I# (int8ToInt# i))
 instance IntegralUpsize Int8 Int where
-    integralUpsize (I8# i) = I# i
+    integralUpsize (I8# i) = I# (int8ToInt# i)
 
 instance IntegralUpsize Int16 Int32 where
-    integralUpsize (I16# i) = I32# i
+    integralUpsize (I16# i) = I32# (int16ToInt32# i)
 instance IntegralUpsize Int16 Int64 where
-    integralUpsize (I16# i) = intToInt64 (I# i)
+    integralUpsize (I16# i) = intToInt64 (I# (int16ToInt# i))
 instance IntegralUpsize Int16 Int where
-    integralUpsize (I16# i) = I# i
+    integralUpsize (I16# i) = I# (int16ToInt# i)
 
 instance IntegralUpsize Int32 Int64 where
-    integralUpsize (I32# i) = intToInt64 (I# i)
+    integralUpsize (I32# i) = intToInt64 (I# (int32ToInt# i))
 instance IntegralUpsize Int32 Int where
-    integralUpsize (I32# i) = I# i
+    integralUpsize (I32# i) = I# (int32ToInt# i)
 
 instance IntegralUpsize Int Int64 where
     integralUpsize = intToInt64
 
 instance IntegralUpsize Word8 Word16 where
-    integralUpsize (W8# i) = W16# i
+    integralUpsize (W8# i) = W16# (word8ToWord16# i)
 instance IntegralUpsize Word8 Word32 where
-    integralUpsize (W8# i) = W32# i
+    integralUpsize (W8# i) = W32# (word8ToWord32# i)
 instance IntegralUpsize Word8 Word64 where
-    integralUpsize (W8# i) = wordToWord64 (W# i)
+    integralUpsize (W8# i) = wordToWord64 (W# (word8ToWord# i))
 instance IntegralUpsize Word8 Word where
-    integralUpsize (W8# i) = W# i
+    integralUpsize (W8# i) = W# (word8ToWord# i)
 instance IntegralUpsize Word8 Int16 where
-    integralUpsize (W8# w) = I16# (word2Int# w)
+    integralUpsize (W8# w) = I16# (word8ToInt16# w)
 instance IntegralUpsize Word8 Int32 where
-    integralUpsize (W8# w) = I32# (word2Int# w)
+    integralUpsize (W8# w) = I32# (word8ToInt32# w)
 instance IntegralUpsize Word8 Int64 where
-    integralUpsize (W8# w) = intToInt64 (I# (word2Int# w))
+    integralUpsize (W8# w) = intToInt64 (I# (word2Int# (word8ToWord# w)))
 instance IntegralUpsize Word8 Int where
-    integralUpsize (W8# w) = I# (word2Int# w)
+    integralUpsize (W8# w) = I# (word2Int# (word8ToWord# w))
 
 instance IntegralUpsize Word16 Word32 where
-    integralUpsize (W16# i) = W32# i
+    integralUpsize (W16# i) = W32# (word16ToWord32# i)
 instance IntegralUpsize Word16 Word64 where
-    integralUpsize (W16# i) = wordToWord64 (W# i)
+    integralUpsize (W16# i) = wordToWord64 (W# (word16ToWord# i))
 instance IntegralUpsize Word16 Word where
-    integralUpsize (W16# i) = W# i
+    integralUpsize (W16# i) = W# (word16ToWord# i)
 
 instance IntegralUpsize Word32 Word64 where
-    integralUpsize (W32# i) = wordToWord64 (W# i)
+    integralUpsize (W32# i) = wordToWord64 (W# (word32ToWord# i))
 instance IntegralUpsize Word32 Word where
-    integralUpsize (W32# i) = W# i
+    integralUpsize (W32# i) = W# (word32ToWord# i)
 
 instance IntegralUpsize Word Word64 where
     integralUpsize = wordToWord64
 
 instance IntegralDownsize Int Int8 where
-    integralDownsize      (I# i) = I8# (narrow8Int# i)
+    integralDownsize      (I# i) = I8# (intToInt8# i)
     integralDownsizeCheck = integralDownsizeBounded integralDownsize
 instance IntegralDownsize Int Int16 where
-    integralDownsize      (I# i) = I16# (narrow16Int# i)
+    integralDownsize      (I# i) = I16# (intToInt16# i)
     integralDownsizeCheck = integralDownsizeBounded integralDownsize
 instance IntegralDownsize Int Int32 where
-    integralDownsize      (I# i) = I32# (narrow32Int# i)
+    integralDownsize      (I# i) = I32# (intToInt32# i)
     integralDownsizeCheck = integralDownsizeBounded integralDownsize
 
 instance IntegralDownsize Int64 Int8 where
@@ -137,34 +138,34 @@ instance IntegralDownsize Int64 Int where
     integralDownsizeCheck = integralDownsizeBounded integralDownsize
 
 instance IntegralDownsize Word64 Word8 where
-    integralDownsize      (W64# i) = W8# (narrow8Word# (word64ToWord# i))
+    integralDownsize      (W64# i) = W8# (wordToWord8# (word64ToWord# i))
     integralDownsizeCheck = integralDownsizeBounded integralDownsize
 instance IntegralDownsize Word64 Word16 where
-    integralDownsize      (W64# i) = W16# (narrow16Word# (word64ToWord# i))
+    integralDownsize      (W64# i) = W16# (wordToWord16# (word64ToWord# i))
     integralDownsizeCheck = integralDownsizeBounded integralDownsize
 instance IntegralDownsize Word64 Word32 where
-    integralDownsize      (W64# i) = W32# (narrow32Word# (word64ToWord# i))
+    integralDownsize      (W64# i) = W32# (wordToWord32# (word64ToWord# i))
     integralDownsizeCheck = integralDownsizeBounded integralDownsize
 
 instance IntegralDownsize Word Word8 where
-    integralDownsize (W# w) = W8# (narrow8Word# w)
+    integralDownsize (W# w) = W8# (wordToWord8# w)
     integralDownsizeCheck = integralDownsizeBounded integralDownsize
 instance IntegralDownsize Word Word16 where
-    integralDownsize (W# w) = W16# (narrow16Word# w)
+    integralDownsize (W# w) = W16# (wordToWord16# w)
     integralDownsizeCheck = integralDownsizeBounded integralDownsize
 instance IntegralDownsize Word Word32 where
-    integralDownsize (W# w) = W32# (narrow32Word# w)
+    integralDownsize (W# w) = W32# (wordToWord32# w)
     integralDownsizeCheck = integralDownsizeBounded integralDownsize
 
 instance IntegralDownsize Word32 Word8 where
-    integralDownsize      (W32# i) = W8# (narrow8Word# i)
+    integralDownsize      (W32# i) = W8# (word32ToWord8# i)
     integralDownsizeCheck = integralDownsizeBounded integralDownsize
 instance IntegralDownsize Word32 Word16 where
-    integralDownsize      (W32# i) = W16# (narrow16Word# i)
+    integralDownsize      (W32# i) = W16# (word32ToWord16# i)
     integralDownsizeCheck = integralDownsizeBounded integralDownsize
 
 instance IntegralDownsize Word16 Word8 where
-    integralDownsize      (W16# i) = W8# (narrow8Word# i)
+    integralDownsize      (W16# i) = W8# (word16ToWord8# i)
     integralDownsizeCheck = integralDownsizeBounded integralDownsize
 
 instance IntegralDownsize Integer Int8 where

--- a/basement/Basement/Numerical/Additive.hs
+++ b/basement/Basement/Numerical/Additive.hs
@@ -14,10 +14,11 @@ module Basement.Numerical.Additive
 import           Basement.Compat.Base
 import           Basement.Compat.C.Types
 import           Basement.Compat.Natural
+import           Basement.Compat.Primitive
 import           Basement.Numerical.Number
 import qualified Prelude
-import           GHC.Types
-import           GHC.Prim
+import           GHC.Types (Float(..), Double(..))
+import           GHC.Prim (plusWord#, plusFloat#, (+#), (+##))
 import           GHC.Int
 import           GHC.Word
 import           Basement.Bounded
@@ -65,15 +66,15 @@ instance Additive Int where
     scale = scaleNum
 instance Additive Int8 where
     azero = 0
-    (I8# a) + (I8# b) = I8# (narrow8Int# (a +# b))
+    (I8# a) + (I8# b) = I8# (a `plusInt8#` b)
     scale = scaleNum
 instance Additive Int16 where
     azero = 0
-    (I16# a) + (I16# b) = I16# (narrow16Int# (a +# b))
+    (I16# a) + (I16# b) = I16# (a `plusInt16#` b)
     scale = scaleNum
 instance Additive Int32 where
     azero = 0
-    (I32# a) + (I32# b) = I32# (narrow32Int# (a +# b))
+    (I32# a) + (I32# b) = I32# (a `plusInt32#` b)
     scale = scaleNum
 instance Additive Int64 where
     azero = 0
@@ -93,15 +94,15 @@ instance Additive Natural where
     scale = scaleNum
 instance Additive Word8 where
     azero = 0
-    (W8# a) + (W8# b) = W8# (narrow8Word# (a `plusWord#` b))
+    (W8# a) + (W8# b) = W8# (a `plusWord8#` b)
     scale = scaleNum
 instance Additive Word16 where
     azero = 0
-    (W16# a) + (W16# b) = W16# (narrow16Word# (a `plusWord#` b))
+    (W16# a) + (W16# b) = W16# (a `plusWord16#` b)
     scale = scaleNum
 instance Additive Word32 where
     azero = 0
-    (W32# a) + (W32# b) = W32# (narrow32Word# (a `plusWord#` b))
+    (W32# a) + (W32# b) = W32# (a `plusWord32#` b)
     scale = scaleNum
 instance Additive Word64 where
     azero = 0

--- a/basement/Basement/Numerical/Conversion.hs
+++ b/basement/Basement/Numerical/Conversion.hs
@@ -22,6 +22,7 @@ import GHC.Types
 import GHC.Prim
 import GHC.Int
 import GHC.Word
+import Basement.Compat.Primitive
 
 #if WORD_SIZE_IN_BITS < 64
 import GHC.IntWord64
@@ -81,7 +82,7 @@ data Word32x2 = Word32x2 {-# UNPACK #-} !Word32
 
 #if WORD_SIZE_IN_BITS == 64
 word64ToWord32s :: Word64 -> Word32x2
-word64ToWord32s (W64# w64) = Word32x2 (W32# (uncheckedShiftRL# w64 32#)) (W32# (narrow32Word# w64))
+word64ToWord32s (W64# w64) = Word32x2 (W32# (wordToWord32# (uncheckedShiftRL# w64 32#))) (W32# (wordToWord32# w64))
 #else
 word64ToWord32s :: Word64 -> Word32x2
 word64ToWord32s (W64# w64) = Word32x2 (W32# (word64ToWord# (uncheckedShiftRL64# w64 32#))) (W32# (word64ToWord# w64))

--- a/basement/Basement/String/Encoding/ASCII7.hs
+++ b/basement/Basement/String/Encoding/ASCII7.hs
@@ -14,11 +14,13 @@ module Basement.String.Encoding.ASCII7
     ) where
 
 import Basement.Compat.Base
+import Basement.Compat.Primitive
 import Basement.Types.OffsetSize
 import Basement.Numerical.Additive
 import Basement.Monad
+import Basement.Bits
 
-import GHC.Prim
+import GHC.Prim (int2Word#, ord#)
 import GHC.Word
 import GHC.Types
 import Basement.UArray
@@ -32,7 +34,7 @@ import Basement.String.Encoding.Encoding
 -- This function check the 8th bit is set to 0
 --
 isAscii :: Word8 -> Bool
-isAscii (W8# w) = W8# (and# w 0x80## ) == 0
+isAscii w = (w .&. 0x80) == 0
 {-# INLINE isAscii #-}
 
 data ASCII7_Invalid
@@ -64,8 +66,8 @@ next getter off
     | otherwise  = Left $ ByteOutOfBound w8
   where
     !w8@(W8# w) = getter off
-    toChar :: Word# -> Char
-    toChar a = C# (chr# (word2Int# a))
+    toChar :: Word8# -> Char
+    toChar a = C# (word8ToChar# w)
 
 -- Write ascii char
 --
@@ -81,4 +83,4 @@ write c
     | otherwise       = throw $ CharNotAscii c
   where
     w8 :: Char -> Word8
-    w8 (C# ch) = W8# (int2Word# (ord# ch))
+    w8 (C# ch) = W8# (wordToWord8# (int2Word# (ord# ch)))

--- a/basement/Basement/String/Encoding/ISO_8859_1.hs
+++ b/basement/Basement/String/Encoding/ISO_8859_1.hs
@@ -14,11 +14,12 @@ module Basement.String.Encoding.ISO_8859_1
     ) where
 
 import Basement.Compat.Base
+import Basement.Compat.Primitive
 import Basement.Types.OffsetSize
 import Basement.Numerical.Additive
 import Basement.Monad
 
-import GHC.Prim
+import GHC.Prim (int2Word#, ord#)
 import GHC.Word
 import GHC.Types
 import Basement.UArray
@@ -50,8 +51,8 @@ next :: (Offset Word8 -> Word8)
 next getter off = Right (toChar w, off + aone)
   where
     !(W8# w) = getter off
-    toChar :: Word# -> Char
-    toChar a = C# (chr# (word2Int# a))
+    toChar :: Word8# -> Char
+    toChar a = C# (word8ToChar# w)
 
 write :: (PrimMonad st, Monad st)
       => Char
@@ -60,5 +61,5 @@ write c@(C# ch)
     | c <= toEnum 0xFF = builderAppend (W8# x)
     | otherwise        = throw $ NotISO_8859_1 c
   where
-    x :: Word#
-    !x = int2Word# (ord# ch)
+    x :: Word8#
+    !x = wordToWord8# (int2Word# (ord# ch))

--- a/basement/Basement/String/Encoding/UTF16.hs
+++ b/basement/Basement/String/Encoding/UTF16.hs
@@ -14,12 +14,15 @@ module Basement.String.Encoding.UTF16
 import GHC.Prim
 import GHC.Word
 import GHC.Types
-import Data.Bits
 import qualified Prelude
 import Basement.Compat.Base
+import Basement.Compat.Primitive
+import Basement.IntegralConv
+import Basement.Bits
 import Basement.Types.OffsetSize
 import Basement.Monad
 import Basement.Numerical.Additive
+import Basement.Numerical.Subtractive
 import Basement.UArray
 import Basement.UArray.Mutable (MUArray)
 import Basement.MutableBuilder
@@ -54,22 +57,23 @@ next :: (Offset Word16 -> Word16)
      -> Offset Word16
      -> Either UTF16_Invalid (Char, Offset Word16)
 next getter off
-    | h <  0xd800 = Right (toChar hh, off + Offset 1)
-    | h >= 0xe000 = Right (toChar hh, off + Offset 1)
+    | h <  0xd800 = Right (toChar16 h, off + Offset 1)
+    | h >= 0xe000 = Right (toChar16 h, off + Offset 1)
     | otherwise   = nextContinuation
   where
     h :: Word16
-    !h@(W16# hh) = getter off
-    toChar :: Word# -> Char
-    toChar w = C# (chr# (word2Int# w))
+    !h = getter off
+
     to32 :: Word16 -> Word32
-    to32 (W16# w) = W32# w
+    to32 (W16# w) = W32# (word16ToWord32# w)
+
+    toChar16 :: Word16 -> Char
+    toChar16 (W16# w) = C# (word32ToChar# (word16ToWord32# w))
 
     nextContinuation
         | cont >= 0xdc00 && cont < 0xe00 =
-            let !(W32# w) = ((to32 h .&. 0x3ff) `shiftL` 10)
-                         .|. (to32 cont .&. 0x3ff)
-             in Right (toChar w, off + Offset 2)
+            let !(W32# w) = ((to32 h .&. 0x3ff) .<<. 10) .|. (to32 cont .&. 0x3ff)
+             in Right (C# (word32ToChar# w), off + Offset 2)
         | otherwise = Left InvalidContinuation
       where
         cont :: Word16
@@ -86,12 +90,12 @@ write c
     | otherwise = throw $ InvalidUnicode c
   where
     w16 :: Char -> Word16
-    w16 (C# ch) = W16# (int2Word# (ord# ch))
+    w16 (C# ch) = W16# (wordToWord16# (int2Word# (ord# ch)))
 
     to16 :: Word32 -> Word16
     to16 = Prelude.fromIntegral
 
     wHigh :: Char -> (Word16, Word16)
     wHigh (C# ch) =
-        let v = W32# (minusWord# (int2Word# (ord# ch)) 0x10000##)
-         in (0xdc00 .|. to16 (v `shiftR` 10), 0xd800 .|. to16 (v .&. 0x3ff))
+        let v = W32# (charToWord32# ch) - 0x10000
+         in (0xdc00 .|. to16 (v .>>. 10), 0xd800 .|. to16 (v .&. 0x3ff))

--- a/basement/Basement/String/Encoding/UTF32.hs
+++ b/basement/Basement/String/Encoding/UTF32.hs
@@ -15,6 +15,7 @@ import GHC.Prim
 import GHC.Word
 import GHC.Types
 import Basement.Compat.Base
+import Basement.Compat.Primitive
 import Basement.Types.OffsetSize
 import Basement.Monad
 import Basement.Numerical.Additive
@@ -43,7 +44,7 @@ next getter off = Right (char, off + Offset 1)
   where
     !(W32# hh) = getter off
     char :: Char
-    char = C# (chr# (word2Int# hh))
+    char = C# (word32ToChar# hh)
 
 write :: (PrimMonad st, Monad st)
       => Char
@@ -52,4 +53,4 @@ write c = builderAppend w32
   where
     !(C# ch) = c
     w32 :: Word32
-    w32 = W32# (int2Word# (ord# ch))
+    w32 = W32# (charToWord32# ch)

--- a/basement/Basement/Types/Char7.hs
+++ b/basement/Basement/Types/Char7.hs
@@ -36,7 +36,7 @@ import GHC.Types
 import Data.Bits
 import Data.Maybe
 import Basement.Compat.Base
-import Basement.Compat.Primitive (bool#)
+import Basement.Compat.Primitive
 
 -- | ASCII value between 0x0 and 0x7f
 newtype Char7 = Char7 { toByte :: Word8 }
@@ -44,14 +44,14 @@ newtype Char7 = Char7 { toByte :: Word8 }
 
 -- | Convert a 'Char7' to a unicode code point 'Char'
 toChar :: Char7 -> Char
-toChar !(Char7 (W8# w)) = C# (chr# (word2Int# w))
+toChar !(Char7 (W8# w)) = C# (chr# (word2Int# (word8ToWord# w)))
 
 -- | Try to convert a 'Char' to a 'Char7'
 -- 
 -- If the code point is non ascii, then Nothing is returned.
 fromChar :: Char -> Maybe Char7
 fromChar !(C# c#)
-    | bool# (ltChar# c# (chr# 0x80#)) = Just $ Char7 $ W8# (int2Word# (ord# c#))
+    | bool# (ltChar# c# (chr# 0x80#)) = Just $ Char7 $ W8# (wordToWord8# (int2Word# (ord# c#)))
     | otherwise                       = Nothing
 
 -- | Try to convert 'Word8' to a 'Char7'
@@ -64,11 +64,11 @@ fromByte !w
 
 -- | Convert a 'Char' to a 'Char7' ignoring all higher bits
 fromCharMask :: Char -> Char7
-fromCharMask !(C# c#) = Char7 $ W8# (and# (int2Word# (ord# c#)) 0x7f##)
+fromCharMask !(C# c#) = Char7 $ W8# (wordToWord8# (and# (int2Word# (ord# c#)) 0x7f##))
 
 -- | Convert a 'Byte' to a 'Char7' ignoring the higher bit
 fromByteMask :: Word8 -> Char7
-fromByteMask !(W8# w#) = Char7 $ W8# (and# w# 0x7f##)
+fromByteMask !w = Char7 (w .&. 0x7f)
 
 c7_LF :: Char7
 c7_LF = Char7 0xa

--- a/basement/Basement/UArray.hs
+++ b/basement/Basement/UArray.hs
@@ -124,6 +124,7 @@ import           Basement.PrimType
 import           Basement.FinalPtr
 import           Basement.Exception
 import           Basement.UArray.Base
+import           Basement.Bits
 import           Basement.Block (Block(..), MutableBlock(..))
 import qualified Basement.Block as BLK
 import qualified Basement.Block.Base as BLK (withPtr, unsafeWrite)
@@ -912,15 +913,15 @@ outputLengthBase64 padding (CountOf inputLenInt) = outputLength
     (d,m) = inputLenInt `divMod` 3
 
 convert3 :: Addr# -> Word8 -> Word8 -> Word8 -> (Word8, Word8, Word8, Word8)
-convert3 table (W8# a) (W8# b) (W8# c) =
-    let !w = narrow8Word# (uncheckedShiftRL# a 2#)
-        !x = or# (and# (uncheckedShiftL# a 4#) 0x30##) (uncheckedShiftRL# b 4#)
-        !y = or# (and# (uncheckedShiftL# b 2#) 0x3c##) (uncheckedShiftRL# c 6#)
-        !z = and# c 0x3f##
+convert3 table a b c =
+    let !w = a .>>. 2
+        !x = ((a .<<. 4) .&. 0x30) .|. (b .>>. 4)
+        !y = ((b .<<. 2) .&. 0x3c) .|. (c .>>. 6)
+        !z = c .&. 0x3f
      in (idx w, idx x, idx y, idx z)
   where
-    idx :: Word# -> Word8
-    idx i = W8# (indexWord8OffAddr# table (word2Int# i))
+    idx :: Word8 -> Word8
+    idx (W8# i) = W8# (indexWord8OffAddr# table (word2Int# (word8ToWord# i)))
 
 isPrefixOf :: PrimType ty => UArray ty -> UArray ty -> Bool
 isPrefixOf pre arr


### PR DESCRIPTION
add support for ghc 9.2 distinguishing all the new `WordN#` and `IntN#` types and compat for previous versions